### PR TITLE
ENG-921: Implement matrix auth as IaaC for rel.cd

### DIFF
--- a/IaC/rel.cd/init.groovy.d/matrix.groovy
+++ b/IaC/rel.cd/init.groovy.d/matrix.groovy
@@ -144,6 +144,7 @@ authz_strategy_config = [
     strategy: 'GlobalMatrixAuthorizationStrategy',
     user_permissions: [
         'percona*Build Engineers': ['Overall Administer'],
+        'percona*iit': ['Overall Administer'],
         'percona': ['Overall Read','Agent Build','Agent Connect','Agent Provision','Job Discover','Job Read','Job Build','Job Cancel','Job Workspace','View Read']
     ]
 ]

--- a/IaC/rel.cd/init.groovy.d/matrix.groovy
+++ b/IaC/rel.cd/init.groovy.d/matrix.groovy
@@ -145,7 +145,7 @@ authz_strategy_config = [
     user_permissions: [
         'percona*Build Engineers': ['Overall Administer'],
         'percona*iit': ['Overall Administer'],
-        'percona': ['Overall Read','Agent Build','Agent Connect','Agent Provision','Job Discover','Job Read','Job Build','Job Cancel','Job Workspace','View Read']
+        'percona': ['Overall Read','Agent Build','Agent Connect','Agent Provision','Job Discover','Job Read','Job Build','Job Cancel','Job Workspace','View Read'],
     ]
 ]
 

--- a/IaC/rel.cd/init.groovy.d/matrix.groovy
+++ b/IaC/rel.cd/init.groovy.d/matrix.groovy
@@ -143,7 +143,8 @@ Map<String, Permission> permissionIds = Permission.all.findAll { permission ->
 authz_strategy_config = [
     strategy: 'GlobalMatrixAuthorizationStrategy',
     user_permissions: [
-        'percona*Build Engineers': ['Overall Administer']
+        'percona*Build Engineers': ['Overall Administer'],
+        'percona': ['Overall Read','Agent Build','Agent Connect','Agent Provision','Job Discover','Job Read','Job Build','Job Cancel','Job Workspace','View Read']
     ]
 ]
 

--- a/IaC/rel.cd/init.groovy.d/matrix.groovy
+++ b/IaC/rel.cd/init.groovy.d/matrix.groovy
@@ -1,0 +1,184 @@
+/*
+   Copyright (c) 2015-2020 Sam Gleske - https://github.com/samrocketman/jenkins-bootstrap-shared
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+   */
+/*
+   Configure matrix authorization strategy with permissions for users and
+   groups.  This script is idempotent and will only change configuration if
+   necessary.
+
+   Example configuration:
+       authz_strategy_config = [
+           strategy: 'GlobalMatrixAuthorizationStrategy',
+           user_permissions: [
+               anonymous: ['Job Discover'],
+               authenticated: ['Overall Read', 'Job Read', 'View Read'],
+               admin: ['Overall Administer']
+           ]
+       ]
+
+   Available Authorization Strategies:
+       GlobalMatrixAuthorizationStrategy
+       ProjectMatrixAuthorizationStrategy
+
+   Available user permissions:
+       Overall Administer
+       Overall Read
+       Agent Configure
+       Agent Delete
+       Agent Create
+       Agent Disconnect
+       Agent Connect
+       Agent Build
+       Agent Provision
+       Run Delete
+       Run Update
+       Job Create
+       Job Delete
+       Job Configure
+       Job Read
+       Job Discover
+       Job Build
+       Job Workspace
+       Job Cancel
+       SCM Tag
+       Credentials Create
+       Credentials Update
+       Credentials View
+       Credentials Delete
+       Credentials ManageDomains
+       Job Move
+       View Create
+       View Delete
+       View Configure
+       View Read
+       Run Replay
+
+   "Job ViewStatus" permission becomes available after installing the
+   embeddable build status plugin.
+ */
+
+import hudson.security.GlobalMatrixAuthorizationStrategy
+import hudson.security.Permission
+import hudson.security.ProjectMatrixAuthorizationStrategy
+import jenkins.model.Jenkins
+
+/**
+ * FUNCTIONS AND SETUP CODE
+ */
+String shortName(Permission p) {
+    p.id.tokenize('.')[-2..-1].join(' ')
+        .replace('Hudson','Overall')
+        .replace('Computer', 'Agent')
+        .replace('Item', 'Job')
+        .replace('CredentialsProvider', 'Credentials')
+}
+
+Map getCurrentPermissions(Map config = [:]) {
+    Map currentPermissions = [:].withDefault { [].toSet() }
+    if(!('getGrantedPermissions' in Jenkins.instance.authorizationStrategy.metaClass.methods*.name.sort().unique())) {
+        return currentPermissions
+    }
+    Closure merger = { Map nmap, Map m ->
+        m.each { k, v ->
+            nmap[k] += v
+        }
+    }
+    Jenkins.instance.authorizationStrategy.grantedPermissions.collect { permission, userList ->
+        userList.collect { user ->
+            [ (user): shortName(permission) ]
+        }
+    }.flatten().each merger.curry(currentPermissions)
+    currentPermissions
+}
+
+boolean isConfigurationEqual(Map config) {
+    Map currentPermissions = getCurrentPermissions(config)
+    Jenkins.instance.authorizationStrategy.class.name.endsWith(config['strategy']) &&
+    !(false in config['user_permissions'].collect { k, v -> currentPermissions[k] == v.toSet() }) &&
+    currentPermissions.keySet() == config['user_permissions'].keySet()
+}
+
+boolean isValidConfig(def config, List<String> validPermissions) {
+    Map currentPermissions = getCurrentPermissions()
+    config instanceof Map &&
+    config.keySet().containsAll(['strategy', 'user_permissions']) &&
+    config['strategy'] &&
+    config['strategy'] instanceof String &&
+    config['strategy'] in ['GlobalMatrixAuthorizationStrategy', 'ProjectMatrixAuthorizationStrategy'] &&
+    config['user_permissions'] &&
+    !(false in config['user_permissions'].collect { k, v ->
+        k instanceof String &&
+        (v instanceof List || v instanceof Set) &&
+        !(false in v.collect {
+            validPermissions.contains(it)
+        })
+    })
+}
+
+Map<String, Permission> permissionIds = Permission.all.findAll { permission ->
+    List<String> nonConfigurablePerms = ['RunScripts', 'UploadPlugins', 'ConfigureUpdateCenter']
+    permission.enabled &&
+        !permission.id.startsWith('hudson.security.Permission') &&
+        !(true in nonConfigurablePerms.collect { permission.id.endsWith(it) })
+}.collect { permission ->
+    [ (shortName(permission)): permission ]
+}.sum()
+
+/**
+ * MAIN EXECUTION
+ */
+
+authz_strategy_config = [
+    strategy: 'GlobalMatrixAuthorizationStrategy',
+    user_permissions: [
+        'percona*Build Engineers': ['Overall Administer']
+    ]
+]
+
+if(!binding.hasVariable('authz_strategy_config')) {
+    authz_strategy_config = [:]
+}
+
+if(!isValidConfig(authz_strategy_config, permissionIds.keySet().toList())) {
+    println([
+        'Skip configuring matrix authorization strategy because no valid config was provided.',
+        'Available Authorization Strategies:\n    GlobalMatrixAuthorizationStrategy\n    ProjectMatrixAuthorizationStrategy',
+        "Available Permissions:\n    ${permissionIds.keySet().join('\n    ')}"
+    ].join('\n'))
+    return
+}
+
+if(isConfigurationEqual(authz_strategy_config)) {
+    println "Nothing changed.  ${authz_strategy_config['strategy']} authorization strategy already configured."
+    return
+}
+
+println "Configuring authorization strategy ${authz_strategy_config['strategy']}"
+
+def authz_strategy = Class.forName("hudson.security.${authz_strategy_config['strategy']}").newInstance()
+
+// build the permissions in the strategy
+authz_strategy_config['user_permissions'].each { user, permissions ->
+    permissions.each { p ->
+        authz_strategy.add(permissionIds[p], user)
+        println "    For user ${user} grant permission ${p}."
+    }
+}
+
+// configure global authorization
+Jenkins.instance.authorizationStrategy = authz_strategy
+
+// save settings to persist across restarts
+Jenkins.instance.save()


### PR DESCRIPTION
This script has syntax checker which is awesome feature for our Jenkinses, it won't overwrite configuration if mistake was made:
```
2020-09-22 07:35:35.877+0000 [id=28]	INFO	j.util.groovy.GroovyHookScript#execute: Executing /mnt/rel.cd.percona.com/init.groovy.d/matrix.groovy
Configuring authorization strategy GlobalMatrixAuthorizationStrategy
    For user sudokamikaze grant permission Overall Administer.
    For user percona*Build Engineers grant permission Overall Administer.
2020-09-22 07:35:36.283+0000 [id=28]	INFO	jenkins.InitReactorRunner$1#onAttained: Completed initialization
```

And when failed:
```
2020-09-22 07:30:43.092+0000 [id=30]	INFO	j.util.groovy.GroovyHookScript#execute: Executing /mnt/rel.cd.percona.com/init.groovy.d/matrix.groovy
Skip configuring matrix authorization strategy because no valid config was provided.
Available Authorization Strategies:
    GlobalMatrixAuthorizationStrategy
    ProjectMatrixAuthorizationStrategy
Available Permissions:
    Overall Administer
    Overall Read
    Agent Configure
    Agent Delete
< >
2020-09-22 07:30:43.477+0000 [id=27]	INFO	jenkins.InitReactorRunner$1#onAttained: Completed initialization
```