### PR TITLE
Fix timeout in pxc_operator_minikube.groovy

### DIFF
--- a/cloud/jenkins/pxc_operator_minikube.groovy
+++ b/cloud/jenkins/pxc_operator_minikube.groovy
@@ -195,11 +195,11 @@ pipeline {
             }
         }
         stage('Tests') {
+            options {
+                timeout(time: 3, unit: 'HOURS')
+            }
             agent { label 'docker-32gb' }
                 steps {
-                    options {
-                        timeout(time: 3, unit: 'HOURS')
-                    }
                     sh '''
                         if [ ! -d $HOME/google-cloud-sdk/bin ]; then
                             rm -rf $HOME/google-cloud-sdk


### PR DESCRIPTION
Minikube jenkins job is showing this error below (so moving the options should fix it):
```
java.lang.NoSuchMethodError: No such DSL method 'options' found among steps [archive, bat, catchError, checkout, compareVersions, deleteDir, dir, dockerFingerprintFrom, dockerFingerprintRun, ec2, echo, envVarsForTool, error, fileExists, findFiles, getContext, git, input, isUnix, junit, library, libraryResource, load, mail, node, nodesByLabel, parallel, powershell, properties, publishIssues, pwd, pwsh, readCSV, readFile, readJSON, readManifest, readMavenPom, readProperties, readTrusted, readYaml, recordIssues, resolveScm, retry, scanForIssues, script, sh, sha1, slackSend, slackUploadFile, slackUserIdFromEmail, slackUserIdsFromCommitters, sleep, sshagent, stage, stash, step, tee, timeout, tm, tool, touch, unarchive, unstable, unstash, unzip, validateDeclarativePipeline, waitUntil, warnError, withContext, withCredentials, withDockerContainer, withDockerRegistry, withDockerServer, withEnv, wrap, writeCSV, writeFile, writeJSON, writeMavenPom, writeYaml, ws, zip] or symbols [PVSStudio, acuCobol, ajc, all, allOf, always, androidLintParser, ansibleLint, ant, antFromApache, antOutcome, antTarget, any, anyOf, apiToken, architecture, archiveArtifacts, armCc, artifactManager, authorizationMatrix, axivion, axivionSuite, batchFile, booleanParam, branch, buckminster, buildButton, buildDiscarder, buildDiscarders, buildParameter, buildSelector, buildingTag, cadence, cargo, caseInsensitive, caseSensitive, ccm, certificate, changeRequest, changelog, changeset, checkStyle, checkoutToSubdirectory, choice, choiceParam, clang, clangAnalyzer, clangTidy, clock, cmake, codeAnalysis, codeNarc, command, coolflux, copyArtifactPermission, copyArtifacts, copyartifact, cpd, cppCheck, cppLint, credentials, cron, crumb, cssLint, defaultFolderConfiguration, defaultView, demand, detekt, diabC, disableConcurrentBuilds, disableResume, docFx, docker, dockerCert, dockerfile, downstream, doxygen, drMemory, dscanner, dumb, dupFinder, durabilityHint, eclipse, envVars, environment, equals, erlc, errorProne, esLint, excludeCategory, excludeFile, excludeMessage, excludeModule, excludeNamespace, excludePackage, excludeType, expression, file, fileParam, filePath, findBugs, fingerprint, flake8, flexSdk, frameOptions, freeStyle, freeStyleJob, fromScm, fromSource, fxcop, gcc, gcc3, gcc4, gendarme, ghsMulti, git, gitBranchDiscovery, gitHubBranchDiscovery, gitHubBranchHeadAuthority, gitHubExcludeArchivedRepositories, gitHubForkDiscovery, gitHubPullRequestDiscovery, gitHubSshCheckout, gitHubTagDiscovery, gitHubTrustContributors, gitHubTrustEveryone, gitHubTrustNobody, gitHubTrustPermissions, gitTagDiscovery, github, githubPush, gnat, gnuFortran, goLint, goVet, groovyScript, headRegexFilter, headWildcardFilter, hyperlink, hyperlinkToModels, iar, iarCstat, ibLinter, ideaInspection, includeCategory, includeFile, includeMessage, includeModule, includeNamespace, includePackage, includeType, infer, inheriting, inheritingGlobal, installSource, intel, invalids, isRestartedRun, issues, java, javaDoc, jcReport, jdk, jdkInstaller, jgit, jgitapache, jnlp, jobBuildDiscarder, jobName, jsHint, jsLint, junitParser, klocWork, kotlin, ktLint, label, lastCompleted, lastDuration, lastFailure, lastGrantedAuthorities, lastStable, lastSuccess, lastSuccessful, lastWithArtifacts, latestSavedBuild, legacy, legacySCM, list, local, location, logRotator, loggedInUsersCanDoAnything, mailer, masterBuild, maven, maven3Mojos, mavenConsole, mavenErrors, mavenMojos, mavenWarnings, metrowerksCodeWarrior, mineRepository, modelsim, modernSCM, msBuild, myPy, myView, nagFortran, newContainerPerStage, node, nodeProperties, nonInheriting, none, not, overrideIndexTriggers, paneStatus, parallelsAlwaysFailFast, parameters, password, pattern, pcLint, pep8, perforce, perlCritic, permalink, permanent, php, phpCodeSniffer, phpStan, pipeline-model, pipeline-model-docker, pipelineTriggers, pit, plainText, plugin, pmdParser, pollSCM, prefast, preserveStashes, projectNamingStrategy, protoLint, proxy, pruneTags, puppetLint, pyDocStyle, pyLint, qacSourceCodeAnalyser, queueItemAuthenticator, quietPeriod, rateLimitBuilds, recordIssues, resharperInspectCode, resourceRoot, rfLint, robocopy, ruboCop, run, runParam, sSHLauncher, scala, schedule, scmRetryCount, scriptApproval, scriptApprovalLink, search, security, shell, simian, simpleBuildDiscarder, skipDefaultCheckout, skipStagesAfterUnstable, slackNotifier, slave, sonarQube, sourceRegexFilter, sourceWildcardFilter, specific, sphinxBuild, spotBugs, ssh, sshUserPrivateKey, stackTrace, standard, status, string, stringParam, styleCop, sunC, swapSpace, swiftLint, tag, tagList, taskScanner, taskingVx, teamSlugFilter, text, textParam, tiCss, timezone, tmpSpace, tnsdl, toolLocation, triggeredBy, tsLint, unsecured, upstream, userSeed, usernameColonPassword, usernamePassword, viewsTabBar, warnings, warningsParsers, warningsPlugin, weather, withAnt, workspace, xlc, xmlLint, yamlLint, yuiCompressor, zfs, zip, zptLint] or globals [currentBuild, docker, env, params, pipeline, scm]
```