### PR TITLE
Fix test timeout and upgrade test cleanup for PXC operator jobs

### DIFF
--- a/cloud/jenkins/pxc_operator_aws_openshift.groovy
+++ b/cloud/jenkins/pxc_operator_aws_openshift.groovy
@@ -50,40 +50,42 @@ void runTest(String TEST_NAME) {
 
             popArtifactFile("$VERSION-$TEST_NAME-$PXC_TAG-CW_${params.CLUSTER_WIDE}")
 
-            sh """
-                if [ -f "$VERSION-$TEST_NAME-$PXC_TAG-CW_${params.CLUSTER_WIDE}" ]; then
-                    echo Skip $TEST_NAME test
-                else
-                    cd ./source
-                    if [ -n "${PXC_OPERATOR_IMAGE}" ]; then
-                        export IMAGE=${PXC_OPERATOR_IMAGE}
+            timeout(time: 90, unit: 'MINUTES') {
+                sh """
+                    if [ -f "$VERSION-$TEST_NAME-$PXC_TAG-CW_${params.CLUSTER_WIDE}" ]; then
+                        echo Skip $TEST_NAME test
                     else
-                        export IMAGE=perconalab/percona-xtradb-cluster-operator:${env.GIT_BRANCH}
-                    fi
+                        cd ./source
+                        if [ -n "${PXC_OPERATOR_IMAGE}" ]; then
+                            export IMAGE=${PXC_OPERATOR_IMAGE}
+                        else
+                            export IMAGE=perconalab/percona-xtradb-cluster-operator:${env.GIT_BRANCH}
+                        fi
 
-                    if [ -n "${IMAGE_PXC}" ]; then
-                        export IMAGE_PXC=${IMAGE_PXC}
-                    fi
+                        if [ -n "${IMAGE_PXC}" ]; then
+                            export IMAGE_PXC=${IMAGE_PXC}
+                        fi
 
-                    if [ -n "${IMAGE_PROXY}" ]; then
-                        export IMAGE_PROXY=${IMAGE_PROXY}
-                    fi
+                        if [ -n "${IMAGE_PROXY}" ]; then
+                            export IMAGE_PROXY=${IMAGE_PROXY}
+                        fi
 
-                    if [ -n "${IMAGE_HAPROXY}" ]; then
-                        export IMAGE_HAPROXY=${IMAGE_HAPROXY}
-                    fi
-                    if [ -n "${IMAGE_BACKUP}" ]; then
-                        export IMAGE_BACKUP=${IMAGE_BACKUP}
-                    fi
+                        if [ -n "${IMAGE_HAPROXY}" ]; then
+                            export IMAGE_HAPROXY=${IMAGE_HAPROXY}
+                        fi
+                        if [ -n "${IMAGE_BACKUP}" ]; then
+                            export IMAGE_BACKUP=${IMAGE_BACKUP}
+                        fi
 
-                    if [ -n "${IMAGE_PMM}" ]; then
-                        export IMAGE_PMM=${IMAGE_PMM}
-                    fi
+                        if [ -n "${IMAGE_PMM}" ]; then
+                            export IMAGE_PMM=${IMAGE_PMM}
+                        fi
 
-                    source $HOME/google-cloud-sdk/path.bash.inc
-                    ./e2e-tests/$TEST_NAME/run
-                fi
-            """
+                        source $HOME/google-cloud-sdk/path.bash.inc
+                        ./e2e-tests/$TEST_NAME/run
+                    fi
+                """
+            }
             pushArtifactFile("$VERSION-$TEST_NAME-$PXC_TAG-CW_${params.CLUSTER_WIDE}")
             testsReportMap[TEST_NAME] = 'passed'
             return true
@@ -272,7 +274,11 @@ pipeline {
             steps {
                 CreateCluster('upgrade')
                 runTest('upgrade-haproxy')
+                ShutdownCluster('upgrade')
+                CreateCluster('upgrade')
                 runTest('upgrade-proxysql')
+                ShutdownCluster('upgrade')
+                CreateCluster('upgrade')
                 runTest('smart-update')
                 runTest('upgrade-consistency')
                 ShutdownCluster('upgrade')

--- a/cloud/jenkins/pxc_operator_eks.groovy
+++ b/cloud/jenkins/pxc_operator_eks.groovy
@@ -50,45 +50,47 @@ void runTest(String TEST_NAME) {
 
             popArtifactFile("$VERSION-$TEST_NAME-$PXC_TAG-CW_${params.CLUSTER_WIDE}")
 
-            withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'eks-cicd'], file(credentialsId: 'eks-conf-file', variable: 'EKS_CONF_FILE')]) {
-                sh """
-                    if [ -f "$VERSION-$TEST_NAME-$PXC_TAG-CW_${params.CLUSTER_WIDE}" ]; then
-                        echo Skip $TEST_NAME test
-                    else
-                        cd ./source
-                        if [ -n "${PXC_OPERATOR_IMAGE}" ]; then
-                            export IMAGE=${PXC_OPERATOR_IMAGE}
+            timeout(time: 90, unit: 'MINUTES') {
+                withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'eks-cicd'], file(credentialsId: 'eks-conf-file', variable: 'EKS_CONF_FILE')]) {
+                    sh """
+                        if [ -f "$VERSION-$TEST_NAME-$PXC_TAG-CW_${params.CLUSTER_WIDE}" ]; then
+                            echo Skip $TEST_NAME test
                         else
-                            export IMAGE=perconalab/percona-xtradb-cluster-operator:${env.GIT_BRANCH}
+                            cd ./source
+                            if [ -n "${PXC_OPERATOR_IMAGE}" ]; then
+                                export IMAGE=${PXC_OPERATOR_IMAGE}
+                            else
+                                export IMAGE=perconalab/percona-xtradb-cluster-operator:${env.GIT_BRANCH}
+                            fi
+
+                            if [ -n "${IMAGE_PXC}" ]; then
+                                export IMAGE_PXC=${IMAGE_PXC}
+                            fi
+
+                            if [ -n "${IMAGE_PROXY}" ]; then
+                                export IMAGE_PROXY=${IMAGE_PROXY}
+                            fi
+
+                            if [ -n "${IMAGE_HAPROXY}" ]; then
+                                export IMAGE_HAPROXY=${IMAGE_HAPROXY}
+                            fi
+
+                            if [ -n "${IMAGE_BACKUP}" ]; then
+                                export IMAGE_BACKUP=${IMAGE_BACKUP}
+                            fi
+
+                            if [ -n "${IMAGE_PMM}" ]; then
+                                export IMAGE_PMM=${IMAGE_PMM}
+                            fi
+
+                            export PATH=/home/ec2-user/.local/bin:$PATH
+                            source $HOME/google-cloud-sdk/path.bash.inc
+                            export KUBECONFIG=~/.kube/config
+
+                            ./e2e-tests/$TEST_NAME/run
                         fi
-
-                        if [ -n "${IMAGE_PXC}" ]; then
-                            export IMAGE_PXC=${IMAGE_PXC}
-                        fi
-
-                        if [ -n "${IMAGE_PROXY}" ]; then
-                            export IMAGE_PROXY=${IMAGE_PROXY}
-                        fi
-
-                        if [ -n "${IMAGE_HAPROXY}" ]; then
-                            export IMAGE_HAPROXY=${IMAGE_HAPROXY}
-                        fi
-
-                        if [ -n "${IMAGE_BACKUP}" ]; then
-                            export IMAGE_BACKUP=${IMAGE_BACKUP}
-                        fi
-
-                        if [ -n "${IMAGE_PMM}" ]; then
-                            export IMAGE_PMM=${IMAGE_PMM}
-                        fi
-
-                        export PATH=/home/ec2-user/.local/bin:$PATH
-                        source $HOME/google-cloud-sdk/path.bash.inc
-                        export KUBECONFIG=~/.kube/config
-
-                        ./e2e-tests/$TEST_NAME/run
-                    fi
-                """
+                    """
+                }
             }
             pushArtifactFile("$VERSION-$TEST_NAME-$PXC_TAG-CW_${params.CLUSTER_WIDE}")
             testsReportMap[TEST_NAME] = 'passed'
@@ -262,7 +264,11 @@ EOF
             steps {
                 CreateCluster('upgrade')
                 runTest('upgrade-haproxy')
+                ShutdownCluster('upgrade')
+                CreateCluster('upgrade')
                 runTest('upgrade-proxysql')
+                ShutdownCluster('upgrade')
+                CreateCluster('upgrade')
                 runTest('smart-update')
                 runTest('upgrade-consistency')
                 ShutdownCluster('upgrade')


### PR DESCRIPTION
This is same change that was done here for PR tests:
https://github.com/percona/percona-xtradb-cluster-operator/pull/676

Adding 90min timeout to the command which actually runs the test and recreating the cluster for upgrade tests.