### PR TITLE
Do not start extra services for API tests.

### DIFF
--- a/pmm/pmm2-api-tests.groovy
+++ b/pmm/pmm2-api-tests.groovy
@@ -57,7 +57,7 @@ pipeline {
         }
         stage('Start staging') {
             steps {
-                runStaging(DOCKER_VERSION, CLIENT_VERSION, '--addclient=ps,1 --addclient=mo,2 --with-replica --addclient=pgsql,1')
+                runStaging(DOCKER_VERSION, CLIENT_VERSION, ' ')
             }
         }
         stage('Setup Step') {


### PR DESCRIPTION
We do not currently use them, but they consume resources and cause timing-sensitive update tests to fail.