### PR TITLE
Remove monitoring test in cloud tests for PSMDBO

### DIFF
--- a/cloud/jenkins/psmdb_operator_aws_openshift-4.groovy
+++ b/cloud/jenkins/psmdb_operator_aws_openshift-4.groovy
@@ -227,7 +227,6 @@ pipeline {
         stage('E2E Basic Tests') {
             steps {
                 runTest('one-pod')
-                runTest('monitoring')
                 runTest('arbiter')
                 runTest('service-per-pod')
                 runTest('liveness')

--- a/cloud/jenkins/psmdb_operator_aws_openshift.groovy
+++ b/cloud/jenkins/psmdb_operator_aws_openshift.groovy
@@ -253,7 +253,6 @@ pipeline {
         stage('E2E Basic Tests') {
             steps {
                 runTest('one-pod')
-                runTest('monitoring')
                 runTest('arbiter')
                 runTest('service-per-pod')
                 runTest('liveness')

--- a/cloud/jenkins/psmdb_operator_eks.groovy
+++ b/cloud/jenkins/psmdb_operator_eks.groovy
@@ -241,7 +241,6 @@ EOF
         stage('E2E Basic Tests') {
             steps {
                 runTest('one-pod')
-                runTest('monitoring')
                 runTest('monitoring-2-0')
                 runTest('arbiter')
                 runTest('service-per-pod')

--- a/cloud/jenkins/psmdb_operator_gke_version.groovy
+++ b/cloud/jenkins/psmdb_operator_gke_version.groovy
@@ -263,7 +263,6 @@ pipeline {
                     steps {
                         CreateCluster('basic')
                         runTest('one-pod', 'basic')
-                        runTest('monitoring', 'basic')
                         runTest('monitoring-2-0', 'basic')
                         runTest('arbiter', 'basic')
                         runTest('service-per-pod', 'basic')

--- a/cloud/jenkins/psmdb_operator_lke_version.groovy
+++ b/cloud/jenkins/psmdb_operator_lke_version.groovy
@@ -265,7 +265,6 @@ pipeline {
                     steps {
                         CreateCluster('basic')
                         runTest('one-pod', 'basic')
-                        runTest('monitoring', 'basic')
                         runTest('monitoring-2-0', 'basic')
                         runTest('arbiter', 'basic')
                         runTest('service-per-pod', 'basic')

--- a/cloud/jenkins/pxc_operator_aws_openshift-4.groovy
+++ b/cloud/jenkins/pxc_operator_aws_openshift-4.groovy
@@ -265,7 +265,6 @@ pipeline {
             steps {
                 runTest('init-deploy')
                 runTest('limits')
-                runTest('monitoring')
                 runTest('affinity')
                 runTest('one-pod')
                 runTest('auto-tuning')

--- a/cloud/jenkins/pxc_operator_aws_openshift.groovy
+++ b/cloud/jenkins/pxc_operator_aws_openshift.groovy
@@ -291,7 +291,6 @@ pipeline {
             steps {
                 runTest('init-deploy')
                 runTest('limits')
-                runTest('monitoring')
                 runTest('affinity')
                 runTest('one-pod')
                 runTest('auto-tuning')

--- a/cloud/jenkins/pxc_operator_eks.groovy
+++ b/cloud/jenkins/pxc_operator_eks.groovy
@@ -281,7 +281,6 @@ EOF
             steps {
                 runTest('init-deploy')
                 runTest('limits')
-                runTest('monitoring')
                 runTest('monitoring-2-0')
                 runTest('affinity')
                 runTest('one-pod')

--- a/cloud/jenkins/pxc_operator_gke_version.groovy
+++ b/cloud/jenkins/pxc_operator_gke_version.groovy
@@ -298,7 +298,6 @@ pipeline {
                         CreateCluster('basic')
                         runTest('init-deploy', 'basic')
                         runTest('limits', 'basic')
-                        runTest('monitoring', 'basic')
                         runTest('monitoring-2-0', 'basic')
                         runTest('affinity', 'basic')
                         runTest('one-pod', 'basic')

--- a/cloud/jenkins/pxc_operator_lke_version.groovy
+++ b/cloud/jenkins/pxc_operator_lke_version.groovy
@@ -293,7 +293,6 @@ pipeline {
                         CreateCluster('basic')
                         runTest('init-deploy', 'basic')
                         runTest('limits', 'basic')
-                        runTest('monitoring', 'basic')
                         runTest('monitoring-2-0', 'basic')
                         runTest('affinity', 'basic')
                         runTest('one-pod', 'basic')


### PR DESCRIPTION
We don't support PMM 1.x any more and this test sometimes gets stuck so this will speed up release testing.