### PR TITLE
Change default number of parallel jobs for running PSMDB tests

### DIFF
--- a/psmdb/percona-server-for-mongodb-3.2-param.yml
+++ b/psmdb/percona-server-for-mongodb-3.2-param.yml
@@ -59,7 +59,7 @@
         name: PSM_BRANCH
         trim: false
     - string:
-        default: '4'
+        default: 'auto'
         description: <h3>Number of parallel jobs for running tests, auto=number of
           cores or specify exact number like 8,4,2,1</h3>
         name: JOBS

--- a/psmdb/percona-server-for-mongodb-3.2-trunk.yml
+++ b/psmdb/percona-server-for-mongodb-3.2-trunk.yml
@@ -160,7 +160,7 @@
             MAIN_VERSION_LINE=v3.2
             PSM_REPO=https://github.com/percona/percona-server-mongodb.git
             PSM_BRANCH=v3.2
-            JOBS=4
+            JOBS=auto
             SUITE=resmoke_psmdb_3.2_big
             RELEASE_TEST=false
             ENABLE_KILLER=true

--- a/psmdb/percona-server-for-mongodb-3.4-param.yml
+++ b/psmdb/percona-server-for-mongodb-3.4-param.yml
@@ -36,7 +36,7 @@
         name: PSM_BRANCH
         trim: false
     - string:
-        default: '4'
+        default: 'auto'
         description: <h3>Number of parallel jobs for running tests, auto=number of
           cores or specify exact number like 8,4,2,1</h3>
         name: JOBS

--- a/psmdb/percona-server-for-mongodb-3.4-trunk.yml
+++ b/psmdb/percona-server-for-mongodb-3.4-trunk.yml
@@ -150,7 +150,7 @@
             MAIN_VERSION_LINE=v3.4
             PSM_REPO=https://github.com/percona/percona-server-mongodb.git
             PSM_BRANCH=v3.4
-            JOBS=4
+            JOBS=auto
             SUITE=resmoke_psmdb_3.4_big
             RELEASE_TEST=false
             NUM_TRIALS=1

--- a/psmdb/percona-server-for-mongodb-3.6-param.yml
+++ b/psmdb/percona-server-for-mongodb-3.6-param.yml
@@ -36,7 +36,7 @@
         name: PSM_BRANCH
         trim: false
     - string:
-        default: '4'
+        default: 'auto'
         description: <h3>Number of parallel jobs for running tests, auto=number of
           cores or specify exact number like 8,4,2,1</h3>
         name: JOBS

--- a/psmdb/percona-server-for-mongodb-3.6-trunk.yml
+++ b/psmdb/percona-server-for-mongodb-3.6-trunk.yml
@@ -150,7 +150,7 @@
             MAIN_VERSION_LINE=v3.6
             PSM_REPO=https://github.com/percona/percona-server-mongodb.git
             PSM_BRANCH=v3.6
-            JOBS=4
+            JOBS=auto
             SUITE=resmoke_psmdb_3.6_big
             RELEASE_TEST=false
             NUM_TRIALS=1

--- a/psmdb/percona-server-for-mongodb-4.0-param.yml
+++ b/psmdb/percona-server-for-mongodb-4.0-param.yml
@@ -32,7 +32,7 @@
         name: PSM_BRANCH
         trim: false
     - string:
-        default: '4'
+        default: 'auto'
         description: <h3>Number of parallel jobs for running tests, auto=number of
           cores or specify exact number like 8,4,2,1</h3>
         name: JOBS

--- a/psmdb/percona-server-for-mongodb-4.0-trunk.yml
+++ b/psmdb/percona-server-for-mongodb-4.0-trunk.yml
@@ -64,7 +64,7 @@
             BUILD_TYPE=release
             PSM_REPO=https://github.com/percona/percona-server-mongodb.git
             PSM_BRANCH=v4.0
-            JOBS=4
+            JOBS=auto
             SUITE=resmoke_psmdb_4.0_big
             RELEASE_TEST=false
             NUM_TRIALS=1

--- a/psmdb/percona-server-for-mongodb-master-param.yml
+++ b/psmdb/percona-server-for-mongodb-master-param.yml
@@ -32,7 +32,7 @@
         name: PSM_BRANCH
         trim: false
     - string:
-        default: '4'
+        default: 'auto'
         description: <h3>Number of parallel jobs for running tests, auto=number of
           cores or specify exact number like 8,4,2,1</h3>
         name: JOBS

--- a/psmdb/percona-server-for-mongodb-master.yml
+++ b/psmdb/percona-server-for-mongodb-master.yml
@@ -64,7 +64,7 @@
             BUILD_TYPE=release
             PSM_REPO=https://github.com/percona/percona-server-mongodb.git
             PSM_BRANCH=master
-            JOBS=4
+            JOBS=auto
             SUITE=resmoke_psmdb_master_big
             RELEASE_TEST=false
             NUM_TRIALS=1


### PR DESCRIPTION
Minor change for default number of parallel jobs in PSMDB tests so I'll merge myself.