### PR TITLE
ENG-906: Fix installation of git on CentOS

### DIFF
--- a/IaC/ps80.cd/init.groovy.d/cloud.groovy
+++ b/IaC/ps80.cd/init.groovy.d/cloud.groovy
@@ -187,7 +187,8 @@ initMap['micro-amazon'] = '''
         sleep 1
         echo try again
     done
-    sudo yum -y install java-1.8.0-openjdk git aws-cli || :
+    sudo yum -y install java-1.8.0-openjdk aws-cli || :
+    sudo yum -y install git || :
     sudo yum -y remove java-1.7.0-openjdk || :
     sudo install -o $(id -u -n) -g $(id -g -n) -d /mnt/jenkins
 '''
@@ -206,7 +207,8 @@ initMap['min-centos-6-x32'] = '''
         sleep 1
         echo try again
     done
-    sudo yum -y install java-1.8.0-openjdk git aws-cli || :
+    sudo yum -y install java-1.8.0-openjdk aws-cli || :
+    sudo yum -y install git || :
     sudo yum -y remove java-1.7.0-openjdk || :
     sudo install -o $(id -u -n) -g $(id -g -n) -d /mnt/jenkins
 


### PR DESCRIPTION
Hrvoje reported that CentOS 8 doesn't have `git` installed:
With `|| : ` it only installs java package

Here's the sample:
```
++ sudo yum -y install java-1.8.0-openjdk git aws-cli

Last metadata expiration check: 0:00:03 ago on Wed 16 Sep 2020 04:44:46 PM UTC.
No match for argument: aws-cli
Error: Unable to find a match: aws-cli
++ :
<<>>
Dependencies resolved.
==========================================================================================
 Package                       Arch    Version                            Repo        Size
==========================================================================================
Installing:
 java-1.8.0-openjdk            x86_64  1:1.8.0.262.b10-0.el8_2            AppStream  323 k
Installing dependencies:
```


