### PR TITLE
PXC-3520: Switch -DWITH_ZLIB to bundled

### DIFF
--- a/pxc/local/build-binary-pxc
+++ b/pxc/local/build-binary-pxc
@@ -164,6 +164,7 @@ pushd ${WORKDIR}
         -DWITH_RE2=bundled \
         -DWITH_LIBEVENT=bundled \
         -DWITH_EDITLINE=bundled \
+        -DWITH_ZLIB=bundled \
         -DWITH_ZSTD=bundled \
         -DBUILD_CONFIG=mysql_release \
         -DFEATURE_SET=community \


### PR DESCRIPTION
Build: https://pxc.cd.percona.com/job/pxc-8.0-pipeline-pxc-3520/1/
It passed the compilation stage with following parameter
I discussed the failure of tests with Kamil and we agreed to open a PR as the main issue was fixed