### PR TITLE
PXC-3472: Updated MTR output process function

### DIFF
--- a/pxc/local/test-binary-pxc56
+++ b/pxc/local/test-binary-pxc56
@@ -103,12 +103,8 @@ if [[ "${DEFAULT_TESTING}" != "no" ]]; then
     fi
     chmod 755 ${WORKDIR_ABS}/PXC/bin/garbd
     export MTR_BUILD_THREAD=auto
-    if [ -f /usr/bin/yum ]; then
-      MTR_RUN='sudo ./mysql-test-run.pl'
-    else
-      MTR_RUN='sudo -E ./mysql-test-run.pl'
-    fi
-    $MTR_RUN --parallel=${PARALLEL} \
+    ./mysql-test-run.pl \
+        --parallel=${PARALLEL} \
         --result-file \
         ${MTR_ARGS} \
         --force \


### PR DESCRIPTION
Post-push fix: Revert to old behavior by not running MTR with root user.

Note to Reviewers
---
Many of the testcases were failing because the tests were run with root user.

```
rpl_gtid_mode
2020-11-16 14:00:49 0 [Warning] The syntax '--master-retry-count' is deprecated and will be removed in a future release. Please use 'CHANGE MASTER TO master_retry_count = <num>' instead.
2020-11-16 14:00:49 0 [Warning] TIMESTAMP with implicit DEFAULT value is deprecated. Please use --explicit_defaults_for_timestamp server option (see documentation for more details).
2020-11-16 14:00:49 0 [Warning] Insecure configuration for --secure-file-priv: Data directory is accessible through --secure-file-priv. Consider choosing a different directory.
2020-11-16 14:00:49 0 [Warning] Insecure configuration for --secure-file-priv: Location is accessible to all OS users. Consider choosing a different directory.
2020-11-16 14:00:49 0 [Note] /home/venki/work/pxc/56/bld/sql/mysqld (mysqld 5.6.50-90.0-debug-log) starting as process 107219 ...
2020-11-16 14:00:49 107219 [ERROR] Fatal error: Please read "Security" section of the manual to find out how to run mysqld as root!
```

```
galera.galera_memcached
2020-11-13 15:44:50 30154 [Note] WSREP: wsrep_notify_cmd is not defined, skipping notification.
InnoDB MEMCACHED: Memcached uses atomic increment 
can't run as root without the -u switch
safe_process[30153]: Child process: 30154, exit: 64
----------SERVER LOG END-------------
```
```
sys_vars.proxy_protocol_networks_malformed [ fail ]
        Test ended at 2020-11-13 15:45:22

CURRENT_TEST: sys_vars.proxy_protocol_networks_malformed
# ERROR: The file '/tmp/results/PXC/mysql-test/var/log/my_restart.err' does not contain the expected pattern  Too long network in 'proxy_protocol_networks' directive.
->2020-11-13 18:45:13 0 [Warning] TIMESTAMP with implicit DEFAULT value is deprecated. Please use --explicit_defaults_for_timestamp server option (see documentation for more details).
2020-11-13 18:45:13 0 [Warning] Insecure configuration for --secure-file-priv: Data directory is accessible through --secure-file-priv. Consider choosing a different directory.
2020-11-13 18:45:13 0 [Warning] Insecure configuration for --secure-file-priv: Location is accessible to all OS users. Consider choosing a different directory.
2020-11-13 18:45:13 0 [Note] /tmp/results/PXC/bin/mysqld (mysqld 5.6.50-90.0-28.42-log) starting as process 14879 ...
2020-11-13 18:45:13 14879 [ERROR] Fatal error: Please read "Security" section of the manual to find out how to run mysqld as root!
```