### PR TITLE
ENG-933: Loop the installation of dependencies on REL.cd apt workers

### DIFF
--- a/IaC/rel.cd/init.groovy.d/cloud.groovy
+++ b/IaC/rel.cd/init.groovy.d/cloud.groovy
@@ -199,7 +199,10 @@ initMap['min-artful-x64'] = '''
         sleep 1
         echo try again
     done
-    sudo apt-get -y install openjdk-8-jre-headless git
+    until sudo apt-get -y install openjdk-8-jre-headless git; do
+        sleep 1
+        echo try again
+    done
     sudo install -o $(id -u -n) -g $(id -g -n) -d /mnt/jenkins
 '''
 initMap['min-buster-x64'] = '''


### PR DESCRIPTION
It's only needed for xenial-x32 AMI, but I think it won't create any downsides for other OS which uses this `initMap`
Tested on REL.cd