### PR TITLE
Disable THP for PSMDB jobs

### DIFF
--- a/psmdb/percona-server-for-mongodb-3.2-template.yml
+++ b/psmdb/percona-server-for-mongodb-3.2-template.yml
@@ -25,6 +25,14 @@
         sudo chmod 777 /mnt/data
         sudo ln -s /mnt/data /data
         #
+        echo "echo never > /sys/kernel/mm/transparent_hugepage/enabled" > disable-thp.sh
+        echo "echo never > /sys/kernel/mm/transparent_hugepage/defrag" >> disable-thp.sh
+        chmod +x disable-thp.sh
+        sudo -n ./disable-thp.sh
+        rm -f disable-thp.sh
+
+        echo "Transparent huge pages status:"
+        cat /sys/kernel/mm/transparent_hugepage/enabled
     - shell: |-
         sudo apt-get update
         sudo apt-get -y install build-essential python-pip g++-5 gcc-5 libgflags-dev libsnappy-dev gcc-4.8

--- a/psmdb/percona-server-for-mongodb-3.4-template.yml
+++ b/psmdb/percona-server-for-mongodb-3.4-template.yml
@@ -17,6 +17,13 @@
             result=$(hostname | grep -c "bigram.*xenial" || true)
         fi
         # we need to setup the instance first
+        # disable THP
+        echo "echo never > /sys/kernel/mm/transparent_hugepage/enabled" > disable-thp.sh
+        echo "echo never > /sys/kernel/mm/transparent_hugepage/defrag" >> disable-thp.sh
+        chmod +x disable-thp.sh
+        sudo -n ./disable-thp.sh
+        rm -f disable-thp.sh
+
         echo "----------------"
         echo "HOST INFO:"
         echo "HOSTNAME: $(hostname)"
@@ -29,6 +36,8 @@
         ulimit -a
         echo "NETWORK"
         ip addr show
+        echo "Transparent huge pages status:"
+        cat /sys/kernel/mm/transparent_hugepage/enabled
         echo "----------------"
         #
         if [ $(grep -c $(hostname) /etc/hosts) -eq 0 ]; then

--- a/psmdb/percona-server-for-mongodb-3.6-template.yml
+++ b/psmdb/percona-server-for-mongodb-3.6-template.yml
@@ -17,6 +17,13 @@
         result=$(hostname | grep -c "bigram.*xenial" || true)
         fi
         # we need to setup the instance first
+        # disable THP
+        echo "echo never > /sys/kernel/mm/transparent_hugepage/enabled" > disable-thp.sh
+        echo "echo never > /sys/kernel/mm/transparent_hugepage/defrag" >> disable-thp.sh
+        chmod +x disable-thp.sh
+        sudo -n ./disable-thp.sh
+        rm -f disable-thp.sh
+
         echo "----------------"
         echo "HOST INFO:"
         echo "HOSTNAME: $(hostname)"
@@ -29,6 +36,8 @@
         ulimit -a
         echo "NETWORK"
         ip addr show
+        echo "Transparent huge pages status:"
+        cat /sys/kernel/mm/transparent_hugepage/enabled
         echo "----------------"
         #
         if [ $(grep -c $(hostname) /etc/hosts) -eq 0 ]; then

--- a/psmdb/percona-server-for-mongodb-master-template.yml
+++ b/psmdb/percona-server-for-mongodb-master-template.yml
@@ -17,6 +17,13 @@
         result=$(hostname | grep -c "bigram.*xenial" || true)
         fi
         # we need to setup the instance first
+        # disable THP
+        echo "echo never > /sys/kernel/mm/transparent_hugepage/enabled" > disable-thp.sh
+        echo "echo never > /sys/kernel/mm/transparent_hugepage/defrag" >> disable-thp.sh
+        chmod +x disable-thp.sh
+        sudo -n ./disable-thp.sh
+        rm -f disable-thp.sh
+
         echo "----------------"
         echo "HOST INFO:"
         echo "HOSTNAME: $(hostname)"
@@ -30,6 +37,8 @@
         ulimit -a
         echo "NETWORK"
         ip addr show
+        echo "Transparent huge pages status:"
+        cat /sys/kernel/mm/transparent_hugepage/enabled
         echo "----------------"
         #
         if [ $(grep -c $(hostname) /etc/hosts) -eq 0 ]; then


### PR DESCRIPTION
THP should be disabled when running PSMDB tests so here we disable THP in the job templates.