### PR TITLE
PMM-5403 PMM2 Ubuntu 20.04

### DIFF
--- a/pmm/pmm2-client-autobuild.groovy
+++ b/pmm/pmm2-client-autobuild.groovy
@@ -134,6 +134,7 @@ pipeline {
                 sh 'sg docker -c "./build/bin/build-client-deb debian:stretch"'
                 sh 'sg docker -c "./build/bin/build-client-deb ubuntu:bionic"'
                 sh 'sg docker -c "./build/bin/build-client-deb ubuntu:xenial"'
+                sh 'sg docker -c "./build/bin/build-client-deb ubuntu:focal"'
                 stash includes: 'results/deb/*.deb', name: 'debs'
                 uploadDEB()
             }


### PR DESCRIPTION
Updated pmm-client pipeline to provide packages for Ubuntu 20.04 