### PR TITLE
PXC-3364 : Make MTR workers configurable for param jobs

### DIFF
--- a/pxc/docker/run-test
+++ b/pxc/docker/run-test
@@ -34,7 +34,7 @@ docker run --rm \
 
     mkdir /tmp/results/log
     rsync -a --prune-empty-dirs --include '*/' --include '*.err' --exclude '*' /tmp/results/PXC/mysql-test/var* /tmp/results/log
-    sudo tar -C /tmp/results/log -czf "pxc80-test-mtr_logs.tar.gz" var1 var2 var3
+    sudo tar -C /tmp/results/log -czf "pxc80-test-mtr_logs.tar.gz" var1 var2 var3 var4 var5 
 
     sudo mv ./pxc80-test-mtr_logs.tar.gz /tmp/pxc/results/
     sudo mv /tmp/results/*.xml /tmp/results/*.output  /tmp/pxc/results/

--- a/pxc/docker/run-test
+++ b/pxc/docker/run-test
@@ -22,6 +22,10 @@ docker run --rm \
     export MTR_ARGS='${MTR_ARGS}'
     export MTR_REPEAT='${MTR_REPEAT}'
     export MTR_VAULT_TOKEN='${MTR_VAULT_TOKEN}'
+	export FULL_MTR='${FULL_MTR}'
+	export GALERA_PARALLEL_RUN='${GALERA_PARALLEL_RUN}'
+	export MTR_SUITES='${MTR_SUITES}'
+	export PARALLEL_RUN='${PARALLEL_RUN}'
 
     mkdir /tmp/results
     cp /tmp/pxc/results/*.tar.gz /tmp/results
@@ -29,8 +33,8 @@ docker run --rm \
     bash -x /tmp/scripts/test-binary-pxc /tmp/results
 
     mkdir /tmp/results/log
-    rsync -a --prune-empty-dirs --include '*/' --include '*.err' --exclude '*' /tmp/results/PXC/mysql-test/var /tmp/results/log
-    sudo tar -C /tmp/results/log -czf "pxc80-test-mtr_logs.tar.gz" var
+    rsync -a --prune-empty-dirs --include '*/' --include '*.err' --exclude '*' /tmp/results/PXC/mysql-test/var* /tmp/results/log
+    sudo tar -C /tmp/results/log -czf "pxc80-test-mtr_logs.tar.gz" var1 var2 var3
 
     sudo mv ./pxc80-test-mtr_logs.tar.gz /tmp/pxc/results/
     sudo mv /tmp/results/*.xml /tmp/results/*.output  /tmp/pxc/results/

--- a/pxc/docker/run-test
+++ b/pxc/docker/run-test
@@ -22,10 +22,10 @@ docker run --rm \
     export MTR_ARGS='${MTR_ARGS}'
     export MTR_REPEAT='${MTR_REPEAT}'
     export MTR_VAULT_TOKEN='${MTR_VAULT_TOKEN}'
-	export FULL_MTR='${FULL_MTR}'
-	export GALERA_PARALLEL_RUN='${GALERA_PARALLEL_RUN}'
-	export MTR_SUITES='${MTR_SUITES}'
-	export PARALLEL_RUN='${PARALLEL_RUN}'
+    export FULL_MTR='${FULL_MTR}'
+    export GALERA_PARALLEL_RUN='${GALERA_PARALLEL_RUN}'
+    export MTR_SUITES='${MTR_SUITES}'
+    export PARALLEL_RUN='${PARALLEL_RUN}'
 
     mkdir /tmp/results
     cp /tmp/pxc/results/*.tar.gz /tmp/results
@@ -34,7 +34,7 @@ docker run --rm \
 
     mkdir /tmp/results/log
     rsync -a --prune-empty-dirs --include '*/' --include '*.err' --exclude '*' /tmp/results/PXC/mysql-test/mtr_var /tmp/results/log
-    sudo tar -C /tmp/results/log -czf "pxc80-test-mtr_logs.tar.gz" mtr_var || true
+    sudo tar -C /tmp/results/log -czf "pxc80-test-mtr_logs.tar.gz" mtr_var
 
     sudo mv ./pxc80-test-mtr_logs.tar.gz /tmp/pxc/results/
     sudo mv /tmp/results/*.xml /tmp/results/*.output  /tmp/pxc/results/

--- a/pxc/docker/run-test
+++ b/pxc/docker/run-test
@@ -34,7 +34,7 @@ docker run --rm \
 
     mkdir /tmp/results/log
     rsync -a --prune-empty-dirs --include '*/' --include '*.err' --exclude '*' /tmp/results/PXC/mysql-test/var* /tmp/results/log
-    sudo tar -C /tmp/results/log -czf "pxc80-test-mtr_logs.tar.gz" var1 var2 var3 var4 var5 
+    sudo tar -C /tmp/results/log -czf "pxc80-test-mtr_logs.tar.gz" var1 var2 var3 var4 var5 || true
 
     sudo mv ./pxc80-test-mtr_logs.tar.gz /tmp/pxc/results/
     sudo mv /tmp/results/*.xml /tmp/results/*.output  /tmp/pxc/results/

--- a/pxc/docker/run-test
+++ b/pxc/docker/run-test
@@ -33,8 +33,8 @@ docker run --rm \
     bash -x /tmp/scripts/test-binary-pxc /tmp/results
 
     mkdir /tmp/results/log
-    rsync -a --prune-empty-dirs --include '*/' --include '*.err' --exclude '*' /tmp/results/PXC/mysql-test/var* /tmp/results/log
-    sudo tar -C /tmp/results/log -czf "pxc80-test-mtr_logs.tar.gz" var1 var2 var3 var4 var5 || true
+    rsync -a --prune-empty-dirs --include '*/' --include '*.err' --exclude '*' /tmp/results/PXC/mysql-test/mtr_var /tmp/results/log
+    sudo tar -C /tmp/results/log -czf "pxc80-test-mtr_logs.tar.gz" mtr_var || true
 
     sudo mv ./pxc80-test-mtr_logs.tar.gz /tmp/pxc/results/
     sudo mv /tmp/results/*.xml /tmp/results/*.output  /tmp/pxc/results/

--- a/pxc/docker/run-test57
+++ b/pxc/docker/run-test57
@@ -22,6 +22,10 @@ docker run --rm \
     export MTR_ARGS='${MTR_ARGS}'
     export MTR_REPEAT='${MTR_REPEAT}'
     export MTR_VAULT_TOKEN='${MTR_VAULT_TOKEN}'
+	export FULL_MTR='${FULL_MTR}'
+	export GALERA_PARALLEL_RUN='${GALERA_PARALLEL_RUN}'
+	export MTR_SUITES='${MTR_SUITES}'
+	export PARALLEL_RUN='${PARALLEL_RUN}'
 
     mkdir /tmp/results
     cp /tmp/pxc/results/*.tar.gz /tmp/results

--- a/pxc/docker/run-test57
+++ b/pxc/docker/run-test57
@@ -34,7 +34,7 @@ docker run --rm \
 
     mkdir /tmp/results/log
     rsync -a --prune-empty-dirs --include '*/' --include '*.err' --exclude '*' /tmp/results/PXC/mysql-test/var* /tmp/results/log
-    sudo tar -C /tmp/results/log -czf "pxc57-test-mtr_logs.tar.gz" var1 var2 var3 || true
+    sudo tar -C /tmp/results/log -czf "pxc57-test-mtr_logs.tar.gz" var1 var2 var3
 
     sudo mv ./pxc57-test-mtr_logs.tar.gz /tmp/pxc/results/
     sudo mv /tmp/results/*.xml /tmp/results/*.output  /tmp/pxc/results/

--- a/pxc/docker/run-test57
+++ b/pxc/docker/run-test57
@@ -34,7 +34,7 @@ docker run --rm \
 
     mkdir /tmp/results/log
     rsync -a --prune-empty-dirs --include '*/' --include '*.err' --exclude '*' /tmp/results/PXC/mysql-test/var* /tmp/results/log
-    sudo tar -C /tmp/results/log -czf "pxc57-test-mtr_logs.tar.gz" var1 var2 var3
+    sudo tar -C /tmp/results/log -czf "pxc57-test-mtr_logs.tar.gz" var1 var2 var3 || true
 
     sudo mv ./pxc57-test-mtr_logs.tar.gz /tmp/pxc/results/
     sudo mv /tmp/results/*.xml /tmp/results/*.output  /tmp/pxc/results/

--- a/pxc/docker/run-test57
+++ b/pxc/docker/run-test57
@@ -33,8 +33,8 @@ docker run --rm \
     bash -x /tmp/scripts/test-binary-pxc57 /tmp/results
 
     mkdir /tmp/results/log
-    rsync -a --prune-empty-dirs --include '*/' --include '*.err' --exclude '*' /tmp/results/PXC/mysql-test/var* /tmp/results/log
-    sudo tar -C /tmp/results/log -czf "pxc57-test-mtr_logs.tar.gz" var1 var2 var3 || true
+    rsync -a --prune-empty-dirs --include '*/' --include '*.err' --exclude '*' /tmp/results/PXC/mysql-test/mtr_var /tmp/results/log
+    sudo tar -C /tmp/results/log -czf "pxc57-test-mtr_logs.tar.gz" mtr_var || true
 
     sudo mv ./pxc57-test-mtr_logs.tar.gz /tmp/pxc/results/
     sudo mv /tmp/results/*.xml /tmp/results/*.output  /tmp/pxc/results/

--- a/pxc/docker/run-test57
+++ b/pxc/docker/run-test57
@@ -22,10 +22,10 @@ docker run --rm \
     export MTR_ARGS='${MTR_ARGS}'
     export MTR_REPEAT='${MTR_REPEAT}'
     export MTR_VAULT_TOKEN='${MTR_VAULT_TOKEN}'
-	export FULL_MTR='${FULL_MTR}'
-	export GALERA_PARALLEL_RUN='${GALERA_PARALLEL_RUN}'
-	export MTR_SUITES='${MTR_SUITES}'
-	export PARALLEL_RUN='${PARALLEL_RUN}'
+    export FULL_MTR='${FULL_MTR}'
+    export GALERA_PARALLEL_RUN='${GALERA_PARALLEL_RUN}'
+    export MTR_SUITES='${MTR_SUITES}'
+    export PARALLEL_RUN='${PARALLEL_RUN}'
 
     mkdir /tmp/results
     cp /tmp/pxc/results/*.tar.gz /tmp/results
@@ -34,7 +34,7 @@ docker run --rm \
 
     mkdir /tmp/results/log
     rsync -a --prune-empty-dirs --include '*/' --include '*.err' --exclude '*' /tmp/results/PXC/mysql-test/mtr_var /tmp/results/log
-    sudo tar -C /tmp/results/log -czf "pxc57-test-mtr_logs.tar.gz" mtr_var || true
+    sudo tar -C /tmp/results/log -czf "pxc57-test-mtr_logs.tar.gz" mtr_var
 
     sudo mv ./pxc57-test-mtr_logs.tar.gz /tmp/pxc/results/
     sudo mv /tmp/results/*.xml /tmp/results/*.output  /tmp/pxc/results/

--- a/pxc/docker/run-test57
+++ b/pxc/docker/run-test57
@@ -29,8 +29,8 @@ docker run --rm \
     bash -x /tmp/scripts/test-binary-pxc57 /tmp/results
 
     mkdir /tmp/results/log
-    rsync -a --prune-empty-dirs --include '*/' --include '*.err' --exclude '*' /tmp/results/PXC/mysql-test/var /tmp/results/log
-    sudo tar -C /tmp/results/log -czf "pxc57-test-mtr_logs.tar.gz" var
+    rsync -a --prune-empty-dirs --include '*/' --include '*.err' --exclude '*' /tmp/results/PXC/mysql-test/var* /tmp/results/log
+    sudo tar -C /tmp/results/log -czf "pxc57-test-mtr_logs.tar.gz" var*
 
     sudo mv ./pxc57-test-mtr_logs.tar.gz /tmp/pxc/results/
     sudo mv /tmp/results/*.xml /tmp/results/*.output  /tmp/pxc/results/

--- a/pxc/docker/run-test57
+++ b/pxc/docker/run-test57
@@ -34,7 +34,7 @@ docker run --rm \
 
     mkdir /tmp/results/log
     rsync -a --prune-empty-dirs --include '*/' --include '*.err' --exclude '*' /tmp/results/PXC/mysql-test/var* /tmp/results/log
-    sudo tar -C /tmp/results/log -czf "pxc57-test-mtr_logs.tar.gz" var*
+    sudo tar -C /tmp/results/log -czf "pxc57-test-mtr_logs.tar.gz" var1 var2 var3 || true
 
     sudo mv ./pxc57-test-mtr_logs.tar.gz /tmp/pxc/results/
     sudo mv /tmp/results/*.xml /tmp/results/*.output  /tmp/pxc/results/

--- a/pxc/jenkins/param.yml
+++ b/pxc/jenkins/param.yml
@@ -1,5 +1,5 @@
 - job:
-    name: test-pxc-8.0-param
+    name: pxc-8.0-param
     project-type: matrix
     defaults: global
     description: |
@@ -95,11 +95,16 @@
          type: user-defined
          name: DOCKER_OS
          values:
+          - centos:7
           - centos:8
+          - ubuntu:xenial
+          - ubuntu:bionic
           - ubuntu:focal
+          - debian:stretch
+          - debian:buster
     builders:
     - trigger-builds:
-      - project: test-pxc-8.0-pipeline
+      - project: pxc-8.0-pipeline
         current-parameters: true
         predefined-parameters: |
           DOCKER_OS=${DOCKER_OS}
@@ -112,14 +117,12 @@
     - shell: |
         sudo find . -name "*.xml" -o -name "*.log" -delete
     - copyartifact:
-        project: test-pxc-8.0-pipeline
+        project: pxc-8.0-pipeline
         which-build: specific-build
-        build-number: "${TRIGGERED_BUILD_NUMBERS_test_pxc_8_0_pipeline}"
+        build-number: "${TRIGGERED_BUILD_NUMBERS_pxc_8_0_pipeline}"
         do-not-fingerprint: true
     - shell: |
-        echo "${TRIGGERED_BUILD_NUMBERS_test_pxc_8_0_pipeline}" > PIPELINE_BUILD_NUMBER
-        ls -l
-        ls -l ../
+        echo "${TRIGGERED_BUILD_NUMBERS_pxc_8_0_pipeline}" > PIPELINE_BUILD_NUMBER
     publishers:
     - junit:
         results: "**/*.xml"

--- a/pxc/jenkins/param.yml
+++ b/pxc/jenkins/param.yml
@@ -118,6 +118,8 @@
         do-not-fingerprint: true
     - shell: |
         echo "${TRIGGERED_BUILD_NUMBERS_test_pxc_8_0_pipeline}" > PIPELINE_BUILD_NUMBER
+        ls -l
+        ls -l ../
     publishers:
     - junit:
         results: "**/*.xml"

--- a/pxc/jenkins/param.yml
+++ b/pxc/jenkins/param.yml
@@ -118,7 +118,6 @@
         do-not-fingerprint: true
     - shell: |
         echo "${TRIGGERED_BUILD_NUMBERS_test_pxc_8_0_pipeline}" > PIPELINE_BUILD_NUMBER
-        gunzip build.log.gz
     publishers:
     - junit:
         results: "**/*.xml"

--- a/pxc/jenkins/param.yml
+++ b/pxc/jenkins/param.yml
@@ -1,5 +1,5 @@
 - job:
-    name: pxc-8.0-param
+    name: test-pxc-8.0-param
     project-type: matrix
     defaults: global
     description: |
@@ -29,7 +29,7 @@
         description: URL to PXB80 repository
     - string:
         name: PXB80_BRANCH
-        default: percona-xtrabackup-8.0.9
+        default: percona-xtrabackup-8.0.12
         description: Tag/Branch for PXB80 repository
     - string:
         name: PXB24_REPO
@@ -37,7 +37,7 @@
         description: URL to PXB24 repository
     - string:
         name: PXB24_BRANCH
-        default: percona-xtrabackup-2.4.18
+        default: percona-xtrabackup-2.4.20
         description: Tag/Branch for PXC repository
     - choice:
         name: JOB_CMAKE
@@ -58,15 +58,27 @@
         - "yes"
         - "no"
         description: Run mysql-test-run.pl
+    - string:
+        name: PARALLEL_RUN
+        default: "4"
+        description: "(sys_vars test suite) mtr can start n parallel server and distrbute workload among them. More parallelism is better but extra parallelism (beyond CPU power) will have less effect. This value is used for the sys_vars test suite."
+    - string:
+        name: GALERA_PARALLEL_RUN
+        default: "2"
+        description: "(galera and galera_3nodes test suite) mtr can start n parallel server and distrbute workload among them. More parallelism is better but extra parallelism (beyond CPU power) will have less effect. This value is used for the galera and galera_3nodes test suite."
     - choice:
-        name: HOTBACKUP_TESTING
+        name: FULL_MTR
         choices:
-        - "yes"
         - "no"
-        description: Run mysql-test-run.pl --suite tokudb_backup
+        - "yes"
+        description: Run mtr suites based on variable MTR_SUITES if the value is `no`. Otherwise the full mtr will be perfomed.
+    - string:
+        name: MTR_SUITES
+        default: galera,galera_3nodes,galera_sr,galera_3nodes_sr,sys_vars
+        description: "mysql-test-run.pl suite names"
     - string:
         name: MTR_ARGS
-        default: --unit-tests-report --suite=galera,galera_3nodes,galera_sr,galera_3nodes_sr,sys_vars
+        default: --unit-tests-report
         description: "mysql-test-run.pl options, for options like: --big-test --only-big-test --nounit-tests --unit-tests-report"
     - string:
         name: MTR_REPEAT
@@ -83,16 +95,11 @@
          type: user-defined
          name: DOCKER_OS
          values:
-          - centos:7
           - centos:8
-          - ubuntu:xenial
-          - ubuntu:bionic
           - ubuntu:focal
-          - debian:stretch
-          - debian:buster
     builders:
     - trigger-builds:
-      - project: pxc-8.0-pipeline
+      - project: test-pxc-8.0-pipeline
         current-parameters: true
         predefined-parameters: |
           DOCKER_OS=${DOCKER_OS}
@@ -105,12 +112,12 @@
     - shell: |
         sudo find . -name "*.xml" -o -name "*.log" -delete
     - copyartifact:
-        project: pxc-8.0-pipeline
+        project: test-pxc-8.0-pipeline
         which-build: specific-build
-        build-number: "${TRIGGERED_BUILD_NUMBERS_pxc_8_0_pipeline}"
+        build-number: "${TRIGGERED_BUILD_NUMBERS_test_pxc_8_0_pipeline}"
         do-not-fingerprint: true
     - shell: |
-        echo "${TRIGGERED_BUILD_NUMBERS_pxc_8_0_pipeline}" > PIPELINE_BUILD_NUMBER
+        echo "${TRIGGERED_BUILD_NUMBERS_test_pxc_8_0_pipeline}" > PIPELINE_BUILD_NUMBER
         gunzip build.log.gz
     publishers:
     - junit:

--- a/pxc/jenkins/param.yml
+++ b/pxc/jenkins/param.yml
@@ -61,11 +61,11 @@
     - string:
         name: PARALLEL_RUN
         default: "4"
-        description: "(sys_vars test suite) mtr can start n parallel server and distrbute workload among them. More parallelism is better but extra parallelism (beyond CPU power) will have less effect. This value is used for the sys_vars test suite."
+        description: "mtr can start n parallel server and distrbute workload among them. More parallelism is better but extra parallelism (beyond CPU power) will have less effect. This value is used for all test suites except Galera specific suites."
     - string:
         name: GALERA_PARALLEL_RUN
         default: "2"
-        description: "(galera and galera_3nodes test suite) mtr can start n parallel server and distrbute workload among them. More parallelism is better but extra parallelism (beyond CPU power) will have less effect. This value is used for the galera and galera_3nodes test suite."
+        description: "mtr can start n parallel server and distrbute workload among them. More parallelism is better but extra parallelism (beyond CPU power) will have less effect. This value is used for the Galera specific test suites."
     - choice:
         name: FULL_MTR
         choices:

--- a/pxc/jenkins/param.yml
+++ b/pxc/jenkins/param.yml
@@ -69,8 +69,8 @@
     - choice:
         name: FULL_MTR
         choices:
-        - "no"
         - "yes"
+        - "no"
         description: Run mtr suites based on variable MTR_SUITES if the value is `no`. Otherwise the full mtr will be perfomed.
     - string:
         name: MTR_SUITES

--- a/pxc/jenkins/param57.yml
+++ b/pxc/jenkins/param57.yml
@@ -50,12 +50,6 @@
         - "yes"
         - "no"
         description: Run mysql-test-run.pl
-    - choice:
-        name: HOTBACKUP_TESTING
-        choices:
-        - "yes"
-        - "no"
-        description: Run mysql-test-run.pl --suite tokudb_backup
     - string:
         name: PARALLEL_RUN
         default: "4"

--- a/pxc/jenkins/param57.yml
+++ b/pxc/jenkins/param57.yml
@@ -64,10 +64,12 @@
         name: GALERA_PARALLEL_RUN
         default: "2"
         description: "(galera and galera_3nodes test suite) mtr can start n parallel server and distrbute workload among them. More parallelism is better but extra parallelism (beyond CPU power) will have less effect. This value is used for the galera and galera_3nodes test suite."
-    - string:
+    - choice:
         name: FULL_MTR
-        default: "1"
-        description: If empty, only galera and sys_vars suites will be run. Otherwise the full mtr will be perfomed.
+        choices:
+        - "no"
+        - "yes"
+        description: Run mtr suites based on variable MTR_SUITES if the value is `no`. Otherwise the full mtr will be perfomed.
     - string:
         name: MTR_SUITES
         default: galera,galera_3nodes,sys_vars

--- a/pxc/jenkins/param57.yml
+++ b/pxc/jenkins/param57.yml
@@ -110,10 +110,10 @@
     - copyartifact:
         project: test-pxc-5.7-pipeline
         which-build: specific-build
-        build-number: "${TRIGGERED_BUILD_NUMBERS_pxc_5_7_pipeline}"
+        build-number: "${TRIGGERED_BUILD_NUMBERS_test_pxc_5_7_pipeline}"
         do-not-fingerprint: true
     - shell: |
-        echo "${TRIGGERED_BUILD_NUMBERS_pxc_5_7_pipeline}" > PIPELINE_BUILD_NUMBER
+        echo "${TRIGGERED_BUILD_NUMBERS_test_pxc_5_7_pipeline}" > PIPELINE_BUILD_NUMBER
     publishers:
     - junit:
         results: "**/*.xml"

--- a/pxc/jenkins/param57.yml
+++ b/pxc/jenkins/param57.yml
@@ -53,11 +53,11 @@
     - string:
         name: PARALLEL_RUN
         default: "4"
-        description: "(sys_vars test suite) mtr can start n parallel server and distrbute workload among them. More parallelism is better but extra parallelism (beyond CPU power) will have less effect. This value is used for the sys_vars test suite."
+        description: "mtr can start n parallel server and distrbute workload among them. More parallelism is better but extra parallelism (beyond CPU power) will have less effect. This value is used for all test suites except Galera specific suites."
     - string:
         name: GALERA_PARALLEL_RUN
         default: "2"
-        description: "(galera and galera_3nodes test suite) mtr can start n parallel server and distrbute workload among them. More parallelism is better but extra parallelism (beyond CPU power) will have less effect. This value is used for the galera and galera_3nodes test suite."
+        description: "mtr can start n parallel server and distrbute workload among them. More parallelism is better but extra parallelism (beyond CPU power) will have less effect. This value is used for the Galera specific test suites."
     - choice:
         name: FULL_MTR
         choices:

--- a/pxc/jenkins/param57.yml
+++ b/pxc/jenkins/param57.yml
@@ -70,11 +70,11 @@
         description: If empty, only galera and sys_vars suites will be run. Otherwise the full mtr will be perfomed.
     - string:
         name: MTR_SUITES
-        default: galera,galera_3nodes,galera_sr,galera_3nodes_sr,sys_vars
+        default: galera,galera_3nodes,sys_vars
         description: "mysql-test-run.pl suite names"
     - string:
         name: MTR_ARGS
-        default: --unit-tests-report --suite=galera,galera_3nodes,sys_vars
+        default: --unit-tests-report
         description: "mysql-test-run.pl options, for options like: --big-test --only-big-test --nounit-tests --unit-tests-report"
     - string:
         name: MTR_REPEAT
@@ -91,8 +91,8 @@
          type: user-defined
          name: DOCKER_OS
          values:
-          - centos:7
-          - ubuntu:bionic
+          - centos:8
+          - ubuntu:focal
     builders:
     - trigger-builds:
       - project: test-pxc-5.7-pipeline

--- a/pxc/jenkins/param57.yml
+++ b/pxc/jenkins/param57.yml
@@ -61,8 +61,8 @@
     - choice:
         name: FULL_MTR
         choices:
-        - "no"
         - "yes"
+        - "no"
         description: Run mtr suites based on variable MTR_SUITES if the value is `no`. Otherwise the full mtr will be perfomed.
     - string:
         name: MTR_SUITES

--- a/pxc/jenkins/param57.yml
+++ b/pxc/jenkins/param57.yml
@@ -1,5 +1,5 @@
 - job:
-    name: test-pxc-5.7-param
+    name: pxc-5.7-param
     project-type: matrix
     defaults: global
     description: |
@@ -87,11 +87,17 @@
          type: user-defined
          name: DOCKER_OS
          values:
+          - centos:6
+          - centos:7
           - centos:8
+          - ubuntu:xenial
+          - ubuntu:bionic
           - ubuntu:focal
+          - debian:stretch
+          - debian:buster
     builders:
     - trigger-builds:
-      - project: test-pxc-5.7-pipeline
+      - project: pxc-5.7-pipeline
         current-parameters: true
         predefined-parameters: |
           DOCKER_OS=${DOCKER_OS}
@@ -104,12 +110,12 @@
     - shell: |
         sudo find . -name "*.xml" -o -name "*.log" -delete
     - copyartifact:
-        project: test-pxc-5.7-pipeline
+        project: pxc-5.7-pipeline
         which-build: specific-build
-        build-number: "${TRIGGERED_BUILD_NUMBERS_test_pxc_5_7_pipeline}"
+        build-number: "${TRIGGERED_BUILD_NUMBERS_pxc_5_7_pipeline}"
         do-not-fingerprint: true
     - shell: |
-        echo "${TRIGGERED_BUILD_NUMBERS_test_pxc_5_7_pipeline}" > PIPELINE_BUILD_NUMBER
+        echo "${TRIGGERED_BUILD_NUMBERS_pxc_5_7_pipeline}" > PIPELINE_BUILD_NUMBER
     publishers:
     - junit:
         results: "**/*.xml"

--- a/pxc/jenkins/param57.yml
+++ b/pxc/jenkins/param57.yml
@@ -1,5 +1,5 @@
 - job:
-    name: pxc-5.7-param
+    name: test-pxc-5.7-param
     project-type: matrix
     defaults: global
     description: |
@@ -57,6 +57,22 @@
         - "no"
         description: Run mysql-test-run.pl --suite tokudb_backup
     - string:
+        name: PARALLEL_RUN
+        default: "4"
+        description: "(sys_vars test suite) mtr can start n parallel server and distrbute workload among them. More parallelism is better but extra parallelism (beyond CPU power) will have less effect. This value is used for the sys_vars test suite."
+    - string:
+        name: GALERA_PARALLEL_RUN
+        default: "2"
+        description: "(galera and galera_3nodes test suite) mtr can start n parallel server and distrbute workload among them. More parallelism is better but extra parallelism (beyond CPU power) will have less effect. This value is used for the galera and galera_3nodes test suite."
+    - string:
+        name: FULL_MTR
+        default: "1"
+        description: If empty, only galera and sys_vars suites will be run. Otherwise the full mtr will be perfomed.
+    - string:
+        name: MTR_SUITES
+        default: galera,galera_3nodes,galera_sr,galera_3nodes_sr,sys_vars
+        description: "mysql-test-run.pl suite names"
+    - string:
         name: MTR_ARGS
         default: --unit-tests-report --suite=galera,galera_3nodes,sys_vars
         description: "mysql-test-run.pl options, for options like: --big-test --only-big-test --nounit-tests --unit-tests-report"
@@ -75,18 +91,11 @@
          type: user-defined
          name: DOCKER_OS
          values:
-          - centos:6
           - centos:7
-          - centos:8
-          - ubuntu:xenial
           - ubuntu:bionic
-          - ubuntu:focal
-          - debian:jessie
-          - debian:stretch
-          - debian:buster
     builders:
     - trigger-builds:
-      - project: pxc-5.7-pipeline
+      - project: test-pxc-5.7-pipeline
         current-parameters: true
         predefined-parameters: |
           DOCKER_OS=${DOCKER_OS}
@@ -99,7 +108,7 @@
     - shell: |
         sudo find . -name "*.xml" -o -name "*.log" -delete
     - copyartifact:
-        project: pxc-5.7-pipeline
+        project: test-pxc-5.7-pipeline
         which-build: specific-build
         build-number: "${TRIGGERED_BUILD_NUMBERS_pxc_5_7_pipeline}"
         do-not-fingerprint: true

--- a/pxc/jenkins/pxc57-pipeline.groovy
+++ b/pxc/jenkins/pxc57-pipeline.groovy
@@ -48,11 +48,11 @@ pipeline {
             name: 'DEFAULT_TESTING')
 		string(
 		    defaultValue: '4',
-		    description: '(sys_vars test suite) mtr can start n parallel server and distrbute workload among them. More parallelism is better but extra parallelism (beyond CPU power) will have less effect. This value is used for the sys_vars test suite.',
+		    description: 'mtr can start n parallel server and distrbute workload among them. More parallelism is better but extra parallelism (beyond CPU power) will have less effect. This value is used for all test suites except Galera specific suites.',
 		    name: 'PARALLEL_RUN')
 		string(
 			defaultValue: '2',
-			description: '(galera and galera_3nodes test suite) mtr can start n parallel server and distrbute workload among them. More parallelism is better but extra parallelism (beyond CPU power) will have less effect. This value is used for the galera and galera_3nodes test suite.',
+			description: 'mtr can start n parallel server and distrbute workload among them. More parallelism is better but extra parallelism (beyond CPU power) will have less effect. This value is used for the Galera specific test suites.',
 			name: 'GALERA_PARALLEL_RUN')
 	    choice(
 	        choices: 'no\nyes',

--- a/pxc/jenkins/pxc57-pipeline.groovy
+++ b/pxc/jenkins/pxc57-pipeline.groovy
@@ -23,7 +23,7 @@ pipeline {
             name: 'PXB24_BRANCH',
             trim: true)
         choice(
-            choices: 'centos:7\nubuntu:bionic',
+            choices: 'centos:8\nubuntu:focal',
             description: 'OS version for compilation',
             name: 'DOCKER_OS')
         choice(

--- a/pxc/jenkins/pxc57-pipeline.groovy
+++ b/pxc/jenkins/pxc57-pipeline.groovy
@@ -23,7 +23,7 @@ pipeline {
             name: 'PXB24_BRANCH',
             trim: true)
         choice(
-            choices: 'centos:8\nubuntu:focal',
+            choices: 'centos:6\ncentos:7\ncentos:8\nubuntu:xenial\nubuntu:bionic\nubuntu:focal\ndebian:stretch\ndebian:buster',
             description: 'OS version for compilation',
             name: 'DOCKER_OS')
         choice(
@@ -51,7 +51,7 @@ pipeline {
 		    description: '(sys_vars test suite) mtr can start n parallel server and distrbute workload among them. More parallelism is better but extra parallelism (beyond CPU power) will have less effect. This value is used for the sys_vars test suite.',
 		    name: 'PARALLEL_RUN')
 		string(
-			defaultValue: '4',
+			defaultValue: '2',
 			description: '(galera and galera_3nodes test suite) mtr can start n parallel server and distrbute workload among them. More parallelism is better but extra parallelism (beyond CPU power) will have less effect. This value is used for the galera and galera_3nodes test suite.',
 			name: 'GALERA_PARALLEL_RUN')
 	    choice(
@@ -110,7 +110,7 @@ pipeline {
                 stage('Build PXB24') {
                     agent { label 'docker' }
                     steps {
-                        git branch: 'PXC-3364-Add-MTR-params', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
+                        git branch: 'master', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
                         echo 'Checkout PXB24 sources'
                         sh '''
                             # sudo is needed for better node recovery after compilation failure
@@ -147,7 +147,7 @@ pipeline {
         stage('Build PXC57') {
                 agent { label 'docker-32gb' }
                 steps {
-                    git branch: 'PXC-3364-Add-MTR-params', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
+                    git branch: 'master', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
                     echo 'Checkout PXC57 sources'
                     sh '''
                         # sudo is needed for better node recovery after compilation failure
@@ -183,7 +183,7 @@ pipeline {
         stage('Test PXC57') {
                 agent { label 'docker-32gb' }
                 steps {
-                    git branch: 'PXC-3364-Add-MTR-params', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
+                    git branch: 'master', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
                     echo 'Test PXC57'
                     withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'c42456e5-c28d-4962-b32c-b75d161bff27', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
                         sh '''

--- a/pxc/jenkins/pxc57-pipeline.groovy
+++ b/pxc/jenkins/pxc57-pipeline.groovy
@@ -23,7 +23,7 @@ pipeline {
             name: 'PXB24_BRANCH',
             trim: true)
         choice(
-            choices: 'centos:6\ncentos:7\ncentos:8\nubuntu:xenial\nubuntu:bionic\nubuntu:focal\ndebian:jessie\ndebian:stretch\ndebian:buster',
+            choices: 'centos:7\nubuntu:bionic',
             description: 'OS version for compilation',
             name: 'DOCKER_OS')
         choice(
@@ -46,8 +46,24 @@ pipeline {
             choices: 'yes\nno',
             description: 'Run mysql-test-run.pl',
             name: 'DEFAULT_TESTING')
+		string(
+		    defaultValue: '4',
+		    description: '(sys_vars test suite) mtr can start n parallel server and distrbute workload among them. More parallelism is better but extra parallelism (beyond CPU power) will have less effect. This value is used for the sys_vars test suite.',
+		    name: 'PARALLEL_RUN')
+		string(
+			defaultValue: '4',
+			description: '(galera and galera_3nodes test suite) mtr can start n parallel server and distrbute workload among them. More parallelism is better but extra parallelism (beyond CPU power) will have less effect. This value is used for the galera and galera_3nodes test suite.',
+			name: 'GALERA_PARALLEL_RUN')
+	    string(
+	        defaultValue: '1',
+	        description: 'If empty, only galera and sys_vars suites will be run. Otherwise the full mtr will be perfomed.',
+	        name: 'FULL_MTR')
+	    string(
+	        defaultValue: 'galera,galera_3nodes,sys_vars',
+	        description: 'mysql-test-run.pl suite names',
+	        name: 'MTR_SUITES')
         string(
-            defaultValue: '--unit-tests-report --suite=galera,galera_3nodes,galera_sr,galera_3nodes_sr,sys_vars',
+            defaultValue: '--unit-tests-report --big-test',
             description: 'mysql-test-run.pl options, for options like: --big-test --only-big-test --nounit-tests --unit-tests-report',
             name: 'MTR_ARGS')
         string(
@@ -94,7 +110,7 @@ pipeline {
                 stage('Build PXB24') {
                     agent { label 'docker' }
                     steps {
-                        git branch: 'master', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
+                        git branch: 'PXC-3364-Add-MTR-params', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
                         echo 'Checkout PXB24 sources'
                         sh '''
                             # sudo is needed for better node recovery after compilation failure
@@ -131,7 +147,7 @@ pipeline {
         stage('Build PXC57') {
                 agent { label 'docker-32gb' }
                 steps {
-                    git branch: 'master', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
+                    git branch: 'PXC-3364-Add-MTR-params', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
                     echo 'Checkout PXC57 sources'
                     sh '''
                         # sudo is needed for better node recovery after compilation failure
@@ -167,7 +183,7 @@ pipeline {
         stage('Test PXC57') {
                 agent { label 'docker-32gb' }
                 steps {
-                    git branch: 'master', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
+                    git branch: 'PXC-3364-Add-MTR-params', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
                     echo 'Test PXC57'
                     withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'c42456e5-c28d-4962-b32c-b75d161bff27', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
                         sh '''

--- a/pxc/jenkins/pxc57-pipeline.groovy
+++ b/pxc/jenkins/pxc57-pipeline.groovy
@@ -55,7 +55,7 @@ pipeline {
 			description: 'mtr can start n parallel server and distrbute workload among them. More parallelism is better but extra parallelism (beyond CPU power) will have less effect. This value is used for the Galera specific test suites.',
 			name: 'GALERA_PARALLEL_RUN')
 	    choice(
-	        choices: 'no\nyes',
+	        choices: 'yes\nno',
 	        description: 'Run mtr suites based on variable MTR_SUITES if the value is `no`. Otherwise the full mtr will be perfomed.',
 	        name: 'FULL_MTR')
 	    string(

--- a/pxc/jenkins/pxc57-pipeline.groovy
+++ b/pxc/jenkins/pxc57-pipeline.groovy
@@ -54,9 +54,9 @@ pipeline {
 			defaultValue: '4',
 			description: '(galera and galera_3nodes test suite) mtr can start n parallel server and distrbute workload among them. More parallelism is better but extra parallelism (beyond CPU power) will have less effect. This value is used for the galera and galera_3nodes test suite.',
 			name: 'GALERA_PARALLEL_RUN')
-	    string(
-	        defaultValue: '1',
-	        description: 'If empty, only galera and sys_vars suites will be run. Otherwise the full mtr will be perfomed.',
+	    choice(
+	        choices: 'no\nyes',
+	        description: 'Run mtr suites based on variable MTR_SUITES if the value is `no`. Otherwise the full mtr will be perfomed.',
 	        name: 'FULL_MTR')
 	    string(
 	        defaultValue: 'galera,galera_3nodes,sys_vars',

--- a/pxc/jenkins/pxc57-pipeline.yml
+++ b/pxc/jenkins/pxc57-pipeline.yml
@@ -49,12 +49,6 @@
         - "yes"
         - "no"
         description: Run mysql-test-run.pl
-    - choice:
-        name: HOTBACKUP_TESTING
-        choices:
-        - "yes"
-        - "no"
-        description: Run mysql-test-run.pl --suite tokudb_backup
     - string:
         name: PARALLEL_RUN
         default: "4"

--- a/pxc/jenkins/pxc57-pipeline.yml
+++ b/pxc/jenkins/pxc57-pipeline.yml
@@ -1,5 +1,5 @@
 - job:
-    name: pxc-5.7-pipeline
+    name: test-pxc-5.7-pipeline
     project-type: pipeline
     description: |
         Do not edit this job through the web!
@@ -9,7 +9,86 @@
         - git:
             url: https://github.com/Percona-Lab/jenkins-pipelines.git
             branches:
-            - 'master'
+            - 'PXC-3364-Add-MTR-params'
             wipe-workspace: false
       lightweight-checkout: true
       script-path: pxc/jenkins/pxc57-pipeline.groovy
+    parameters:
+    - string:
+        name: PXC57_REPO
+        default: "https://github.com/percona/percona-xtradb-cluster"
+        description: URL to PXC repository
+    - string:
+        name: PXC57_BRANCH
+        default: "5.7"
+        description: Tag/Branch for PXC repository
+    - string:
+        name: PXB24_REPO
+        default: https://github.com/percona/percona-xtrabackup
+        description: URL to PXB24 repository
+    - string:
+        name: PXB24_BRANCH
+        default: percona-xtrabackup-2.4.20
+        description: Tag/Branch for PXC repository
+    - choice:
+        name: JOB_CMAKE
+        choices:
+        - /usr/bin/cmake
+        description: path to cmake binary
+    - string:
+        name: CMAKE_OPTS
+        default:
+        description: cmake options
+    - string:
+        name: MAKE_OPTS
+        default:
+        description: make options, like VERBOSE=1
+    - choice:
+        name: DEFAULT_TESTING
+        choices:
+        - "yes"
+        - "no"
+        description: Run mysql-test-run.pl
+    - choice:
+        name: HOTBACKUP_TESTING
+        choices:
+        - "yes"
+        - "no"
+        description: Run mysql-test-run.pl --suite tokudb_backup
+    - string:
+        name: PARALLEL_RUN
+        default: "4"
+        description: "(sys_vars test suite) mtr can start n parallel server and distrbute workload among them. More parallelism is better but extra parallelism (beyond CPU power) will have less effect. This value is used for the sys_vars test suite."
+    - string:
+        name: GALERA_PARALLEL_RUN
+        default: "2"
+        description: "[galera and galera_3nodes test suite mtr can start n parallel server and distrbute workload among them. More parallelism is better but extra parallelism [beyond CPU power] will have less effect. This value is used for the galera and galera_3nodes test suite."
+    - string:
+        name: FULL_MTR
+        default: "1"
+        description: If empty, only galera and sys_vars suites will be run. Otherwise the full mtr will be perfomed.
+    - string:
+        name: MTR_SUITES
+        default: galera,galera_3nodes,galera_sr,galera_3nodes_sr,sys_vars
+        description: "mysql-test-run.pl suite names"
+    - string:
+        name: MTR_ARGS
+        default: --unit-tests-report --suite=galera,galera_3nodes,sys_vars
+        description: "mysql-test-run.pl options, for options like: --big-test --only-big-test --nounit-tests --unit-tests-report"
+    - string:
+        name: MTR_REPEAT
+        default: "1"
+        description: Run each test N number of times, --repeat=N
+    axes:
+      - axis:
+         type: user-defined
+         name: CMAKE_BUILD_TYPE
+         values:
+          - RelWithDebInfo
+          - Debug
+      - axis:
+         type: user-defined
+         name: DOCKER_OS
+         values:
+          - centos:7
+          - ubuntu:bionic

--- a/pxc/jenkins/pxc57-pipeline.yml
+++ b/pxc/jenkins/pxc57-pipeline.yml
@@ -90,5 +90,5 @@
          type: user-defined
          name: DOCKER_OS
          values:
-          - centos:7
-          - ubuntu:bionic
+          - centos:8
+          - ubuntu:focal

--- a/pxc/jenkins/pxc57-pipeline.yml
+++ b/pxc/jenkins/pxc57-pipeline.yml
@@ -60,8 +60,8 @@
     - choice:
         name: FULL_MTR
         choices:
-        - "no"
         - "yes"
+        - "no"
         description: Run mtr suites based on variable MTR_SUITES if the value is `no`. Otherwise the full mtr will be perfomed.
     - string:
         name: MTR_SUITES

--- a/pxc/jenkins/pxc57-pipeline.yml
+++ b/pxc/jenkins/pxc57-pipeline.yml
@@ -1,5 +1,5 @@
 - job:
-    name: test-pxc-5.7-pipeline
+    name: pxc-5.7-pipeline
     project-type: pipeline
     description: |
         Do not edit this job through the web!
@@ -9,7 +9,7 @@
         - git:
             url: https://github.com/Percona-Lab/jenkins-pipelines.git
             branches:
-            - 'PXC-3364-Add-MTR-params'
+            - 'master'
             wipe-workspace: false
       lightweight-checkout: true
       script-path: pxc/jenkins/pxc57-pipeline.groovy
@@ -86,5 +86,11 @@
          type: user-defined
          name: DOCKER_OS
          values:
+          - centos:6
+          - centos:7
           - centos:8
+          - ubuntu:xenial
+          - ubuntu:bionic
           - ubuntu:focal
+          - debian:stretch
+          - debian:buster

--- a/pxc/jenkins/pxc57-pipeline.yml
+++ b/pxc/jenkins/pxc57-pipeline.yml
@@ -52,11 +52,11 @@
     - string:
         name: PARALLEL_RUN
         default: "4"
-        description: "(sys_vars test suite) mtr can start n parallel server and distrbute workload among them. More parallelism is better but extra parallelism (beyond CPU power) will have less effect. This value is used for the sys_vars test suite."
+        description: "mtr can start n parallel server and distrbute workload among them. More parallelism is better but extra parallelism (beyond CPU power) will have less effect. This value is used for all test suites except Galera specific suites."
     - string:
         name: GALERA_PARALLEL_RUN
         default: "2"
-        description: "(galera and galera_3nodes test suite) mtr can start n parallel server and distrbute workload among them. More parallelism is better but extra parallelism (beyond CPU power) will have less effect. This value is used for the galera and galera_3nodes test suite."
+        description: "mtr can start n parallel server and distrbute workload among them. More parallelism is better but extra parallelism (beyond CPU power) will have less effect. This value is used for the Galera specific test suites."
     - choice:
         name: FULL_MTR
         choices:

--- a/pxc/jenkins/pxc57-pipeline.yml
+++ b/pxc/jenkins/pxc57-pipeline.yml
@@ -69,11 +69,11 @@
         description: If empty, only galera and sys_vars suites will be run. Otherwise the full mtr will be perfomed.
     - string:
         name: MTR_SUITES
-        default: galera,galera_3nodes,galera_sr,galera_3nodes_sr,sys_vars
+        default: galera,galera_3nodes,sys_vars
         description: "mysql-test-run.pl suite names"
     - string:
         name: MTR_ARGS
-        default: --unit-tests-report --suite=galera,galera_3nodes,sys_vars
+        default: --unit-tests-report
         description: "mysql-test-run.pl options, for options like: --big-test --only-big-test --nounit-tests --unit-tests-report"
     - string:
         name: MTR_REPEAT

--- a/pxc/jenkins/pxc57-pipeline.yml
+++ b/pxc/jenkins/pxc57-pipeline.yml
@@ -62,11 +62,13 @@
     - string:
         name: GALERA_PARALLEL_RUN
         default: "2"
-        description: "[galera and galera_3nodes test suite mtr can start n parallel server and distrbute workload among them. More parallelism is better but extra parallelism [beyond CPU power] will have less effect. This value is used for the galera and galera_3nodes test suite."
-    - string:
+        description: "(galera and galera_3nodes test suite) mtr can start n parallel server and distrbute workload among them. More parallelism is better but extra parallelism (beyond CPU power) will have less effect. This value is used for the galera and galera_3nodes test suite."
+    - choice:
         name: FULL_MTR
-        default: "1"
-        description: If empty, only galera and sys_vars suites will be run. Otherwise the full mtr will be perfomed.
+        choices:
+        - "no"
+        - "yes"
+        description: Run mtr suites based on variable MTR_SUITES if the value is `no`. Otherwise the full mtr will be perfomed.
     - string:
         name: MTR_SUITES
         default: galera,galera_3nodes,sys_vars

--- a/pxc/jenkins/pxc80-pipeline.groovy
+++ b/pxc/jenkins/pxc80-pipeline.groovy
@@ -58,11 +58,11 @@ pipeline {
             name: 'DEFAULT_TESTING')
         string(
             defaultValue: '4',
-            description: '(sys_vars test suite) mtr can start n parallel server and distrbute workload among them. More parallelism is better but extra parallelism (beyond CPU power) will have less effect. This value is used for the sys_vars test suite.',
+            description: 'mtr can start n parallel server and distrbute workload among them. More parallelism is better but extra parallelism (beyond CPU power) will have less effect. This value is used for all test suites except Galera specific suites.',
             name: 'PARALLEL_RUN')
         string(
-        	defaultValue: '4',
-        	description: '(galera and galera_3nodes test suite) mtr can start n parallel server and distrbute workload among them. More parallelism is better but extra parallelism (beyond CPU power) will have less effect. This value is used for the galera and galera_3nodes test suite.',
+        	defaultValue: '2',
+        	description: 'mtr can start n parallel server and distrbute workload among them. More parallelism is better but extra parallelism (beyond CPU power) will have less effect. This value is used for the Galera specific test suites.',
         	name: 'GALERA_PARALLEL_RUN')
         choice(
             choices: 'no\nyes',

--- a/pxc/jenkins/pxc80-pipeline.groovy
+++ b/pxc/jenkins/pxc80-pipeline.groovy
@@ -18,7 +18,7 @@ pipeline {
             name: 'PXB80_REPO',
             trim: true)
         string(
-            defaultValue: 'percona-xtrabackup-8.0.11',
+            defaultValue: 'percona-xtrabackup-8.0.12',
             description: 'Tag/Branch for PXB80 repository',
             name: 'PXB80_BRANCH',
             trim: true)
@@ -33,7 +33,7 @@ pipeline {
             name: 'PXB24_BRANCH',
             trim: true)
         choice(
-            choices: 'centos:7\ncentos:8\nubuntu:xenial\nubuntu:bionic\nubuntu:focal\ndebian:stretch\ndebian:buster',
+            choices: 'centos:8\nubuntu:focal',
             description: 'OS version for compilation',
             name: 'DOCKER_OS')
         choice(
@@ -57,7 +57,23 @@ pipeline {
             description: 'Run mysql-test-run.pl',
             name: 'DEFAULT_TESTING')
         string(
-            defaultValue: '--unit-tests-report --suite=galera,galera_3nodes,galera_sr,galera_3nodes_sr,sys_vars',
+            defaultValue: '4',
+            description: '(sys_vars test suite) mtr can start n parallel server and distrbute workload among them. More parallelism is better but extra parallelism (beyond CPU power) will have less effect. This value is used for the sys_vars test suite.',
+            name: 'PARALLEL_RUN')
+        string(
+        	defaultValue: '4',
+        	description: '(galera and galera_3nodes test suite) mtr can start n parallel server and distrbute workload among them. More parallelism is better but extra parallelism (beyond CPU power) will have less effect. This value is used for the galera and galera_3nodes test suite.',
+        	name: 'GALERA_PARALLEL_RUN')
+        choice(
+            choices: 'no\nyes',
+            description: 'Run mtr suites based on variable MTR_SUITES if the value is `no`. Otherwise the full mtr will be perfomed.',
+            name: 'FULL_MTR')
+        string(
+            defaultValue: 'galera,galera_3nodes,galera_sr,galera_3nodes_sr,sys_vars',
+            description: 'mysql-test-run.pl suite names',
+            name: 'MTR_SUITES')
+        string(
+            defaultValue: '--unit-tests-report',
             description: 'mysql-test-run.pl options, for options like: --big-test --only-big-test --nounit-tests --unit-tests-report',
             name: 'MTR_ARGS')
         string(
@@ -104,7 +120,7 @@ pipeline {
                 stage('Build PXB24') {
                     agent { label 'docker' }
                     steps {
-                        git branch: 'master', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
+                        git branch: 'PXC-3364-Add-MTR-params', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
                         echo 'Checkout PXB24 sources'
                         sh '''
                             # sudo is needed for better node recovery after compilation failure
@@ -139,7 +155,7 @@ pipeline {
                 stage('Build PXB80') {
                     agent { label 'docker-32gb' }
                     steps {
-                        git branch: 'master', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
+                        git branch: 'PXC-3364-Add-MTR-params', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
                         echo 'Checkout PXB80 sources'
                         sh '''
                             # sudo is needed for better node recovery after compilation failure
@@ -176,7 +192,7 @@ pipeline {
         stage('Build PXC80') {
                 agent { label 'docker-32gb' }
                 steps {
-                    git branch: 'master', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
+                    git branch: 'PXC-3364-Add-MTR-params', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
                     echo 'Checkout PXC80 sources'
                     sh '''
                         # sudo is needed for better node recovery after compilation failure
@@ -220,7 +236,7 @@ pipeline {
         stage('Test PXC80') {
                 agent { label 'docker-32gb' }
                 steps {
-                    git branch: 'master', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
+                    git branch: 'PXC-3364-Add-MTR-params', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
                     echo 'Test PXC80'
                     withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'c42456e5-c28d-4962-b32c-b75d161bff27', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
                         sh '''

--- a/pxc/jenkins/pxc80-pipeline.groovy
+++ b/pxc/jenkins/pxc80-pipeline.groovy
@@ -33,7 +33,7 @@ pipeline {
             name: 'PXB24_BRANCH',
             trim: true)
         choice(
-            choices: 'centos:8\nubuntu:focal',
+            choices: 'centos:7\ncentos:8\nubuntu:xenial\nubuntu:bionic\nubuntu:focal\ndebian:stretch\ndebian:buster',
             description: 'OS version for compilation',
             name: 'DOCKER_OS')
         choice(
@@ -120,7 +120,7 @@ pipeline {
                 stage('Build PXB24') {
                     agent { label 'docker' }
                     steps {
-                        git branch: 'PXC-3364-Add-MTR-params', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
+                        git branch: 'master', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
                         echo 'Checkout PXB24 sources'
                         sh '''
                             # sudo is needed for better node recovery after compilation failure
@@ -155,7 +155,7 @@ pipeline {
                 stage('Build PXB80') {
                     agent { label 'docker-32gb' }
                     steps {
-                        git branch: 'PXC-3364-Add-MTR-params', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
+                        git branch: 'master', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
                         echo 'Checkout PXB80 sources'
                         sh '''
                             # sudo is needed for better node recovery after compilation failure
@@ -192,7 +192,7 @@ pipeline {
         stage('Build PXC80') {
                 agent { label 'docker-32gb' }
                 steps {
-                    git branch: 'PXC-3364-Add-MTR-params', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
+                    git branch: 'master', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
                     echo 'Checkout PXC80 sources'
                     sh '''
                         # sudo is needed for better node recovery after compilation failure
@@ -236,7 +236,7 @@ pipeline {
         stage('Test PXC80') {
                 agent { label 'docker-32gb' }
                 steps {
-                    git branch: 'PXC-3364-Add-MTR-params', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
+                    git branch: 'master', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
                     echo 'Test PXC80'
                     withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'c42456e5-c28d-4962-b32c-b75d161bff27', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
                         sh '''

--- a/pxc/jenkins/pxc80-pipeline.groovy
+++ b/pxc/jenkins/pxc80-pipeline.groovy
@@ -65,7 +65,7 @@ pipeline {
         	description: 'mtr can start n parallel server and distrbute workload among them. More parallelism is better but extra parallelism (beyond CPU power) will have less effect. This value is used for the Galera specific test suites.',
         	name: 'GALERA_PARALLEL_RUN')
         choice(
-            choices: 'no\nyes',
+            choices: 'yes\nno',
             description: 'Run mtr suites based on variable MTR_SUITES if the value is `no`. Otherwise the full mtr will be perfomed.',
             name: 'FULL_MTR')
         string(

--- a/pxc/jenkins/pxc80-pipeline.yml
+++ b/pxc/jenkins/pxc80-pipeline.yml
@@ -3,6 +3,7 @@
     project-type: pipeline
     description: |
         Do not edit this job through the web!
+    concurrent: true
     pipeline-scm:
       scm:
         - git:

--- a/pxc/jenkins/pxc80-pipeline.yml
+++ b/pxc/jenkins/pxc80-pipeline.yml
@@ -60,11 +60,11 @@
     - string:
         name: PARALLEL_RUN
         default: "4"
-        description: "(sys_vars test suite) mtr can start n parallel server and distrbute workload among them. More parallelism is better but extra parallelism (beyond CPU power) will have less effect. This value is used for the sys_vars test suite."
+        description: "mtr can start n parallel server and distrbute workload among them. More parallelism is better but extra parallelism (beyond CPU power) will have less effect. This value is used for all test suites except Galera specific suites."
     - string:
         name: GALERA_PARALLEL_RUN
         default: "2"
-        description: "(galera and galera_3nodes test suite) mtr can start n parallel server and distrbute workload among them. More parallelism is better but extra parallelism (beyond CPU power) will have less effect. This value is used for the galera and galera_3nodes test suite."
+        description: "mtr can start n parallel server and distrbute workload among them. More parallelism is better but extra parallelism (beyond CPU power) will have less effect. This value is used for the Galera specific test suites."
     - choice:
         name: FULL_MTR
         choices:

--- a/pxc/jenkins/pxc80-pipeline.yml
+++ b/pxc/jenkins/pxc80-pipeline.yml
@@ -1,5 +1,5 @@
 - job:
-    name: pxc-8.0-pipeline
+    name: test-pxc-8.0-pipeline
     project-type: pipeline
     description: |
         Do not edit this job through the web!
@@ -8,8 +8,90 @@
         - git:
             url: https://github.com/Percona-Lab/jenkins-pipelines.git
             branches:
-            - 'master'
+            - 'PXC-3364-Add-MTR-params'
             wipe-workspace: false
       lightweight-checkout: true
       script-path: pxc/jenkins/pxc80-pipeline.groovy
-
+    parameters:
+    - string:
+        name: GIT_REPO
+        default: "https://github.com/percona/percona-xtradb-cluster"
+        description: URL to PXC repository
+    - string:
+        name: BRANCH
+        default: "8.0"
+        description: Tag/Branch for PXC repository
+    - string:
+        name: PXB80_REPO
+        default: https://github.com/percona/percona-xtrabackup
+        description: URL to PXB80 repository
+    - string:
+        name: PXB80_BRANCH
+        default: percona-xtrabackup-8.0.12
+        description: Tag/Branch for PXB80 repository
+    - string:
+        name: PXB24_REPO
+        default: https://github.com/percona/percona-xtrabackup
+        description: URL to PXB24 repository
+    - string:
+        name: PXB24_BRANCH
+        default: percona-xtrabackup-2.4.20
+        description: Tag/Branch for PXC repository
+    - choice:
+        name: JOB_CMAKE
+        choices:
+        - /usr/bin/cmake
+        description: path to cmake binary
+    - string:
+        name: CMAKE_OPTS
+        default:
+        description: cmake options
+    - string:
+        name: MAKE_OPTS
+        default:
+        description: make options, like VERBOSE=1
+    - choice:
+        name: DEFAULT_TESTING
+        choices:
+        - "yes"
+        - "no"
+        description: Run mysql-test-run.pl
+    - string:
+        name: PARALLEL_RUN
+        default: "4"
+        description: "(sys_vars test suite) mtr can start n parallel server and distrbute workload among them. More parallelism is better but extra parallelism (beyond CPU power) will have less effect. This value is used for the sys_vars test suite."
+    - string:
+        name: GALERA_PARALLEL_RUN
+        default: "2"
+        description: "(galera and galera_3nodes test suite) mtr can start n parallel server and distrbute workload among them. More parallelism is better but extra parallelism (beyond CPU power) will have less effect. This value is used for the galera and galera_3nodes test suite."
+    - choice:
+        name: FULL_MTR
+        choices:
+        - "no"
+        - "yes"
+        description: Run mtr suites based on variable MTR_SUITES if the value is `no`. Otherwise the full mtr will be perfomed.
+    - string:
+        name: MTR_SUITES
+        default: galera,galera_3nodes,galera_sr,galera_3nodes_sr,sys_vars
+        description: "mysql-test-run.pl suite names"
+    - string:
+        name: MTR_ARGS
+        default: --unit-tests-report
+        description: "mysql-test-run.pl options, for options like: --big-test --only-big-test --nounit-tests --unit-tests-report"
+    - string:
+        name: MTR_REPEAT
+        default: "1"
+        description: Run each test N number of times, --repeat=N
+    axes:
+      - axis:
+         type: user-defined
+         name: CMAKE_BUILD_TYPE
+         values:
+          - RelWithDebInfo
+          - Debug
+      - axis:
+         type: user-defined
+         name: DOCKER_OS
+         values:
+          - centos:8
+          - ubuntu:focal

--- a/pxc/jenkins/pxc80-pipeline.yml
+++ b/pxc/jenkins/pxc80-pipeline.yml
@@ -68,8 +68,8 @@
     - choice:
         name: FULL_MTR
         choices:
-        - "no"
         - "yes"
+        - "no"
         description: Run mtr suites based on variable MTR_SUITES if the value is `no`. Otherwise the full mtr will be perfomed.
     - string:
         name: MTR_SUITES

--- a/pxc/jenkins/pxc80-pipeline.yml
+++ b/pxc/jenkins/pxc80-pipeline.yml
@@ -1,5 +1,5 @@
 - job:
-    name: test-pxc-8.0-pipeline
+    name: pxc-8.0-pipeline
     project-type: pipeline
     description: |
         Do not edit this job through the web!
@@ -9,7 +9,7 @@
         - git:
             url: https://github.com/Percona-Lab/jenkins-pipelines.git
             branches:
-            - 'PXC-3364-Add-MTR-params'
+            - 'master'
             wipe-workspace: false
       lightweight-checkout: true
       script-path: pxc/jenkins/pxc80-pipeline.groovy
@@ -94,5 +94,10 @@
          type: user-defined
          name: DOCKER_OS
          values:
+          - centos:7
           - centos:8
+          - ubuntu:xenial
+          - ubuntu:bionic
           - ubuntu:focal
+          - debian:stretch
+          - debian:buster

--- a/pxc/local/test-binary-pxc
+++ b/pxc/local/test-binary-pxc
@@ -65,129 +65,50 @@ if [[ "${DEFAULT_TESTING}" != "no" ]]; then
     else
         MYSQLD_ENV="${ADD_TO_LD_PRELOAD:-}${JEMALLOC}:${EATMYDATA}"
     fi
+    mkdir mtr_var
     if [ ${FULL_MTR} == "no" ]; then
-        # galera suite
-        if echo "$MTR_SUITES" | grep -Ewq "galera"; then
-           mkdir var1
-           MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
-              --result-file --suite=galera \
-              ${MTR_ARGS} \
-              --force --xml-report=${WORKDIR_ABS}/galera_mtr.xml \
-              --max-test-fail=0 \
-              --suite-timeout=9999 --parallel $GALERA_PARALLEL_RUN \
-              --port-group-size=20 --vardir=var1 \
-              --testcase-timeout=${TESTCASE_TIMEOUT} \
-              | tee ${WORKDIR_ABS}/galera_mtr.output || status=$?
-    
-            killall -9 mysqld || true
-		    sed -i '1d' ${WORKDIR_ABS}/galera_mtr.xml
-		    sed -i '/<!\[CDATA/,/]]>/d' ${WORKDIR_ABS}/galera_mtr.xml
-		    sed -r 's/comment=.*.\/>/\/>/' ${WORKDIR_ABS}/galera_mtr.xml > ${WORKDIR_ABS}/galera_mtr.tmp
-		    sed -r 's/status=\"skipped\".*.\/>/ > <skipped \/> <\/testcase>/' ${WORKDIR_ABS}/galera_mtr.tmp >  ${WORKDIR_ABS}/galera_mtr1.tmp
-		    sed -r 's/status=\"disabled\".*.\/>/ > <disabled \/> <\/testcase>/' ${WORKDIR_ABS}/galera_mtr1.tmp >  ${WORKDIR_ABS}/galera_junit.xml
-		    rm -f ${WORKDIR_ABS}/galera_mtr*.tmp ${WORKDIR_ABS}/galera_mtr.xml
-        fi
-    
-        # galera_3nodes suite
-        if echo "$MTR_SUITES" | grep -Ewq "galera_3nodes"; then
-           mkdir var2
-           MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
-              --result-file --suite=galera_3nodes \
-              ${MTR_ARGS} \
-              --force --xml-report=${WORKDIR_ABS}/galera3_mtr.xml \
-              --max-test-fail=0 \
-              --suite-timeout=9999 --parallel $GALERA_PARALLEL_RUN \
-              --port-group-size=20 --vardir=var2 \
-              --testcase-timeout=${TESTCASE_TIMEOUT} \
-              | tee ${WORKDIR_ABS}/galera3_mtr.output || status=$?
-    
-            killall -9 mysqld || true
-		    sed -i '1d' ${WORKDIR_ABS}/galera3_mtr.xml
-		    sed -i '/<!\[CDATA/,/]]>/d' ${WORKDIR_ABS}/galera3_mtr.xml
-		    sed -r 's/comment=.*.\/>/\/>/' ${WORKDIR_ABS}/galera3_mtr.xml > ${WORKDIR_ABS}/galera3_mtr.tmp
-		    sed -r 's/status=\"skipped\".*.\/>/ > <skipped \/> <\/testcase>/' ${WORKDIR_ABS}/galera3_mtr.tmp >  ${WORKDIR_ABS}/galera3_mtr1.tmp
-		    sed -r 's/status=\"disabled\".*.\/>/ > <disabled \/> <\/testcase>/' ${WORKDIR_ABS}/galera3_mtr1.tmp >  ${WORKDIR_ABS}/galera3_junit.xml
-		    rm -f ${WORKDIR_ABS}/galera3_mtr*.tmp ${WORKDIR_ABS}/galera3_mtr.xml
-        fi
+        ARRAY_MTR_SUITES=($(echo $MTR_SUITES | sed 's/,/ /g'))
+        for suite in "${ARRAY_MTR_SUITES[@]}"; do
+	        if [[ "$suite" == *"galera"* ]]; then
+	            WORKER=$GALERA_PARALLEL_RUN
+			else
+	            WORKER=$PARALLEL_RUN
+			fi
+	        echo "Running MTR suite: $suite"
+	        mkdir $PWD/var_${suite}
 
-        # galera_sr suite
-        if echo "$MTR_SUITES" | grep -Ewq "galera_sr"; then
-           mkdir var3
-           MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
-              --result-file --suite=galera_sr \
-              ${MTR_ARGS} \
-              --force --xml-report=${WORKDIR_ABS}/galera_sr_mtr.xml \
-              --max-test-fail=0 \
-              --suite-timeout=9999 --parallel $GALERA_PARALLEL_RUN \
-              --port-group-size=20 --vardir=var3 \
-              --testcase-timeout=${TESTCASE_TIMEOUT} \
-              | tee ${WORKDIR_ABS}/galera_sr_mtr.output || status=$?
-    
-            killall -9 mysqld || true
-		    sed -i '1d' ${WORKDIR_ABS}/galera_sr_mtr.xml
-		    sed -i '/<!\[CDATA/,/]]>/d' ${WORKDIR_ABS}/galera_sr_mtr.xml
-		    sed -r 's/comment=.*.\/>/\/>/' ${WORKDIR_ABS}/galera_sr_mtr.xml > ${WORKDIR_ABS}/galera_sr_mtr.tmp
-		    sed -r 's/status=\"skipped\".*.\/>/ > <skipped \/> <\/testcase>/' ${WORKDIR_ABS}/galera_sr_mtr.tmp >  ${WORKDIR_ABS}/galera_sr_mtr1.tmp
-		    sed -r 's/status=\"disabled\".*.\/>/ > <disabled \/> <\/testcase>/' ${WORKDIR_ABS}/galera_sr_mtr1.tmp >  ${WORKDIR_ABS}/galera_sr_junit.xml
-		    rm -f ${WORKDIR_ABS}/galera_sr_mtr*.tmp ${WORKDIR_ABS}/galera_sr_mtr.xml
-        fi
-		
-        # galera_3nodes_sr suite
-        if echo "$MTR_SUITES" | grep -Ewq "galera_3nodes_sr"; then
-           mkdir var4
-           MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
-              --result-file --suite=galera_3nodes_sr \
-              ${MTR_ARGS} \
-              --force --xml-report=${WORKDIR_ABS}/galera3_sr_mtr.xml \
-              --max-test-fail=0 \
-              --suite-timeout=9999 --parallel $GALERA_PARALLEL_RUN \
-              --port-group-size=20 --vardir=var4 \
-              --testcase-timeout=${TESTCASE_TIMEOUT} \
-              | tee ${WORKDIR_ABS}/galera3_sr_mtr.output || status=$?
-    
-            killall -9 mysqld || true
-		    sed -i '1d' ${WORKDIR_ABS}/galera3_sr_mtr.xml
-		    sed -i '/<!\[CDATA/,/]]>/d' ${WORKDIR_ABS}/galera3_sr_mtr.xml
-		    sed -r 's/comment=.*.\/>/\/>/' ${WORKDIR_ABS}/galera3_sr_mtr.xml > ${WORKDIR_ABS}/galera3_sr_mtr.tmp
-		    sed -r 's/status=\"skipped\".*.\/>/ > <skipped \/> <\/testcase>/' ${WORKDIR_ABS}/galera3_sr_mtr.tmp >  ${WORKDIR_ABS}/galera3_sr_mtr1.tmp
-		    sed -r 's/status=\"disabled\".*.\/>/ > <disabled \/> <\/testcase>/' ${WORKDIR_ABS}/galera3_sr_mtr1.tmp >  ${WORKDIR_ABS}/galera3_sr_junit.xml
-		    rm -f ${WORKDIR_ABS}/galera3_sr_mtr*.tmp ${WORKDIR_ABS}/galera3_sr_mtr.xml
-        fi
-		
-        # sys_vars suite
-        if echo "$MTR_SUITES" | grep -Ewq "sys_vars"; then
-           mkdir var5
-           MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
-              --result-file --suite=sys_vars \
-              ${MTR_ARGS} \
-              --force --xml-report=${WORKDIR_ABS}/sys_vars.xml \
-              --max-test-fail=0 \
-              --suite-timeout=9999 --parallel $PARALLEL_RUN \
-              --port-group-size=20 --vardir=var5 \
-              --testcase-timeout=${TESTCASE_TIMEOUT} \
-              | tee ${WORKDIR_ABS}/sys_vars.output || status=$?
-    		  
-            killall -9 mysqld || true
-		    sed -i '1d' ${WORKDIR_ABS}/sys_vars.xml
-		    sed -i '/<!\[CDATA/,/]]>/d' ${WORKDIR_ABS}/sys_vars.xml
-		    sed -r 's/comment=.*.\/>/\/>/' ${WORKDIR_ABS}/sys_vars.xml > ${WORKDIR_ABS}/sys_vars.tmp
-		    sed -r 's/status=\"skipped\".*.\/>/ > <skipped \/> <\/testcase>/' ${WORKDIR_ABS}/sys_vars.tmp >  ${WORKDIR_ABS}/sys_vars1.tmp
-		    sed -r 's/status=\"disabled\".*.\/>/ > <disabled \/> <\/testcase>/' ${WORKDIR_ABS}/sys_vars1.tmp >  ${WORKDIR_ABS}/sys_vars_junit.xml
-		    rm -f ${WORKDIR_ABS}/sys_vars*.tmp ${WORKDIR_ABS}/sys_vars.xml
-        fi
+	        MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
+	           --result-file --suite=$suite \
+	           --force --xml-report=${WORKDIR_ABS}/${suite}_mtr.xml \
+	           --max-test-fail=0 \
+	           --suite-timeout=9999 --parallel $WORKER \
+	           --port-group-size=20 --vardir=$PWD/var_${suite} \
+	           --testcase-timeout=${TESTCASE_TIMEOUT} \
+               ${MTR_ARGS} \
+	           | tee ${WORKDIR_ABS}/${suite}_mtr.output || status=$?
+            mv $PWD/var_${suite} $PWD/mtr_var
+	        killall -9 mysqld || true
+		    sed -i '1d' ${WORKDIR_ABS}/${suite}_mtr.xml
+		    sed -i '/<!\[CDATA/,/]]>/d' ${WORKDIR_ABS}/${suite}_mtr.xml
+		    sed -r 's/comment=.*.\/>/\/>/' ${WORKDIR_ABS}/${suite}_mtr.xml > ${WORKDIR_ABS}/${suite}_junit.tmp
+		    sed -r 's/status=\"skipped\".*.\/>/ > <skipped \/> <\/testcase>/' ${WORKDIR_ABS}/${suite}_junit.tmp >  ${WORKDIR_ABS}/${suite}_junit1.tmp
+		    sed -r 's/status=\"disabled\".*.\/>/ > <disabled \/> <\/testcase>/' ${WORKDIR_ABS}/${suite}_junit1.tmp >  ${WORKDIR_ABS}/${suite}_junit.xml
+		    rm -f ${WORKDIR_ABS}/${suite}_junit*.tmp ${WORKDIR_ABS}/${suite}_mtr.xml
+		done
     else
         echo "Running full MTR"
-        mkdir var1
+		mkdir var
+
         MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
            --result-file \
-           ${MTR_ARGS} \
            --force --xml-report=${WORKDIR_ABS}/mtr.xml \
            --max-test-fail=0 \
            --suite-timeout=9999 --parallel $PARALLEL_RUN \
-           --port-group-size=20 --vardir=var1 \
+           --port-group-size=20 --vardir=var \
            --testcase-timeout=${TESTCASE_TIMEOUT} \
+           ${MTR_ARGS} \
            | tee ${WORKDIR_ABS}/mtr.output || status=$?
-    
+        mv $PWD/var $PWD/mtr_var
         killall -9 mysqld || true
 	    sed -i '1d' ${WORKDIR_ABS}/mtr.xml
 	    sed -i '/<!\[CDATA/,/]]>/d' ${WORKDIR_ABS}/mtr.xml

--- a/pxc/local/test-binary-pxc
+++ b/pxc/local/test-binary-pxc
@@ -146,7 +146,7 @@ if [[ "${DEFAULT_TESTING}" != "no" ]]; then
 
         # galera_sr suite
         if echo "$MTR_SUITES" | grep -Eq "galera_sr[ ,]"; then
-           mkdir var1
+           mkdir var3
            MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
               --result-file --suite=galera_sr \
               ${MTR_ARGS} \
@@ -168,7 +168,7 @@ if [[ "${DEFAULT_TESTING}" != "no" ]]; then
 		
         # galera_3nodes_sr suite
         if echo "$MTR_SUITES" | grep -Eq "galera_3nodes_sr[ ,]"; then
-           mkdir var2
+           mkdir var4
            MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
               --result-file --suite=galera_3nodes_sr \
               ${MTR_ARGS} \
@@ -190,7 +190,7 @@ if [[ "${DEFAULT_TESTING}" != "no" ]]; then
 		
         # sys_vars suite
         if echo "$MTR_SUITES" | grep -Eq "sys_vars"; then
-           mkdir var3
+           mkdir var5
            MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
               --result-file --suite=sys_vars \
               ${MTR_ARGS} \

--- a/pxc/local/test-binary-pxc
+++ b/pxc/local/test-binary-pxc
@@ -7,6 +7,10 @@
 #      DEFAULT_TESTING = (yes no)
 #      MTR_ARGS
 #      MTR_REPEAT
+#      FULL_MTR = (yes no)
+#      GALERA_PARALLEL_RUN
+#      MTR_SUITES
+#      PARALLEL_RUN
 
 set -o errexit
 set -o xtrace
@@ -19,7 +23,6 @@ tar -C ${WORKDIR_ABS}/PXC --strip-components=1 -zxpf $(ls $WORKDIR_ABS/*.tar.gz 
 export WSREP_PROVIDER=${WORKDIR_ABS}/PXC/lib/libgalera_smm.so
 cd ${WORKDIR_ABS}/PXC/mysql-test
 TESTCASE_TIMEOUT=30
-PARALLEL=$(grep -c ^processor /proc/cpuinfo)
 # CentOS 6 & 7
 if [[ -f /opt/rh/devtoolset-7/enable ]]; then
     source /opt/rh/devtoolset-7/enable
@@ -96,17 +99,93 @@ if [[ "${DEFAULT_TESTING}" != "no" ]]; then
     else
         MYSQLD_ENV="${ADD_TO_LD_PRELOAD:-}${JEMALLOC}:${EATMYDATA}"
     fi
-
-  MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
-        --parallel=${PARALLEL} \
-        --result-file \
-        ${MTR_ARGS} \
-        --force \
-        --max-test-fail=0 \
-        --suite-timeout=9999 \
-        --testcase-timeout=${TESTCASE_TIMEOUT} \
-        | tee ${WORKDIR_ABS}/mtr.output || status=$?
-    process_mtr_output PXC "${WORKDIR_ABS}/mtr.output" "${WORKDIR_ABS}/junit.xml"
+    if [ ${FULL_MTR} == "no" ]; then
+        # galera suite
+        if echo "$MTR_SUITES" | grep -Eq "galera[ ,]"; then
+           mkdir var1
+           MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
+              --result-file --suite=galera \
+              ${MTR_ARGS} \
+              --force --xml-report=${WORKDIR_ABS}/galera_mtr.xml \
+              --max-test-fail=0 \
+              --suite-timeout=9999 --parallel $GALERA_PARALLEL_RUN \
+              --port-group-size=20 --vardir=var1 \
+              --testcase-timeout=${TESTCASE_TIMEOUT} \
+              | tee ${WORKDIR_ABS}/galera_mtr.output || status=$?
+    
+            killall -9 mysqld || true
+		    sed -i '1d' ${WORKDIR_ABS}/galera_mtr.xml
+		    sed -i '/<!\[CDATA/,/]]>/d' ${WORKDIR_ABS}/galera_mtr.xml
+		    sed -r 's/comment=.*.\/>/\/>/' ${WORKDIR_ABS}/galera_mtr.xml > ${WORKDIR_ABS}/galera_mtr.tmp
+		    sed -r 's/status=\"skipped\".*.\/>/ > <skipped \/> <\/testcase>/' ${WORKDIR_ABS}/galera_mtr.tmp >  ${WORKDIR_ABS}/galera_mtr1.tmp
+		    sed -r 's/status=\"disabled\".*.\/>/ > <disabled \/> <\/testcase>/' ${WORKDIR_ABS}/galera_mtr1.tmp >  ${WORKDIR_ABS}/galera_junit.xml
+		    rm -f ${WORKDIR_ABS}/galera_mtr*.tmp ${WORKDIR_ABS}/galera_mtr.xml
+        fi
+    
+        # galera_3nodes suite
+        if echo "$MTR_SUITES" | grep -Eq "galera_3nodes"; then
+           mkdir var2
+           MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
+              --result-file --suite=galera_3nodes \
+              ${MTR_ARGS} \
+              --force --xml-report=${WORKDIR_ABS}/galera3_mtr.xml \
+              --max-test-fail=0 \
+              --suite-timeout=9999 --parallel $GALERA_PARALLEL_RUN \
+              --port-group-size=20 --vardir=var2 \
+              --testcase-timeout=${TESTCASE_TIMEOUT} \
+              | tee ${WORKDIR_ABS}/galera3_mtr.output || status=$?
+    
+            killall -9 mysqld || true
+		    sed -i '1d' ${WORKDIR_ABS}/galera3_mtr.xml
+		    sed -i '/<!\[CDATA/,/]]>/d' ${WORKDIR_ABS}/galera3_mtr.xml
+		    sed -r 's/comment=.*.\/>/\/>/' ${WORKDIR_ABS}/galera3_mtr.xml > ${WORKDIR_ABS}/galera3_mtr.tmp
+		    sed -r 's/status=\"skipped\".*.\/>/ > <skipped \/> <\/testcase>/' ${WORKDIR_ABS}/galera3_mtr.tmp >  ${WORKDIR_ABS}/galera3_mtr1.tmp
+		    sed -r 's/status=\"disabled\".*.\/>/ > <disabled \/> <\/testcase>/' ${WORKDIR_ABS}/galera3_mtr1.tmp >  ${WORKDIR_ABS}/galera3_junit.xml
+		    rm -f ${WORKDIR_ABS}/galera3_mtr*.tmp ${WORKDIR_ABS}/galera3_mtr.xml
+        fi
+    
+        # sys_vars suite
+        if echo "$MTR_SUITES" | grep -Eq "sys_vars"; then
+           mkdir var3
+           MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
+              --result-file --suite=sys_vars \
+              ${MTR_ARGS} \
+              --force --xml-report=${WORKDIR_ABS}/sys_vars.xml \
+              --max-test-fail=0 \
+              --suite-timeout=9999 --parallel $PARALLEL_RUN \
+              --port-group-size=20 --vardir=var3 \
+              --testcase-timeout=${TESTCASE_TIMEOUT} \
+              | tee ${WORKDIR_ABS}/sys_vars.output || status=$?
+    		  
+            killall -9 mysqld || true
+		    sed -i '1d' ${WORKDIR_ABS}/sys_vars.xml
+		    sed -i '/<!\[CDATA/,/]]>/d' ${WORKDIR_ABS}/sys_vars.xml
+		    sed -r 's/comment=.*.\/>/\/>/' ${WORKDIR_ABS}/sys_vars.xml > ${WORKDIR_ABS}/sys_vars.tmp
+		    sed -r 's/status=\"skipped\".*.\/>/ > <skipped \/> <\/testcase>/' ${WORKDIR_ABS}/sys_vars.tmp >  ${WORKDIR_ABS}/sys_vars1.tmp
+		    sed -r 's/status=\"disabled\".*.\/>/ > <disabled \/> <\/testcase>/' ${WORKDIR_ABS}/sys_vars1.tmp >  ${WORKDIR_ABS}/sys_vars_junit.xml
+		    rm -f ${WORKDIR_ABS}/sys_vars*.tmp ${WORKDIR_ABS}/sys_vars.xml
+        fi
+    else
+        echo "Running full MTR"
+        mkdir var1
+        MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
+           --result-file \
+           ${MTR_ARGS} \
+           --force --xml-report=${WORKDIR_ABS}/mtr.xml \
+           --max-test-fail=0 \
+           --suite-timeout=9999 --parallel $GALERA_PARALLEL_RUN \
+           --port-group-size=20 --vardir=var1 \
+           --testcase-timeout=${TESTCASE_TIMEOUT} \
+           | tee ${WORKDIR_ABS}/mtr.output || status=$?
+    
+        killall -9 mysqld || true
+	    sed -i '1d' ${WORKDIR_ABS}/mtr.xml
+	    sed -i '/<!\[CDATA/,/]]>/d' ${WORKDIR_ABS}/mtr.xml
+	    sed -r 's/comment=.*.\/>/\/>/' ${WORKDIR_ABS}/mtr.xml > ${WORKDIR_ABS}/junit.tmp
+	    sed -r 's/status=\"skipped\".*.\/>/ > <skipped \/> <\/testcase>/' ${WORKDIR_ABS}/junit.tmp >  ${WORKDIR_ABS}/junit1.tmp
+	    sed -r 's/status=\"disabled\".*.\/>/ > <disabled \/> <\/testcase>/' ${WORKDIR_ABS}/junit1.tmp >  ${WORKDIR_ABS}/junit.xml
+	    rm -f ${WORKDIR_ABS}/junit*.tmp ${WORKDIR_ABS}/mtr.xml
+    fi
 fi
 
 exit $status

--- a/pxc/local/test-binary-pxc
+++ b/pxc/local/test-binary-pxc
@@ -183,7 +183,7 @@ if [[ "${DEFAULT_TESTING}" != "no" ]]; then
            ${MTR_ARGS} \
            --force --xml-report=${WORKDIR_ABS}/mtr.xml \
            --max-test-fail=0 \
-           --suite-timeout=9999 --parallel $GALERA_PARALLEL_RUN \
+           --suite-timeout=9999 --parallel $PARALLEL_RUN \
            --port-group-size=20 --vardir=var1 \
            --testcase-timeout=${TESTCASE_TIMEOUT} \
            | tee ${WORKDIR_ABS}/mtr.output || status=$?

--- a/pxc/local/test-binary-pxc
+++ b/pxc/local/test-binary-pxc
@@ -42,40 +42,6 @@ if [[ -z "${JEMALLOC}" ]]; then
 fi
 MTR_ARGS+="  --big-test "
 
-function process_mtr_output {
-# parameters are:
-  local TESTSUITE=${1}
-  local INFILE=${2}
-  local OUTFILE=${3}
-
-  export LC_ALL=C
-  # `grep` will be printing each MTR testcase through matching result status from the MTR output log and `awk` will segregate unique testcases based on success/failure using the result status and store it in XML file
-  egrep -a -o '[[:alpha:]]+(_[[:alnum:]]+)?(\.\/)?.*\[ .* \].*$' ${INFILE} \
-    | awk '{ if ($3 == "disabled" || $3 == "skipped") { print $1 " " $3 } else if (match($2, /^w[0-9]/)) { print $1 " " $4 " " $6 } else { print $1 "_" substr($2,2,length($2)-2) $5 " " $7 } }' \
-    | sort \
-    | awk 'prev && ($1 != prev) {print seen[prev]} {seen[$1] = $0; prev = $1} END {print seen[$1]}' \
-    | gawk 'BEGIN     { print "<testsuite name=\"@@TESTSUITE@@\" tests=\"@@PASSED@@\" failures=\"@@FAILURES@@\" disabled=\"@@DISABLED@@\" skipped=\"@@SKIPPED@@\">" }
-      $2 ~ /pass/     { printf "\t<testcase name=\"%s\" time=\"%.3f\"></testcase>\n", $1, $NF/1000.0 }
-      $2 ~ /disabled/ { printf "\t<testcase name=\"%s\"><skipped/></testcase>\n", $1 }
-      $2 ~ /skipped/   { printf "\t<testcase name=\"%s\"><skipped/></testcase>\n", $1 }
-      $2 ~ /fail/     { printf "\t<testcase name=\"%s\"><failure/></testcase>\n", $1 }
-      END { print "</testsuite>" }'  > ${OUTFILE}.tmp
-
-  gawk '!seen[$0]++' < ${OUTFILE}.tmp > ${OUTFILE}
-  rm -f ${OUTFILE}.tmp
-#
-  PASSED=$(grep -c 'time=' ${OUTFILE} ||:)
-  FAILURES=$(grep -c '<failure/>' ${OUTFILE} ||:)
-  DISABLED=$(grep -c '\[ disabled \]' ${INFILE} ||:)
-  SKIPPED=$(grep -c '\[ skipped \]' ${INFILE} ||:)
-#
-  sed -i.bak -e "s:@@TESTSUITE@@:${TESTSUITE}:g" ${OUTFILE}
-  sed -i.bak -e "s:@@PASSED@@:${PASSED}:g" ${OUTFILE}
-  sed -i.bak -e "s:@@FAILURES@@:${FAILURES}:g" ${OUTFILE}
-  sed -i.bak -e "s:@@DISABLED@@:${DISABLED}:g" ${OUTFILE}
-  sed -i.bak -e "s:@@SKIPPED@@:${SKIPPED}:g" ${OUTFILE}
-  sed -i.bak -e "s: \[::g" ${OUTFILE}
-}
 
 if [[ -n "${MTR_REPEAT}" ]]; then
   MTR_ARGS+=" --repeat=${MTR_REPEAT}"

--- a/pxc/local/test-binary-pxc
+++ b/pxc/local/test-binary-pxc
@@ -101,7 +101,7 @@ if [[ "${DEFAULT_TESTING}" != "no" ]]; then
     fi
     if [ ${FULL_MTR} == "no" ]; then
         # galera suite
-        if echo "$MTR_SUITES" | grep -Eq "galera[ ,]"; then
+        if echo "$MTR_SUITES" | grep -Ewq "galera"; then
            mkdir var1
            MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
               --result-file --suite=galera \
@@ -123,7 +123,7 @@ if [[ "${DEFAULT_TESTING}" != "no" ]]; then
         fi
     
         # galera_3nodes suite
-        if echo "$MTR_SUITES" | grep -Eq "galera_3nodes[ ,]"; then
+        if echo "$MTR_SUITES" | grep -Ewq "galera_3nodes"; then
            mkdir var2
            MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
               --result-file --suite=galera_3nodes \
@@ -145,7 +145,7 @@ if [[ "${DEFAULT_TESTING}" != "no" ]]; then
         fi
 
         # galera_sr suite
-        if echo "$MTR_SUITES" | grep -Eq "galera_sr[ ,]"; then
+        if echo "$MTR_SUITES" | grep -Ewq "galera_sr"; then
            mkdir var3
            MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
               --result-file --suite=galera_sr \
@@ -167,7 +167,7 @@ if [[ "${DEFAULT_TESTING}" != "no" ]]; then
         fi
 		
         # galera_3nodes_sr suite
-        if echo "$MTR_SUITES" | grep -Eq "galera_3nodes_sr[ ,]"; then
+        if echo "$MTR_SUITES" | grep -Ewq "galera_3nodes_sr"; then
            mkdir var4
            MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
               --result-file --suite=galera_3nodes_sr \
@@ -189,7 +189,7 @@ if [[ "${DEFAULT_TESTING}" != "no" ]]; then
         fi
 		
         # sys_vars suite
-        if echo "$MTR_SUITES" | grep -Eq "sys_vars"; then
+        if echo "$MTR_SUITES" | grep -Ewq "sys_vars"; then
            mkdir var5
            MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
               --result-file --suite=sys_vars \

--- a/pxc/local/test-binary-pxc
+++ b/pxc/local/test-binary-pxc
@@ -123,7 +123,7 @@ if [[ "${DEFAULT_TESTING}" != "no" ]]; then
         fi
     
         # galera_3nodes suite
-        if echo "$MTR_SUITES" | grep -Eq "galera_3nodes"; then
+        if echo "$MTR_SUITES" | grep -Eq "galera_3nodes[ ,]"; then
            mkdir var2
            MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
               --result-file --suite=galera_3nodes \
@@ -143,7 +143,51 @@ if [[ "${DEFAULT_TESTING}" != "no" ]]; then
 		    sed -r 's/status=\"disabled\".*.\/>/ > <disabled \/> <\/testcase>/' ${WORKDIR_ABS}/galera3_mtr1.tmp >  ${WORKDIR_ABS}/galera3_junit.xml
 		    rm -f ${WORKDIR_ABS}/galera3_mtr*.tmp ${WORKDIR_ABS}/galera3_mtr.xml
         fi
+
+        # galera_sr suite
+        if echo "$MTR_SUITES" | grep -Eq "galera_sr[ ,]"; then
+           mkdir var1
+           MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
+              --result-file --suite=galera_sr \
+              ${MTR_ARGS} \
+              --force --xml-report=${WORKDIR_ABS}/galera_sr_mtr.xml \
+              --max-test-fail=0 \
+              --suite-timeout=9999 --parallel $GALERA_PARALLEL_RUN \
+              --port-group-size=20 --vardir=var3 \
+              --testcase-timeout=${TESTCASE_TIMEOUT} \
+              | tee ${WORKDIR_ABS}/galera_sr_mtr.output || status=$?
     
+            killall -9 mysqld || true
+		    sed -i '1d' ${WORKDIR_ABS}/galera_sr_mtr.xml
+		    sed -i '/<!\[CDATA/,/]]>/d' ${WORKDIR_ABS}/galera_sr_mtr.xml
+		    sed -r 's/comment=.*.\/>/\/>/' ${WORKDIR_ABS}/galera_sr_mtr.xml > ${WORKDIR_ABS}/galera_sr_mtr.tmp
+		    sed -r 's/status=\"skipped\".*.\/>/ > <skipped \/> <\/testcase>/' ${WORKDIR_ABS}/galera_sr_mtr.tmp >  ${WORKDIR_ABS}/galera_sr_mtr1.tmp
+		    sed -r 's/status=\"disabled\".*.\/>/ > <disabled \/> <\/testcase>/' ${WORKDIR_ABS}/galera_sr_mtr1.tmp >  ${WORKDIR_ABS}/galera_sr_junit.xml
+		    rm -f ${WORKDIR_ABS}/galera_sr_mtr*.tmp ${WORKDIR_ABS}/galera_sr_mtr.xml
+        fi
+		
+        # galera_3nodes_sr suite
+        if echo "$MTR_SUITES" | grep -Eq "galera_3nodes_sr[ ,]"; then
+           mkdir var2
+           MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
+              --result-file --suite=galera_3nodes_sr \
+              ${MTR_ARGS} \
+              --force --xml-report=${WORKDIR_ABS}/galera3_sr_mtr.xml \
+              --max-test-fail=0 \
+              --suite-timeout=9999 --parallel $GALERA_PARALLEL_RUN \
+              --port-group-size=20 --vardir=var4 \
+              --testcase-timeout=${TESTCASE_TIMEOUT} \
+              | tee ${WORKDIR_ABS}/galera3_sr_mtr.output || status=$?
+    
+            killall -9 mysqld || true
+		    sed -i '1d' ${WORKDIR_ABS}/galera3_sr_mtr.xml
+		    sed -i '/<!\[CDATA/,/]]>/d' ${WORKDIR_ABS}/galera3_sr_mtr.xml
+		    sed -r 's/comment=.*.\/>/\/>/' ${WORKDIR_ABS}/galera3_sr_mtr.xml > ${WORKDIR_ABS}/galera3_sr_mtr.tmp
+		    sed -r 's/status=\"skipped\".*.\/>/ > <skipped \/> <\/testcase>/' ${WORKDIR_ABS}/galera3_sr_mtr.tmp >  ${WORKDIR_ABS}/galera3_sr_mtr1.tmp
+		    sed -r 's/status=\"disabled\".*.\/>/ > <disabled \/> <\/testcase>/' ${WORKDIR_ABS}/galera3_sr_mtr1.tmp >  ${WORKDIR_ABS}/galera3_sr_junit.xml
+		    rm -f ${WORKDIR_ABS}/galera3_sr_mtr*.tmp ${WORKDIR_ABS}/galera3_sr_mtr.xml
+        fi
+		
         # sys_vars suite
         if echo "$MTR_SUITES" | grep -Eq "sys_vars"; then
            mkdir var3
@@ -153,7 +197,7 @@ if [[ "${DEFAULT_TESTING}" != "no" ]]; then
               --force --xml-report=${WORKDIR_ABS}/sys_vars.xml \
               --max-test-fail=0 \
               --suite-timeout=9999 --parallel $PARALLEL_RUN \
-              --port-group-size=20 --vardir=var3 \
+              --port-group-size=20 --vardir=var5 \
               --testcase-timeout=${TESTCASE_TIMEOUT} \
               | tee ${WORKDIR_ABS}/sys_vars.output || status=$?
     		  

--- a/pxc/local/test-binary-pxc57
+++ b/pxc/local/test-binary-pxc57
@@ -72,7 +72,7 @@ if [[ "${DEFAULT_TESTING}" != "no" ]]; then
     fi
     if [ ${FULL_MTR} == "no" ]; then
         # galera suite
-        if echo "$MTR_SUITES" | grep -Eq "galera[ ,]"; then
+        if echo "$MTR_SUITES" | grep -Ewq "galera"; then
            mkdir var1
            MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
               --result-file --suite=galera \
@@ -94,7 +94,7 @@ if [[ "${DEFAULT_TESTING}" != "no" ]]; then
         fi
     
         # galera_3nodes suite
-        if echo "$MTR_SUITES" | grep -Eq "galera_3nodes"; then
+        if echo "$MTR_SUITES" | grep -Ewq "galera_3nodes"; then
            mkdir var2
            MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
               --result-file --suite=galera_3nodes \
@@ -116,7 +116,7 @@ if [[ "${DEFAULT_TESTING}" != "no" ]]; then
         fi
     
         # sys_vars suite
-        if echo "$MTR_SUITES" | grep -Eq "sys_vars"; then
+        if echo "$MTR_SUITES" | grep -Ewq "sys_vars"; then
            mkdir var3
            MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
               --result-file --suite=sys_vars \

--- a/pxc/local/test-binary-pxc57
+++ b/pxc/local/test-binary-pxc57
@@ -64,91 +64,55 @@ status=0
 #
 # Running MTR test cases
 if [[ "${DEFAULT_TESTING}" != "no" ]]; then
-
     if [[ "${ANALYZER_OPTS}" == *WITH_VALGRIND=ON* ]]; then
         MYSQLD_ENV="${ADD_TO_LD_PRELOAD:-}${EATMYDATA}"
     else
         MYSQLD_ENV="${ADD_TO_LD_PRELOAD:-}${JEMALLOC}:${EATMYDATA}"
     fi
+    mkdir mtr_var
     if [ ${FULL_MTR} == "no" ]; then
-        # galera suite
-        if echo "$MTR_SUITES" | grep -Ewq "galera"; then
-           mkdir var1
-           MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
-              --result-file --suite=galera \
-              ${MTR_ARGS} \
-              --force --xml-report=${WORKDIR_ABS}/galera_mtr.xml \
-              --max-test-fail=0 \
-              --suite-timeout=9999 --parallel $GALERA_PARALLEL_RUN \
-              --port-group-size=20 --vardir=var1 \
-              --testcase-timeout=${TESTCASE_TIMEOUT} \
-              | tee ${WORKDIR_ABS}/galera_mtr.output || status=$?
-    
-            killall -9 mysqld || true
-		    sed -i '1d' ${WORKDIR_ABS}/galera_mtr.xml
-		    sed -i '/<!\[CDATA/,/]]>/d' ${WORKDIR_ABS}/galera_mtr.xml
-		    sed -r 's/comment=.*.\/>/\/>/' ${WORKDIR_ABS}/galera_mtr.xml > ${WORKDIR_ABS}/galera_mtr.tmp
-		    sed -r 's/status=\"skipped\".*.\/>/ > <skipped \/> <\/testcase>/' ${WORKDIR_ABS}/galera_mtr.tmp >  ${WORKDIR_ABS}/galera_mtr1.tmp
-		    sed -r 's/status=\"disabled\".*.\/>/ > <disabled \/> <\/testcase>/' ${WORKDIR_ABS}/galera_mtr1.tmp >  ${WORKDIR_ABS}/galera_junit.xml
-		    rm -f ${WORKDIR_ABS}/galera_mtr*.tmp ${WORKDIR_ABS}/galera_mtr.xml
-        fi
-    
-        # galera_3nodes suite
-        if echo "$MTR_SUITES" | grep -Ewq "galera_3nodes"; then
-           mkdir var2
-           MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
-              --result-file --suite=galera_3nodes \
-              ${MTR_ARGS} \
-              --force --xml-report=${WORKDIR_ABS}/galera3_mtr.xml \
-              --max-test-fail=0 \
-              --suite-timeout=9999 --parallel $GALERA_PARALLEL_RUN \
-              --port-group-size=20 --vardir=var2 \
-              --testcase-timeout=${TESTCASE_TIMEOUT} \
-              | tee ${WORKDIR_ABS}/galera3_mtr.output || status=$?
-    
-            killall -9 mysqld || true
-		    sed -i '1d' ${WORKDIR_ABS}/galera3_mtr.xml
-		    sed -i '/<!\[CDATA/,/]]>/d' ${WORKDIR_ABS}/galera3_mtr.xml
-		    sed -r 's/comment=.*.\/>/\/>/' ${WORKDIR_ABS}/galera3_mtr.xml > ${WORKDIR_ABS}/galera3_mtr.tmp
-		    sed -r 's/status=\"skipped\".*.\/>/ > <skipped \/> <\/testcase>/' ${WORKDIR_ABS}/galera3_mtr.tmp >  ${WORKDIR_ABS}/galera3_mtr1.tmp
-		    sed -r 's/status=\"disabled\".*.\/>/ > <disabled \/> <\/testcase>/' ${WORKDIR_ABS}/galera3_mtr1.tmp >  ${WORKDIR_ABS}/galera3_junit.xml
-		    rm -f ${WORKDIR_ABS}/galera3_mtr*.tmp ${WORKDIR_ABS}/galera3_mtr.xml
-        fi
-    
-        # sys_vars suite
-        if echo "$MTR_SUITES" | grep -Ewq "sys_vars"; then
-           mkdir var3
-           MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
-              --result-file --suite=sys_vars \
-              ${MTR_ARGS} \
-              --force --xml-report=${WORKDIR_ABS}/sys_vars.xml \
-              --max-test-fail=0 \
-              --suite-timeout=9999 --parallel $PARALLEL_RUN \
-              --port-group-size=20 --vardir=var3 \
-              --testcase-timeout=${TESTCASE_TIMEOUT} \
-              | tee ${WORKDIR_ABS}/sys_vars.output || status=$?
-    		  
-            killall -9 mysqld || true
-		    sed -i '1d' ${WORKDIR_ABS}/sys_vars.xml
-		    sed -i '/<!\[CDATA/,/]]>/d' ${WORKDIR_ABS}/sys_vars.xml
-		    sed -r 's/comment=.*.\/>/\/>/' ${WORKDIR_ABS}/sys_vars.xml > ${WORKDIR_ABS}/sys_vars.tmp
-		    sed -r 's/status=\"skipped\".*.\/>/ > <skipped \/> <\/testcase>/' ${WORKDIR_ABS}/sys_vars.tmp >  ${WORKDIR_ABS}/sys_vars1.tmp
-		    sed -r 's/status=\"disabled\".*.\/>/ > <disabled \/> <\/testcase>/' ${WORKDIR_ABS}/sys_vars1.tmp >  ${WORKDIR_ABS}/sys_vars_junit.xml
-		    rm -f ${WORKDIR_ABS}/sys_vars*.tmp ${WORKDIR_ABS}/sys_vars.xml
-        fi
+        ARRAY_MTR_SUITES=($(echo $MTR_SUITES | sed 's/,/ /g'))
+        for suite in "${ARRAY_MTR_SUITES[@]}"; do
+	        if [[ "$suite" == *"galera"* ]]; then
+	            WORKER=$GALERA_PARALLEL_RUN
+			else
+	            WORKER=$PARALLEL_RUN
+			fi
+	        echo "Running MTR suite: $suite"
+	        mkdir $PWD/var_${suite}
+	        MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
+	           --result-file --suite=$suite \
+	           --force --xml-report=${WORKDIR_ABS}/${suite}_mtr.xml \
+	           --max-test-fail=0 \
+	           --suite-timeout=9999 --parallel $WORKER \
+	           --port-group-size=20 --vardir=$PWD/var_${suite} \
+	           --testcase-timeout=${TESTCASE_TIMEOUT} \
+               ${MTR_ARGS} \
+	           | tee ${WORKDIR_ABS}/${suite}_mtr.output || status=$?
+
+            mv $PWD/var_${suite} $PWD/mtr_var    
+	        killall -9 mysqld || true
+		    sed -i '1d' ${WORKDIR_ABS}/${suite}_mtr.xml
+		    sed -i '/<!\[CDATA/,/]]>/d' ${WORKDIR_ABS}/${suite}_mtr.xml
+		    sed -r 's/comment=.*.\/>/\/>/' ${WORKDIR_ABS}/${suite}_mtr.xml > ${WORKDIR_ABS}/${suite}_junit.tmp
+		    sed -r 's/status=\"skipped\".*.\/>/ > <skipped \/> <\/testcase>/' ${WORKDIR_ABS}/${suite}_junit.tmp >  ${WORKDIR_ABS}/${suite}_junit1.tmp
+		    sed -r 's/status=\"disabled\".*.\/>/ > <disabled \/> <\/testcase>/' ${WORKDIR_ABS}/${suite}_junit1.tmp >  ${WORKDIR_ABS}/${suite}_junit.xml
+		    rm -f ${WORKDIR_ABS}/${suite}_junit*.tmp ${WORKDIR_ABS}/${suite}_mtr.xml
+		done
     else
         echo "Running full MTR"
-        mkdir var1
+        mkdir var
         MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
            --result-file \
-           ${MTR_ARGS} \
            --force --xml-report=${WORKDIR_ABS}/mtr.xml \
            --max-test-fail=0 \
            --suite-timeout=9999 --parallel $PARALLEL_RUN \
-           --port-group-size=20 --vardir=var1 \
+           --port-group-size=20 --vardir=var \
            --testcase-timeout=${TESTCASE_TIMEOUT} \
+           ${MTR_ARGS} \
            | tee ${WORKDIR_ABS}/mtr.output || status=$?
-    
+
+        mv $PWD/var $PWD/mtr_var
         killall -9 mysqld || true
 	    sed -i '1d' ${WORKDIR_ABS}/mtr.xml
 	    sed -i '/<!\[CDATA/,/]]>/d' ${WORKDIR_ABS}/mtr.xml

--- a/pxc/local/test-binary-pxc57
+++ b/pxc/local/test-binary-pxc57
@@ -7,6 +7,10 @@
 #      DEFAULT_TESTING = (yes no)
 #      MTR_ARGS
 #      MTR_REPEAT
+#      FULL_MTR
+#      GALERA_PARALLEL_RUN
+#      MTR_SUITES
+#      PARALLEL_RUN
 
 set -o errexit
 set -o xtrace
@@ -67,12 +71,11 @@ if [[ "${DEFAULT_TESTING}" != "no" ]]; then
     else
         MYSQLD_ENV="${ADD_TO_LD_PRELOAD:-}${JEMALLOC}:${EATMYDATA}"
     fi
-    if [ -z $FULL_MTR ]; then
+    if [ $FULL_MTR -ne 1 ]; then
         # galera suite
         if echo "$MTR_SUITES" | grep -Eq "galera[ ,]"; then
            mkdir var1
            MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
-              --parallel=${PARALLEL} \
               --result-file --suite=galera \
               ${MTR_ARGS} \
               --force --xml-report=${WORKDIR_ABS}/galera_mtr.xml \

--- a/pxc/local/test-binary-pxc57
+++ b/pxc/local/test-binary-pxc57
@@ -27,7 +27,6 @@ export WSREP_PROVIDER=${WORKDIR_ABS}/PXC/lib/libgalera_smm.so
 export XB_PLUGIN_DIR=${WORKDIR_ABS}/PXB/lib/plugin
 cd ${WORKDIR_ABS}/PXC/mysql-test
 TESTCASE_TIMEOUT=30
-PARALLEL=$(grep -c ^processor /proc/cpuinfo)
 # CentOS 6 & 7
 if [[ -f /opt/rh/devtoolset-7/enable ]]; then
     source /opt/rh/devtoolset-7/enable
@@ -98,7 +97,6 @@ if [[ "${DEFAULT_TESTING}" != "no" ]]; then
         if echo "$MTR_SUITES" | grep -Eq "galera_3nodes"; then
            mkdir var2
            MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
-              --parallel=${PARALLEL} \
               --result-file --suite=galera_3nodes \
               ${MTR_ARGS} \
               --force --xml-report=${WORKDIR_ABS}/galera3_mtr.xml \
@@ -121,7 +119,6 @@ if [[ "${DEFAULT_TESTING}" != "no" ]]; then
         if echo "$MTR_SUITES" | grep -Eq "sys_vars"; then
            mkdir var3
            MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
-              --parallel=${PARALLEL} \
               --result-file --suite=sys_vars \
               ${MTR_ARGS} \
               --force --xml-report=${WORKDIR_ABS}/sys_vars.xml \
@@ -143,7 +140,6 @@ if [[ "${DEFAULT_TESTING}" != "no" ]]; then
         echo "Running full MTR"
         mkdir var1
         MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
-           --parallel=${PARALLEL} \
            --result-file \
            ${MTR_ARGS} \
            --force --xml-report=${WORKDIR_ABS}/mtr.xml \
@@ -161,22 +157,6 @@ if [[ "${DEFAULT_TESTING}" != "no" ]]; then
 	    sed -r 's/status=\"disabled\".*.\/>/ > <disabled \/> <\/testcase>/' ${WORKDIR_ABS}/junit1.tmp >  ${WORKDIR_ABS}/junit.xml
 	    rm -f ${WORKDIR_ABS}/junit*.tmp ${WORKDIR_ABS}/mtr.xml
     fi
-  #MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
-  #      --parallel=${PARALLEL} \
-  #      --result-file \
-  #      ${MTR_ARGS} \
-  #      --force --xml-report=${WORKDIR_ABS}/mtr.xml \
-  #      --max-test-fail=0 \
-  #      --suite-timeout=9999 \
-  #      --testcase-timeout=${TESTCASE_TIMEOUT} \
-  #      | tee ${WORKDIR_ABS}/mtr.output || status=$?
-  
-  #sed -i '1d' ${WORKDIR_ABS}/mtr.xml
-  #sed -i '/<!\[CDATA/,/]]>/d' ${WORKDIR_ABS}/mtr.xml
-  #sed -r 's/comment=.*.\/>/\/>/' ${WORKDIR_ABS}/mtr.xml > ${WORKDIR_ABS}/junit.tmp
-  #sed -r 's/status=\"skipped\".*.\/>/ > <skipped \/> <\/testcase>/' ${WORKDIR_ABS}/junit.tmp >  ${WORKDIR_ABS}/junit1.tmp
-  #sed -r 's/status=\"disabled\".*.\/>/ > <disabled \/> <\/testcase>/' ${WORKDIR_ABS}/junit1.tmp >  ${WORKDIR_ABS}/junit.xml
-  #rm -f ${WORKDIR_ABS}/junit*.tmp ${WORKDIR_ABS}/mtr.xml
 fi
 
 exit $status

--- a/pxc/local/test-binary-pxc57
+++ b/pxc/local/test-binary-pxc57
@@ -7,7 +7,7 @@
 #      DEFAULT_TESTING = (yes no)
 #      MTR_ARGS
 #      MTR_REPEAT
-#      FULL_MTR
+#      FULL_MTR = (yes no)
 #      GALERA_PARALLEL_RUN
 #      MTR_SUITES
 #      PARALLEL_RUN
@@ -71,7 +71,7 @@ if [[ "${DEFAULT_TESTING}" != "no" ]]; then
     else
         MYSQLD_ENV="${ADD_TO_LD_PRELOAD:-}${JEMALLOC}:${EATMYDATA}"
     fi
-    if [ $FULL_MTR -ne 1 ]; then
+    if [ ${FULL_MTR} == "no" ]; then
         # galera suite
         if echo "$MTR_SUITES" | grep -Eq "galera[ ,]"; then
            mkdir var1

--- a/pxc/local/test-binary-pxc57
+++ b/pxc/local/test-binary-pxc57
@@ -144,7 +144,7 @@ if [[ "${DEFAULT_TESTING}" != "no" ]]; then
            ${MTR_ARGS} \
            --force --xml-report=${WORKDIR_ABS}/mtr.xml \
            --max-test-fail=0 \
-           --suite-timeout=9999 --parallel $GALERA_PARALLEL_RUN \
+           --suite-timeout=9999 --parallel $PARALLEL_RUN \
            --port-group-size=20 --vardir=var1 \
            --testcase-timeout=${TESTCASE_TIMEOUT} \
            | tee ${WORKDIR_ABS}/mtr.output || status=$?

--- a/pxc/local/test-binary-pxc57
+++ b/pxc/local/test-binary-pxc57
@@ -67,23 +67,113 @@ if [[ "${DEFAULT_TESTING}" != "no" ]]; then
     else
         MYSQLD_ENV="${ADD_TO_LD_PRELOAD:-}${JEMALLOC}:${EATMYDATA}"
     fi
-
-  MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
-        --parallel=${PARALLEL} \
-        --result-file \
-        ${MTR_ARGS} \
-        --force --xml-report=${WORKDIR_ABS}/mtr.xml \
-        --max-test-fail=0 \
-        --suite-timeout=9999 \
-        --testcase-timeout=${TESTCASE_TIMEOUT} \
-        | tee ${WORKDIR_ABS}/mtr.output || status=$?
+    if [ -z $FULL_MTR ]; then
+        # galera suite
+        if echo "$MTR_SUITES" | grep -Eq "galera[ ,]"; then
+           mkdir var1
+           MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
+              --parallel=${PARALLEL} \
+              --result-file --suite=galera \
+              ${MTR_ARGS} \
+              --force --xml-report=${WORKDIR_ABS}/galera_mtr.xml \
+              --max-test-fail=0 \
+              --suite-timeout=9999 --parallel $GALERA_PARALLEL_RUN \
+              --port-group-size=20 --vardir=var1 \
+              --testcase-timeout=${TESTCASE_TIMEOUT} \
+              | tee ${WORKDIR_ABS}/galera_mtr.output || status=$?
+    
+            killall -9 mysqld || true
+		    sed -i '1d' ${WORKDIR_ABS}/galera_mtr.xml
+		    sed -i '/<!\[CDATA/,/]]>/d' ${WORKDIR_ABS}/galera_mtr.xml
+		    sed -r 's/comment=.*.\/>/\/>/' ${WORKDIR_ABS}/galera_mtr.xml > ${WORKDIR_ABS}/galera_mtr.tmp
+		    sed -r 's/status=\"skipped\".*.\/>/ > <skipped \/> <\/testcase>/' ${WORKDIR_ABS}/galera_mtr.tmp >  ${WORKDIR_ABS}/galera_mtr1.tmp
+		    sed -r 's/status=\"disabled\".*.\/>/ > <disabled \/> <\/testcase>/' ${WORKDIR_ABS}/galera_mtr1.tmp >  ${WORKDIR_ABS}/galera_junit.xml
+		    rm -f ${WORKDIR_ABS}/galera_mtr*.tmp ${WORKDIR_ABS}/galera_mtr.xml
+        fi
+    
+        # galera_3nodes suite
+        if echo "$MTR_SUITES" | grep -Eq "galera_3nodes"; then
+           mkdir var2
+           MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
+              --parallel=${PARALLEL} \
+              --result-file --suite=galera_3nodes \
+              ${MTR_ARGS} \
+              --force --xml-report=${WORKDIR_ABS}/galera3_mtr.xml \
+              --max-test-fail=0 \
+              --suite-timeout=9999 --parallel $GALERA_PARALLEL_RUN \
+              --port-group-size=20 --vardir=var2 \
+              --testcase-timeout=${TESTCASE_TIMEOUT} \
+              | tee ${WORKDIR_ABS}/galera3_mtr.output || status=$?
+    
+            killall -9 mysqld || true
+		    sed -i '1d' ${WORKDIR_ABS}/galera3_mtr.xml
+		    sed -i '/<!\[CDATA/,/]]>/d' ${WORKDIR_ABS}/galera3_mtr.xml
+		    sed -r 's/comment=.*.\/>/\/>/' ${WORKDIR_ABS}/galera3_mtr.xml > ${WORKDIR_ABS}/galera3_mtr.tmp
+		    sed -r 's/status=\"skipped\".*.\/>/ > <skipped \/> <\/testcase>/' ${WORKDIR_ABS}/galera3_mtr.tmp >  ${WORKDIR_ABS}/galera3_mtr1.tmp
+		    sed -r 's/status=\"disabled\".*.\/>/ > <disabled \/> <\/testcase>/' ${WORKDIR_ABS}/galera3_mtr1.tmp >  ${WORKDIR_ABS}/galera3_junit.xml
+		    rm -f ${WORKDIR_ABS}/galera3_mtr*.tmp ${WORKDIR_ABS}/galera3_mtr.xml
+        fi
+    
+        # sys_vars suite
+        if echo "$MTR_SUITES" | grep -Eq "sys_vars"; then
+           mkdir var3
+           MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
+              --parallel=${PARALLEL} \
+              --result-file --suite=sys_vars \
+              ${MTR_ARGS} \
+              --force --xml-report=${WORKDIR_ABS}/sys_vars.xml \
+              --max-test-fail=0 \
+              --suite-timeout=9999 --parallel $PARALLEL_RUN \
+              --port-group-size=20 --vardir=var3 \
+              --testcase-timeout=${TESTCASE_TIMEOUT} \
+              | tee ${WORKDIR_ABS}/sys_vars.output || status=$?
+    		  
+            killall -9 mysqld || true
+		    sed -i '1d' ${WORKDIR_ABS}/sys_vars.xml
+		    sed -i '/<!\[CDATA/,/]]>/d' ${WORKDIR_ABS}/sys_vars.xml
+		    sed -r 's/comment=.*.\/>/\/>/' ${WORKDIR_ABS}/sys_vars.xml > ${WORKDIR_ABS}/sys_vars.tmp
+		    sed -r 's/status=\"skipped\".*.\/>/ > <skipped \/> <\/testcase>/' ${WORKDIR_ABS}/sys_vars.tmp >  ${WORKDIR_ABS}/sys_vars1.tmp
+		    sed -r 's/status=\"disabled\".*.\/>/ > <disabled \/> <\/testcase>/' ${WORKDIR_ABS}/sys_vars1.tmp >  ${WORKDIR_ABS}/sys_vars_junit.xml
+		    rm -f ${WORKDIR_ABS}/sys_vars*.tmp ${WORKDIR_ABS}/sys_vars.xml
+        fi
+    else
+        echo "Running full MTR"
+        mkdir var1
+        MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
+           --parallel=${PARALLEL} \
+           --result-file \
+           ${MTR_ARGS} \
+           --force --xml-report=${WORKDIR_ABS}/mtr.xml \
+           --max-test-fail=0 \
+           --suite-timeout=9999 --parallel $GALERA_PARALLEL_RUN \
+           --port-group-size=20 --vardir=var1 \
+           --testcase-timeout=${TESTCASE_TIMEOUT} \
+           | tee ${WORKDIR_ABS}/mtr.output || status=$?
+    
+        killall -9 mysqld || true
+	    sed -i '1d' ${WORKDIR_ABS}/mtr.xml
+	    sed -i '/<!\[CDATA/,/]]>/d' ${WORKDIR_ABS}/mtr.xml
+	    sed -r 's/comment=.*.\/>/\/>/' ${WORKDIR_ABS}/mtr.xml > ${WORKDIR_ABS}/junit.tmp
+	    sed -r 's/status=\"skipped\".*.\/>/ > <skipped \/> <\/testcase>/' ${WORKDIR_ABS}/junit.tmp >  ${WORKDIR_ABS}/junit1.tmp
+	    sed -r 's/status=\"disabled\".*.\/>/ > <disabled \/> <\/testcase>/' ${WORKDIR_ABS}/junit1.tmp >  ${WORKDIR_ABS}/junit.xml
+	    rm -f ${WORKDIR_ABS}/junit*.tmp ${WORKDIR_ABS}/mtr.xml
+    fi
+  #MTR_BUILD_THREAD=auto ./mysql-test-run.pl \
+  #      --parallel=${PARALLEL} \
+  #      --result-file \
+  #      ${MTR_ARGS} \
+  #      --force --xml-report=${WORKDIR_ABS}/mtr.xml \
+  #      --max-test-fail=0 \
+  #      --suite-timeout=9999 \
+  #      --testcase-timeout=${TESTCASE_TIMEOUT} \
+  #      | tee ${WORKDIR_ABS}/mtr.output || status=$?
   
-  sed -i '1d' ${WORKDIR_ABS}/mtr.xml
-  sed -i '/<!\[CDATA/,/]]>/d' ${WORKDIR_ABS}/mtr.xml
-  sed -r 's/comment=.*.\/>/\/>/' ${WORKDIR_ABS}/mtr.xml > ${WORKDIR_ABS}/junit.tmp
-  sed -r 's/status=\"skipped\".*.\/>/ > <skipped \/> <\/testcase>/' ${WORKDIR_ABS}/junit.tmp >  ${WORKDIR_ABS}/junit1.tmp
-  sed -r 's/status=\"disabled\".*.\/>/ > <disabled \/> <\/testcase>/' ${WORKDIR_ABS}/junit1.tmp >  ${WORKDIR_ABS}/junit.xml
-  rm -f ${WORKDIR_ABS}/junit*.tmp ${WORKDIR_ABS}/mtr.xml
+  #sed -i '1d' ${WORKDIR_ABS}/mtr.xml
+  #sed -i '/<!\[CDATA/,/]]>/d' ${WORKDIR_ABS}/mtr.xml
+  #sed -r 's/comment=.*.\/>/\/>/' ${WORKDIR_ABS}/mtr.xml > ${WORKDIR_ABS}/junit.tmp
+  #sed -r 's/status=\"skipped\".*.\/>/ > <skipped \/> <\/testcase>/' ${WORKDIR_ABS}/junit.tmp >  ${WORKDIR_ABS}/junit1.tmp
+  #sed -r 's/status=\"disabled\".*.\/>/ > <disabled \/> <\/testcase>/' ${WORKDIR_ABS}/junit1.tmp >  ${WORKDIR_ABS}/junit.xml
+  #rm -f ${WORKDIR_ABS}/junit*.tmp ${WORKDIR_ABS}/mtr.xml
 fi
 
 exit $status


### PR DESCRIPTION
Issue : 
          Currently, PXC-57/80 MTR pipeline jobs do not have the option to set custom MTR workers

Solution:
          Added the following parameters to set custom MTR workers
          PARALLEL_RUN : This value is used for all test suites except for Galera specific suites.
          GALERA_PARALLEL_RUN : This value is used for the Galera specific test suites
          MTR_SUITES : mysql-test-run.pl suite names
          FULL_MTR : Run MTR suites based on variable MTR_SUITES if the value is `no`. Otherwise, the full MTR will be performed.

PXC-5.7 test run result: https://pxc.cd.percona.com/job/test-pxc-5.7-param
PXC-8.0 test run result: https://pxc.cd.percona.com/job/test-pxc-8.0-param
          
PS : Removed debian jessie from the OS list as it has reached EOL