### PR TITLE
ENG-935: Update IaC Jenkins Java version to latest and exclude Java from cron updates

### DIFF
--- a/IaC/cloud.cd/JenkinsStack.yml
+++ b/IaC/cloud.cd/JenkinsStack.yml
@@ -534,10 +534,11 @@ Resources:
                   wget -O /etc/yum.repos.d/jenkins.repo https://pkg.jenkins.io/redhat-stable/jenkins.repo
                   rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io.key
                   yum -y update --security
-                  yum -y install java-1.8.0-openjdk-1.8.0.191.b12 jenkins-2.235.5 git yum-cron aws-cli xfsprogs openresty
+                  yum -y install java-1.8.0-openjdk-1.8.0.265.b01 jenkins-2.235.5 git yum-cron aws-cli xfsprogs openresty
 
                   sed -i 's/update_cmd = default/update_cmd = security/' /etc/yum/yum-cron.conf
                   sed -i 's/apply_updates = no/apply_updates = yes/'     /etc/yum/yum-cron.conf
+                  echo "exclude=java*" >> /etc/yum/yum-cron.conf
                   chkconfig yum-cron on
                   service yum-cron start
 

--- a/IaC/fb.cd/JenkinsStack.yml
+++ b/IaC/fb.cd/JenkinsStack.yml
@@ -534,10 +534,11 @@ Resources:
                   wget -O /etc/yum.repos.d/jenkins.repo https://pkg.jenkins.io/redhat-stable/jenkins.repo
                   rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io.key
                   yum -y update --security
-                  yum -y install java-1.8.0-openjdk-1.8.0.191.b12 jenkins-2.249.3 git yum-cron aws-cli xfsprogs openresty
+                  yum -y install java-1.8.0-openjdk-1.8.0.265.b01 jenkins-2.249.3 git yum-cron aws-cli xfsprogs openresty
 
                   sed -i 's/update_cmd = default/update_cmd = security/' /etc/yum/yum-cron.conf
                   sed -i 's/apply_updates = no/apply_updates = yes/'     /etc/yum/yum-cron.conf
+                  echo "exclude=java*" >> /etc/yum/yum-cron.conf
                   chkconfig yum-cron on
                   service yum-cron start
 

--- a/IaC/pg.cd/JenkinsStack.yml
+++ b/IaC/pg.cd/JenkinsStack.yml
@@ -538,10 +538,11 @@ Resources:
                   wget -O /etc/yum.repos.d/jenkins.repo https://pkg.jenkins.io/redhat-stable/jenkins.repo
                   rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io.key
                   yum -y update --security
-                  yum -y install java-1.8.0-openjdk-1.8.0.191.b12 jenkins-2.249.3 git yum-cron aws-cli xfsprogs openresty
+                  yum -y install java-1.8.0-openjdk-1.8.0.265.b01 jenkins-2.249.3 git yum-cron aws-cli xfsprogs openresty
 
                   sed -i 's/update_cmd = default/update_cmd = security/' /etc/yum/yum-cron.conf
                   sed -i 's/apply_updates = no/apply_updates = yes/'     /etc/yum/yum-cron.conf
+                  echo "exclude=java*" >> /etc/yum/yum-cron.conf
                   chkconfig yum-cron on
                   service yum-cron start
 

--- a/IaC/ps.cd/JenkinsStack.yml_ps3
+++ b/IaC/ps.cd/JenkinsStack.yml_ps3
@@ -534,10 +534,11 @@ Resources:
                   wget -O /etc/yum.repos.d/jenkins.repo https://pkg.jenkins.io/redhat-stable/jenkins.repo
                   rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io.key
                   yum -y update --security
-                  yum -y install java-1.8.0-openjdk-1.8.0.191.b12 jenkins-2.249.1 git yum-cron aws-cli xfsprogs openresty
+                  yum -y install java-1.8.0-openjdk-1.8.0.265.b01 jenkins-2.249.1 git yum-cron aws-cli xfsprogs openresty
 
                   sed -i 's/update_cmd = default/update_cmd = security/' /etc/yum/yum-cron.conf
                   sed -i 's/apply_updates = no/apply_updates = yes/'     /etc/yum/yum-cron.conf
+                  echo "exclude=java*" >> /etc/yum/yum-cron.conf
                   chkconfig yum-cron on
                   service yum-cron start
 

--- a/IaC/ps56.cd/JenkinsStack.yml
+++ b/IaC/ps56.cd/JenkinsStack.yml
@@ -537,10 +537,11 @@ Resources:
                   wget -O /etc/yum.repos.d/jenkins.repo https://pkg.jenkins.io/redhat-stable/jenkins.repo
                   rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io.key
                   yum -y update --security
-                  yum -y install java-1.8.0-openjdk jenkins-2.249.1 git yum-cron aws-cli xfsprogs openresty
+                  yum -y install java-1.8.0-openjdk-1.8.0.265.b01 jenkins-2.249.1 git yum-cron aws-cli xfsprogs openresty
 
                   sed -i 's/update_cmd = default/update_cmd = security/' /etc/yum/yum-cron.conf
                   sed -i 's/apply_updates = no/apply_updates = yes/'     /etc/yum/yum-cron.conf
+                  echo "exclude=java*" >> /etc/yum/yum-cron.conf
                   chkconfig yum-cron on
                   service yum-cron start
 

--- a/IaC/ps57.cd/JenkinsStack.yml
+++ b/IaC/ps57.cd/JenkinsStack.yml
@@ -541,10 +541,11 @@ Resources:
                   wget -O /etc/yum.repos.d/jenkins.repo https://pkg.jenkins.io/redhat-stable/jenkins.repo
                   rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io.key
                   yum -y update --security
-                  yum -y install java-1.8.0-openjdk jenkins-2.249.1 git yum-cron aws-cli xfsprogs openresty
+                  yum -y install java-1.8.0-openjdk-1.8.0.265.b01 jenkins-2.249.1 git yum-cron aws-cli xfsprogs openresty
 
                   sed -i 's/update_cmd = default/update_cmd = security/' /etc/yum/yum-cron.conf
                   sed -i 's/apply_updates = no/apply_updates = yes/'     /etc/yum/yum-cron.conf
+                  echo "exclude=java*" >> /etc/yum/yum-cron.conf
                   chkconfig yum-cron on
                   service yum-cron start
 

--- a/IaC/ps80.cd/JenkinsStack.yml
+++ b/IaC/ps80.cd/JenkinsStack.yml
@@ -538,10 +538,11 @@ Resources:
                   wget -O /etc/yum.repos.d/jenkins.repo https://pkg.jenkins.io/redhat-stable/jenkins.repo
                   rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io.key
                   yum -y update --security
-                  yum -y install java-1.8.0-openjdk-1.8.0.191.b12 jenkins-2.249.1 git yum-cron aws-cli xfsprogs openresty
+                  yum -y install java-1.8.0-openjdk-1.8.0.265.b01 jenkins-2.249.1 git yum-cron aws-cli xfsprogs openresty
 
                   sed -i 's/update_cmd = default/update_cmd = security/' /etc/yum/yum-cron.conf
                   sed -i 's/apply_updates = no/apply_updates = yes/'     /etc/yum/yum-cron.conf
+                  echo "exclude=java*" >> /etc/yum/yum-cron.conf
                   chkconfig yum-cron on
                   service yum-cron start
 

--- a/IaC/psmdb.cd/JenkinsStack.yml
+++ b/IaC/psmdb.cd/JenkinsStack.yml
@@ -474,10 +474,11 @@ Resources:
                   rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io.key
                   yum -y update --security
                   amazon-linux-extras install -y nginx1.12
-                  yum -y install java-1.8.0-openjdk jenkins-2.249.3 git yum-cron aws-cli xfsprogs
+                  yum -y install java-1.8.0-openjdk-1.8.0.265.b01 jenkins-2.249.3 git yum-cron aws-cli xfsprogs
 
                   sed -i 's/update_cmd = default/update_cmd = security/' /etc/yum/yum-cron.conf
                   sed -i 's/apply_updates = no/apply_updates = yes/'     /etc/yum/yum-cron.conf
+                  echo "exclude=java*" >> /etc/yum/yum-cron.conf
                   chkconfig yum-cron on
                   service yum-cron start
 

--- a/IaC/pt.cd/JenkinsStack.yml
+++ b/IaC/pt.cd/JenkinsStack.yml
@@ -472,10 +472,11 @@ Resources:
                   rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io.key
                   yum -y update --security
                   amazon-linux-extras install -y nginx1.12
-                  yum -y install java-1.8.0-openjdk jenkins-2.249.3 git yum-cron aws-cli xfsprogs
+                  yum -y install java-1.8.0-openjdk-1.8.0.265.b01 jenkins-2.249.3 git yum-cron aws-cli xfsprogs
 
                   sed -i 's/update_cmd = default/update_cmd = security/' /etc/yum/yum-cron.conf
                   sed -i 's/apply_updates = no/apply_updates = yes/'     /etc/yum/yum-cron.conf
+                  echo "exclude=java*" >> /etc/yum/yum-cron.conf
                   chkconfig yum-cron on
                   service yum-cron start
 

--- a/IaC/pxb.cd/terraform/master_user_data.sh
+++ b/IaC/pxb.cd/terraform/master_user_data.sh
@@ -28,10 +28,11 @@ install_software() {
 
     yum -y update --security
     amazon-linux-extras install -y nginx1.12
-    yum -y install java-1.8.0-openjdk jenkins-2.249.3 git yum-cron aws-cli xfsprogs
+    yum -y install java-1.8.0-openjdk-1.8.0.265.b01 jenkins-2.249.3 git yum-cron aws-cli xfsprogs
 
     sed -i 's/update_cmd = default/update_cmd = security/' /etc/yum/yum-cron.conf
     sed -i 's/apply_updates = no/apply_updates = yes/'     /etc/yum/yum-cron.conf
+    echo "exclude=java*" >> /etc/yum/yum-cron.conf
     chkconfig yum-cron on
     service yum-cron start
 

--- a/IaC/pxc.cd/JenkinsStack.yml
+++ b/IaC/pxc.cd/JenkinsStack.yml
@@ -517,10 +517,11 @@ Resources:
                   wget -O /etc/yum.repos.d/jenkins.repo https://pkg.jenkins.io/redhat-stable/jenkins.repo
                   rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io.key
                   yum -y update --security
-                  yum -y install java-1.8.0-openjdk jenkins-2.249.1 git yum-cron aws-cli xfsprogs openresty
+                  yum -y install java-1.8.0-openjdk-1.8.0.265.b01 jenkins-2.249.1 git yum-cron aws-cli xfsprogs openresty
 
                   sed -i 's/update_cmd = default/update_cmd = security/' /etc/yum/yum-cron.conf
                   sed -i 's/apply_updates = no/apply_updates = yes/'     /etc/yum/yum-cron.conf
+                  echo "exclude=java*" >> /etc/yum/yum-cron.conf
                   chkconfig yum-cron on
                   service yum-cron start
 

--- a/IaC/rel.cd/JenkinsStack.yml
+++ b/IaC/rel.cd/JenkinsStack.yml
@@ -534,10 +534,11 @@ Resources:
                   wget -O /etc/yum.repos.d/jenkins.repo https://pkg.jenkins.io/redhat-stable/jenkins.repo
                   rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io.key
                   yum -y update --security
-                  yum -y install java-1.8.0-openjdk-1.8.0.191.b12 jenkins-2.249.3 git yum-cron aws-cli xfsprogs openresty
+                  yum -y install java-1.8.0-openjdk-1.8.0.265.b01 jenkins-2.249.3 git yum-cron aws-cli xfsprogs openresty
 
                   sed -i 's/update_cmd = default/update_cmd = security/' /etc/yum/yum-cron.conf
                   sed -i 's/apply_updates = no/apply_updates = yes/'     /etc/yum/yum-cron.conf
+                  echo "exclude=java*" >> /etc/yum/yum-cron.conf
                   chkconfig yum-cron on
                   service yum-cron start
 


### PR DESCRIPTION
As discussed on DS, we'll going to exclude Java from autoupdates and updating Java version stacks to latest