### PR TITLE
PXB-2365: Refresh apt cache before installing anything for PXB 

### DIFF
--- a/pxb/docker/test-binary-pxb24
+++ b/pxb/docker/test-binary-pxb24
@@ -28,10 +28,11 @@ fi
 
 if [[ -f /usr/bin/apt-get ]]; then
     DIST=$(lsb_release -sc)
+    DEBIAN_FRONTEND=noninteractive sudo -E apt update
     if [[ "$DIST" == 'focal' ]]; then
-        sudo apt install -y python3-sphinx
+        DEBIAN_FRONTEND=noninteractive sudo -E apt install -y python3-sphinx
     else
-        sudo apt install -y python-sphinx
+        DEBIAN_FRONTEND=noninteractive sudo -E apt install -y python-sphinx
     fi
 fi
 

--- a/pxb/docker/test-binary-pxb80
+++ b/pxb/docker/test-binary-pxb80
@@ -28,10 +28,11 @@ fi
 
 if [[ -f /usr/bin/apt-get ]]; then
     DIST=$(lsb_release -sc)
+    DEBIAN_FRONTEND=noninteractive sudo -E apt update
     if [[ "$DIST" == 'focal' ]]; then
-        sudo apt install -y python3-sphinx
+        DEBIAN_FRONTEND=noninteractive sudo -E apt install -y python3-sphinx
     else
-        sudo apt install -y python-sphinx
+        DEBIAN_FRONTEND=noninteractive sudo -E apt install -y python-sphinx
     fi
 fi
 


### PR DESCRIPTION
Required because: https://pxb.cd.percona.com/view/PXB%208.0/job/pxb80-single-platform-run/7/console

```
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/f/freetype/libfreetype6_2.6.1-0.1ubuntu2.4_amd64.deb  404  Not Found [IP: 91.189.88.152 80]

E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Fetched 11.0 MB in 2s (3994 kB/s)
```