### PR TITLE
PMM-6621 Remove deprecated packages from autobuild pipeline

### DIFF
--- a/pmm/pmm2-server-autobuild.groovy
+++ b/pmm/pmm2-server-autobuild.groovy
@@ -110,9 +110,7 @@ pipeline {
 
                             # 1st-party
                             build-server-rpm percona-dashboards grafana-dashboards
-                            build-server-rpm pmm-manage
                             build-server-rpm pmm-managed
-                            build-server-rpm percona-qan-api qan-api
                             build-server-rpm percona-qan-api2 qan-api2
                             build-server-rpm percona-qan-app qan-app
                             build-server-rpm pmm-server
@@ -122,9 +120,6 @@ pipeline {
 
                             # 3rd-party
                             build-server-rpm clickhouse
-                            build-server-rpm consul
-                            build-server-rpm orchestrator
-                            build-server-rpm rds_exporter
                             build-server-rpm prometheus
                             build-server-rpm alertmanager
                             build-server-rpm grafana


### PR DESCRIPTION
Rebased from: https://github.com/Percona-Lab/jenkins-pipelines/pull/525/files