### PR TITLE
Remove helm init from psmdb_operator_eks.groovy

### DIFF
--- a/cloud/jenkins/psmdb_operator_eks.groovy
+++ b/cloud/jenkins/psmdb_operator_eks.groovy
@@ -142,7 +142,6 @@ pipeline {
 
                     curl -s https://get.helm.sh/helm-v3.2.3-linux-amd64.tar.gz \
                         | sudo tar -C /usr/local/bin --strip-components 1 -zvxpf -
-                    /usr/local/bin/helm init --client-only
 
                     curl --silent --location "https://github.com/weaveworks/eksctl/releases/download/latest_release/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
                     sudo mv -v /tmp/eksctl /usr/local/bin


### PR DESCRIPTION
Failing here: https://cloud.cd.percona.com/job/psmdb-operator-eks/34/execution/node/8/log/
```
+ /usr/local/bin/helm init --client-only
Error: unknown command "init" for "helm"

Did you mean this?
	lint
```