### PR TITLE
PMM-7277 change instance type

### DIFF
--- a/pmm/aws-staging-start.groovy
+++ b/pmm/aws-staging-start.groovy
@@ -211,7 +211,7 @@ pipeline {
                                 "EbsOptimized": false,
                                 "ImageId": "ami-15e9c770",
                                 "UserData": "c3VkbyB5dW0gaW5zdGFsbCAteSBqYXZhLTEuOC4wLW9wZW5qZGsKCnN1ZG8gL3Vzci9zYmluL2FsdGVybmF0aXZlcyAtLXNldCBqYXZhIC91c3IvbGliL2p2bS9qcmUtMS44LjAtb3Blbmpkay54ODZfNjQvYmluL2phdmEKCnN1ZG8gL3Vzci9zYmluL2FsdGVybmF0aXZlcyAtLXNldCBqYXZhYyAvdXNyL2xpYi9qdm0vanJlLTEuOC4wLW9wZW5qZGsueDg2XzY0L2Jpbi9qYXZhYwoKc3VkbyB5dW0gcmVtb3ZlIGphdmEtMS43Cg==",
-                                "InstanceType": "t2.large",
+                                "InstanceType": "t3.large",
                                 "KeyName": "jenkins",
                                 "Monitoring": {
                                     "Enabled": false


### PR DESCRIPTION
`t2.large` is having > 20% frequency of interruption, while `t2.large` is < 5%.  All other resource params (memory, CPU) are the same.
So we'll monitor this one to see if it reduces the hassle.

<img width="855" alt="Screenshot 2021-01-06 at 17 53 34" src="https://user-images.githubusercontent.com/81549/103782642-c4874980-5048-11eb-99cc-c55c159d361d.png">
<img width="852" alt="Screenshot 2021-01-06 at 17 53 51" src="https://user-images.githubusercontent.com/81549/103782644-c5b87680-5048-11eb-9f12-5a37064989f3.png">
