### PR TITLE
Add clearing yum cache and stop tests if tools install fails on minikube

### DIFF
--- a/cloud/jenkins/psmdb_operator_minikube.groovy
+++ b/cloud/jenkins/psmdb_operator_minikube.groovy
@@ -94,7 +94,8 @@ EOF
 
         sudo yum install -y https://repo.percona.com/yum/percona-release-latest.noarch.rpm || true
         sudo percona-release enable-only tools
-        sudo yum install -y percona-xtrabackup-80 jq kubectl socat || true
+        sudo yum clean all || true
+        sudo yum install -y percona-xtrabackup-80 jq kubectl socat
     '''
 }
 pipeline {

--- a/cloud/jenkins/pxc_operator_minikube.groovy
+++ b/cloud/jenkins/pxc_operator_minikube.groovy
@@ -102,7 +102,8 @@ EOF
 
         sudo yum install -y https://repo.percona.com/yum/percona-release-latest.noarch.rpm || true
         sudo percona-release enable-only tools
-        sudo yum install -y percona-xtrabackup-80 jq kubectl socat || true
+        sudo yum clean all || true
+        sudo yum install -y percona-xtrabackup-80 jq kubectl socat
     '''
 }
 pipeline {


### PR DESCRIPTION
PSMDB and PXC minikube tests fail like so:
https://cloud.cd.percona.com/job/psmdb-operator-minikube/98/consoleFull
```
+ sudo yum install -y percona-xtrabackup-80 jq kubectl socat
Loaded plugins: extras_suggestions, langpacks, priorities, update-motd


Error making cache directory: /var/cache/yum/x86_64/2/tools-release-noarch error was: [Errno 17] File exists: '/var/cache/yum/x86_64/2/tools-release-noarch'
...
--- 0 stderr
/mnt/jenkins/workspace/psmdb-operator-minikube/source/e2e-tests/init-deploy/../functions: line 607: kubectl: command not found
```
This clears the cache before installing and also fails the job if the yum install fails so that the tests are not even tried to run.