### PR TITLE
Change AWS instance type from 'm4.large' to 'm5.large'

### DIFF
--- a/pmm/aws-staging-start.groovy
+++ b/pmm/aws-staging-start.groovy
@@ -187,7 +187,7 @@ pipeline {
                                 ],
                                 "EbsOptimized": false,
                                 "ImageId": "ami-15e9c770",
-                                "InstanceType": "m4.large",
+                                "InstanceType": "m5.large",
                                 "KeyName": "jenkins",
                                 "Monitoring": {
                                     "Enabled": false


### PR DESCRIPTION
    * as I can see we have a lot of ec2 instance interaptions so
      we need to change instance type to prevent it