### PR TITLE
PMM-5067 Change the UI job trigger, change console log

### DIFF
--- a/pmm/pmm2-ami.groovy
+++ b/pmm/pmm2-ami.groovy
@@ -6,7 +6,7 @@ void runPmm2AmiUITests(String AMI_ID) {
 
 pipeline {
     environment {
-        specName = 'AMI'
+        specName = 'PMM2-AMI'
     }
     agent {
         label 'awscli'
@@ -62,7 +62,6 @@ pipeline {
                 unstash 'IMAGE'
                 def IMAGE = sh(returnStdout: true, script: "cat IMAGE").trim()
                 slackSend channel: '#pmm-ci', color: '#00FF00', message: "[${specName}]: build finished - ${IMAGE}"
-                runPmm2AmiUITests(IMAGE)
             }
         }
         failure {


### PR DESCRIPTION
This will remove the call to UI test job, which is causing the failure and also change the console log to make it easy to find the latest image tag in ci-channel log.  