### PR TITLE
PMM-4309 Adding Pipefail to avoid false positives

### DIFF
--- a/pmm/pmm-ami.groovy
+++ b/pmm/pmm-ami.groovy
@@ -35,6 +35,7 @@ pipeline {
             steps {
                 withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AMI/OVF', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
                     sh """
+                        set -o pipefail
                         ~/bin/packer build -only amazon-ebs -color=false packer/pmm.json \
                             | tee build.log
                     """

--- a/pmm/pmm2-ami.groovy
+++ b/pmm/pmm2-ami.groovy
@@ -35,6 +35,7 @@ pipeline {
             steps {
                 withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AMI/OVF', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
                     sh """
+                        set -o pipefail
                         ~/bin/packer build -only amazon-ebs -color=false packer/pmm2.json \
                             | tee build.log
                     """


### PR DESCRIPTION
AMI builds show pass even though, they failed in the build step, it is because of the piping we are using. This should reflect the real status code and also change the build status 