### PR TITLE
ENG-921: Fix owner tag in EC2 instances

### DIFF
--- a/pmm/aws-staging-start.groovy
+++ b/pmm/aws-staging-start.groovy
@@ -118,7 +118,7 @@ pipeline {
                     sh """
                         echo "\${BUILD_USER_EMAIL}" > OWNER_EMAIL
                         echo "\${BUILD_USER_EMAIL}" | awk -F '@' '{print \$1}' > OWNER_FULL
-                        echo "pmm-\$(cat OWNER_FULL | cut -d . -f 1)-\$(date -u '+%Y%m%d%H%M%S')-${BUILD_NUMBER}" \
+                        echo "pmm-\$(cat OWNER_FULL)-\$(date -u '+%Y%m%d%H%M%S')-${BUILD_NUMBER}" \
                             > VM_NAME
                     """
                 }


### PR DESCRIPTION
Caused because:
In previous implementation, `OWNER` variable had `<NAME>.<SURNAME>` from email and it was used in `OWNER` tag of EC2 instance
I've reworked it so that it has `<NAME>` only in `OWNER` variable, and causes lp-percona.script to send a mail to  `<NAME>@percona.com`

Here's a proof https://github.com/Percona-Lab/jenkins-pipelines/commit/677de66aa3c7a644d0c3287ee8cee762000c488b#diff-cf39489e2a5e3b641bec0e09fa1ee7a4f9f4c076eb1b8a7aa517440fb2e22a9cL115 