### PR TITLE
Reduce the number of builds kept for PSMDB trunk jobs

### DIFF
--- a/psmdb/percona-server-for-mongodb-3.2-trunk.yml
+++ b/psmdb/percona-server-for-mongodb-3.2-trunk.yml
@@ -38,7 +38,7 @@
         artifact-days-to-keep: -1
         artifact-num-to-keep: -1
         days-to-keep: -1
-        num-to-keep: 30
+        num-to-keep: 10
     - raw:
         xml: |
           <hudson.plugins.disk__usage.DiskUsageProperty plugin="disk-usage@0.28" />

--- a/psmdb/percona-server-for-mongodb-3.4-trunk.yml
+++ b/psmdb/percona-server-for-mongodb-3.4-trunk.yml
@@ -27,7 +27,7 @@
         artifact-days-to-keep: -1
         artifact-num-to-keep: -1
         days-to-keep: -1
-        num-to-keep: 30
+        num-to-keep: 10
     - raw:
         xml: |
           <hudson.plugins.disk__usage.DiskUsageProperty plugin="disk-usage@0.28" />

--- a/psmdb/percona-server-for-mongodb-3.6-trunk.yml
+++ b/psmdb/percona-server-for-mongodb-3.6-trunk.yml
@@ -27,7 +27,7 @@
         artifact-days-to-keep: -1
         artifact-num-to-keep: -1
         days-to-keep: -1
-        num-to-keep: 30
+        num-to-keep: 10
     - raw:
         xml: |
           <hudson.plugins.disk__usage.DiskUsageProperty plugin="disk-usage@0.28" />

--- a/psmdb/percona-server-for-mongodb-4.0-trunk.yml
+++ b/psmdb/percona-server-for-mongodb-4.0-trunk.yml
@@ -15,7 +15,7 @@
         artifact-days-to-keep: -1
         artifact-num-to-keep: -1
         days-to-keep: -1
-        num-to-keep: 30
+        num-to-keep: 10
     - disk-usage
     publishers:
     - warnings:

--- a/psmdb/percona-server-for-mongodb-master.yml
+++ b/psmdb/percona-server-for-mongodb-master.yml
@@ -15,7 +15,7 @@
         artifact-days-to-keep: -1
         artifact-num-to-keep: -1
         days-to-keep: -1
-        num-to-keep: 30
+        num-to-keep: 10
     - disk-usage
     publishers:
     - warnings:


### PR DESCRIPTION
This is to save on disk space.