### PR TITLE
PXC-3369: Add boost-devel package

### DIFF
--- a/pxc/docker/install-deps
+++ b/pxc/docker/install-deps
@@ -67,7 +67,7 @@ if [ -f /usr/bin/yum ]; then
     "
 
     if [[ ${RHVER} -eq 8 ]]; then
-        PKGLIST+=" lz4 perl-Memoize perl-open valgrind-devel libubsan rpcgen libtirpc-devel"
+        PKGLIST+=" lz4 perl-Memoize perl-open valgrind-devel libubsan rpcgen libtirpc-devel boost-devel"
     else
         PKGLIST+=" asio-devel"
     fi


### PR DESCRIPTION
The `shared_ptr.hpp` being missing on system which causes failure on pipeline run for CentOS 8