### PR TITLE
ENG-966: Rework certbot-auto to certbot for Jenkins

### DIFF
--- a/IaC/cloud.cd/JenkinsStack.yml
+++ b/IaC/cloud.cd/JenkinsStack.yml
@@ -533,18 +533,15 @@ Resources:
                   rpm --import https://openresty.org/package/pubkey.gpg
                   wget -O /etc/yum.repos.d/jenkins.repo https://pkg.jenkins.io/redhat-stable/jenkins.repo
                   rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io.key
+                  amazon-linux-extras install epel -y
                   yum -y update --security
-                  yum -y install java-1.8.0-openjdk-1.8.0.265.b01 jenkins-2.249.3 git yum-cron aws-cli xfsprogs openresty
+                  yum -y install java-1.8.0-openjdk-1.8.0.265.b01 jenkins-2.249.3 certbot git yum-cron aws-cli xfsprogs openresty
 
                   sed -i 's/update_cmd = default/update_cmd = security/' /etc/yum/yum-cron.conf
                   sed -i 's/apply_updates = no/apply_updates = yes/'     /etc/yum/yum-cron.conf
                   echo "exclude=java*" >> /etc/yum/yum-cron.conf
                   chkconfig yum-cron on
                   service yum-cron start
-
-                  wget https://dl.eff.org/certbot-auto -O /opt/certbot-auto
-                  chmod 755 /opt/certbot-auto
-                  touch /etc/redhat-release
               }
 
               volume_state() {
@@ -721,10 +718,10 @@ Resources:
 
               setup_letsencrypt() {
                   install -d /usr/share/nginx/html
-                  /opt/certbot-auto --debug --non-interactive certonly --agree-tos --register-unsafely-without-email --webroot -w /usr/share/nginx/html --keep -d $JENKINS_HOST
+                  certbot --debug --non-interactive certonly --agree-tos --register-unsafely-without-email --webroot -w /usr/share/nginx/html --keep -d $JENKINS_HOST
                   ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/fullchain.pem /etc/nginx/ssl/certificate.crt
                   ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/privkey.pem   /etc/nginx/ssl/certificate.key
-                  printf '#!/bin/sh\n/opt/certbot-auto renew\nservice nginx restart\n' > /etc/cron.daily/certbot
+                  printf '#!/bin/sh\ncertbot renew\nservice openresty reload\n' > /etc/cron.daily/certbot
                   chmod 755 /etc/cron.daily/certbot
                   service openresty stop
                   sleep 2

--- a/IaC/fb.cd/JenkinsStack.yml
+++ b/IaC/fb.cd/JenkinsStack.yml
@@ -533,18 +533,15 @@ Resources:
                   rpm --import https://openresty.org/package/pubkey.gpg
                   wget -O /etc/yum.repos.d/jenkins.repo https://pkg.jenkins.io/redhat-stable/jenkins.repo
                   rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io.key
+                  amazon-linux-extras install epel -y
                   yum -y update --security
-                  yum -y install java-1.8.0-openjdk-1.8.0.265.b01 jenkins-2.249.3 git yum-cron aws-cli xfsprogs openresty
+                  yum -y install java-1.8.0-openjdk-1.8.0.265.b01 jenkins-2.249.3 certbot git yum-cron aws-cli xfsprogs openresty
 
                   sed -i 's/update_cmd = default/update_cmd = security/' /etc/yum/yum-cron.conf
                   sed -i 's/apply_updates = no/apply_updates = yes/'     /etc/yum/yum-cron.conf
                   echo "exclude=java*" >> /etc/yum/yum-cron.conf
                   chkconfig yum-cron on
                   service yum-cron start
-
-                  wget https://dl.eff.org/certbot-auto -O /opt/certbot-auto
-                  chmod 755 /opt/certbot-auto
-                  touch /etc/redhat-release
               }
 
               volume_state() {
@@ -721,10 +718,10 @@ Resources:
 
               setup_letsencrypt() {
                   install -d /usr/share/nginx/html
-                  /opt/certbot-auto --debug --non-interactive certonly --agree-tos --register-unsafely-without-email --webroot -w /usr/share/nginx/html --keep -d $JENKINS_HOST
+                  certbot --debug --non-interactive certonly --agree-tos --register-unsafely-without-email --webroot -w /usr/share/nginx/html --keep -d $JENKINS_HOST
                   ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/fullchain.pem /etc/nginx/ssl/certificate.crt
                   ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/privkey.pem   /etc/nginx/ssl/certificate.key
-                  printf '#!/bin/sh\n/opt/certbot-auto renew\nservice nginx restart\n' > /etc/cron.daily/certbot
+                  printf '#!/bin/sh\ncertbot renew\nservice openresty reload\n' > /etc/cron.daily/certbot
                   chmod 755 /etc/cron.daily/certbot
                   service openresty stop
                   sleep 2

--- a/IaC/pg.cd/JenkinsStack.yml
+++ b/IaC/pg.cd/JenkinsStack.yml
@@ -537,18 +537,15 @@ Resources:
                   rpm --import https://openresty.org/package/pubkey.gpg
                   wget -O /etc/yum.repos.d/jenkins.repo https://pkg.jenkins.io/redhat-stable/jenkins.repo
                   rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io.key
+                  amazon-linux-extras install epel -y
                   yum -y update --security
-                  yum -y install java-1.8.0-openjdk-1.8.0.265.b01 jenkins-2.249.3 git yum-cron aws-cli xfsprogs openresty
+                  yum -y install java-1.8.0-openjdk-1.8.0.265.b01 jenkins-2.249.3 certbot git yum-cron aws-cli xfsprogs openresty
 
                   sed -i 's/update_cmd = default/update_cmd = security/' /etc/yum/yum-cron.conf
                   sed -i 's/apply_updates = no/apply_updates = yes/'     /etc/yum/yum-cron.conf
                   echo "exclude=java*" >> /etc/yum/yum-cron.conf
                   chkconfig yum-cron on
                   service yum-cron start
-
-                  wget https://dl.eff.org/certbot-auto -O /opt/certbot-auto
-                  chmod 755 /opt/certbot-auto
-                  touch /etc/redhat-release
               }
 
               volume_state() {
@@ -726,10 +723,10 @@ Resources:
 
               setup_letsencrypt() {
                   install -d /usr/share/nginx/html
-                  /opt/certbot-auto --debug --non-interactive certonly --agree-tos --register-unsafely-without-email --webroot -w /usr/share/nginx/html --keep -d $JENKINS_HOST
+                  certbot --debug --non-interactive certonly --agree-tos --register-unsafely-without-email --webroot -w /usr/share/nginx/html --keep -d $JENKINS_HOST
                   ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/fullchain.pem /etc/nginx/ssl/certificate.crt
                   ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/privkey.pem   /etc/nginx/ssl/certificate.key
-                  printf '#!/bin/sh\n/opt/certbot-auto renew\nservice nginx restart\n' > /etc/cron.daily/certbot
+                  printf '#!/bin/sh\ncertbot renew\nservice openresty reload\n' > /etc/cron.daily/certbot
                   chmod 755 /etc/cron.daily/certbot
                   service openresty stop
                   sleep 2

--- a/IaC/ps.cd/JenkinsStack.yml_ps3
+++ b/IaC/ps.cd/JenkinsStack.yml_ps3
@@ -533,18 +533,15 @@ Resources:
                   rpm --import https://openresty.org/package/pubkey.gpg
                   wget -O /etc/yum.repos.d/jenkins.repo https://pkg.jenkins.io/redhat-stable/jenkins.repo
                   rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io.key
+                  amazon-linux-extras install epel -y
                   yum -y update --security
-                  yum -y install java-1.8.0-openjdk-1.8.0.265.b01 jenkins-2.249.3 git yum-cron aws-cli xfsprogs openresty
+                  yum -y install java-1.8.0-openjdk-1.8.0.265.b01 jenkins-2.249.3 certbot git yum-cron aws-cli xfsprogs openresty
 
                   sed -i 's/update_cmd = default/update_cmd = security/' /etc/yum/yum-cron.conf
                   sed -i 's/apply_updates = no/apply_updates = yes/'     /etc/yum/yum-cron.conf
                   echo "exclude=java*" >> /etc/yum/yum-cron.conf
                   chkconfig yum-cron on
                   service yum-cron start
-
-                  wget https://dl.eff.org/certbot-auto -O /opt/certbot-auto
-                  chmod 755 /opt/certbot-auto
-                  touch /etc/redhat-release
               }
 
               volume_state() {
@@ -721,10 +718,10 @@ Resources:
 
               setup_letsencrypt() {
                   install -d /usr/share/nginx/html
-                  /opt/certbot-auto --debug --non-interactive certonly --agree-tos --register-unsafely-without-email --webroot -w /usr/share/nginx/html --keep -d $JENKINS_HOST
+                  certbot --debug --non-interactive certonly --agree-tos --register-unsafely-without-email --webroot -w /usr/share/nginx/html --keep -d $JENKINS_HOST
                   ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/fullchain.pem /etc/nginx/ssl/certificate.crt
                   ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/privkey.pem   /etc/nginx/ssl/certificate.key
-                  printf '#!/bin/sh\n/opt/certbot-auto renew\nservice nginx restart\n' > /etc/cron.daily/certbot
+                  printf '#!/bin/sh\ncertbot renew\nservice openresty reload\n' > /etc/cron.daily/certbot
                   chmod 755 /etc/cron.daily/certbot
                   service openresty stop
                   sleep 2

--- a/IaC/ps56.cd/JenkinsStack.yml
+++ b/IaC/ps56.cd/JenkinsStack.yml
@@ -536,18 +536,15 @@ Resources:
                   rpm --import https://openresty.org/package/pubkey.gpg
                   wget -O /etc/yum.repos.d/jenkins.repo https://pkg.jenkins.io/redhat-stable/jenkins.repo
                   rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io.key
+                  amazon-linux-extras install epel -y
                   yum -y update --security
-                  yum -y install java-1.8.0-openjdk-1.8.0.265.b01 jenkins-2.249.3 git yum-cron aws-cli xfsprogs openresty
+                  yum -y install java-1.8.0-openjdk-1.8.0.265.b01 jenkins-2.249.3 certbot git yum-cron aws-cli xfsprogs openresty
 
                   sed -i 's/update_cmd = default/update_cmd = security/' /etc/yum/yum-cron.conf
                   sed -i 's/apply_updates = no/apply_updates = yes/'     /etc/yum/yum-cron.conf
                   echo "exclude=java*" >> /etc/yum/yum-cron.conf
                   chkconfig yum-cron on
                   service yum-cron start
-
-                  wget https://dl.eff.org/certbot-auto -O /opt/certbot-auto
-                  chmod 755 /opt/certbot-auto
-                  touch /etc/redhat-release
               }
 
               volume_state() {
@@ -724,10 +721,10 @@ Resources:
 
               setup_letsencrypt() {
                   install -d /usr/share/nginx/html
-                  /opt/certbot-auto --debug --non-interactive certonly --agree-tos --register-unsafely-without-email --webroot -w /usr/share/nginx/html --keep -d $JENKINS_HOST
+                  certbot --debug --non-interactive certonly --agree-tos --register-unsafely-without-email --webroot -w /usr/share/nginx/html --keep -d $JENKINS_HOST
                   ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/fullchain.pem /etc/nginx/ssl/certificate.crt
                   ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/privkey.pem   /etc/nginx/ssl/certificate.key
-                  printf '#!/bin/sh\n/opt/certbot-auto renew\nservice nginx restart\n' > /etc/cron.daily/certbot
+                  printf '#!/bin/sh\ncertbot renew\nservice openresty reload\n' > /etc/cron.daily/certbot
                   chmod 755 /etc/cron.daily/certbot
                   service openresty stop
                   sleep 2

--- a/IaC/ps57.cd/JenkinsStack.yml
+++ b/IaC/ps57.cd/JenkinsStack.yml
@@ -540,18 +540,15 @@ Resources:
                   rpm --import https://openresty.org/package/pubkey.gpg
                   wget -O /etc/yum.repos.d/jenkins.repo https://pkg.jenkins.io/redhat-stable/jenkins.repo
                   rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io.key
+                  amazon-linux-extras install epel -y
                   yum -y update --security
-                  yum -y install java-1.8.0-openjdk-1.8.0.265.b01 jenkins-2.249.3 git yum-cron aws-cli xfsprogs openresty
+                  yum -y install java-1.8.0-openjdk-1.8.0.265.b01 jenkins-2.249.3 certbot git yum-cron aws-cli xfsprogs openresty
 
                   sed -i 's/update_cmd = default/update_cmd = security/' /etc/yum/yum-cron.conf
                   sed -i 's/apply_updates = no/apply_updates = yes/'     /etc/yum/yum-cron.conf
                   echo "exclude=java*" >> /etc/yum/yum-cron.conf
                   chkconfig yum-cron on
                   service yum-cron start
-
-                  wget https://dl.eff.org/certbot-auto -O /opt/certbot-auto
-                  chmod 755 /opt/certbot-auto
-                  touch /etc/redhat-release
               }
 
               volume_state() {
@@ -728,10 +725,10 @@ Resources:
 
               setup_letsencrypt() {
                   install -d /usr/share/nginx/html
-                  /opt/certbot-auto --debug --non-interactive certonly --agree-tos --register-unsafely-without-email --webroot -w /usr/share/nginx/html --keep -d $JENKINS_HOST
+                  certbot --debug --non-interactive certonly --agree-tos --register-unsafely-without-email --webroot -w /usr/share/nginx/html --keep -d $JENKINS_HOST
                   ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/fullchain.pem /etc/nginx/ssl/certificate.crt
                   ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/privkey.pem   /etc/nginx/ssl/certificate.key
-                  printf '#!/bin/sh\n/opt/certbot-auto renew\nservice nginx restart\n' > /etc/cron.daily/certbot
+                  printf '#!/bin/sh\ncertbot renew\nservice openresty reload\n' > /etc/cron.daily/certbot
                   chmod 755 /etc/cron.daily/certbot
                   service openresty stop
                   sleep 2

--- a/IaC/ps80.cd/JenkinsStack.yml
+++ b/IaC/ps80.cd/JenkinsStack.yml
@@ -537,18 +537,15 @@ Resources:
                   rpm --import https://openresty.org/package/pubkey.gpg
                   wget -O /etc/yum.repos.d/jenkins.repo https://pkg.jenkins.io/redhat-stable/jenkins.repo
                   rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io.key
+                  amazon-linux-extras install epel -y
                   yum -y update --security
-                  yum -y install java-1.8.0-openjdk-1.8.0.265.b01 jenkins-2.249.3 git yum-cron aws-cli xfsprogs openresty
+                  yum -y install java-1.8.0-openjdk-1.8.0.265.b01 jenkins-2.249.3 certbot git yum-cron aws-cli xfsprogs openresty
 
                   sed -i 's/update_cmd = default/update_cmd = security/' /etc/yum/yum-cron.conf
                   sed -i 's/apply_updates = no/apply_updates = yes/'     /etc/yum/yum-cron.conf
                   echo "exclude=java*" >> /etc/yum/yum-cron.conf
                   chkconfig yum-cron on
                   service yum-cron start
-
-                  wget https://dl.eff.org/certbot-auto -O /opt/certbot-auto
-                  chmod 755 /opt/certbot-auto
-                  touch /etc/redhat-release
               }
 
               volume_state() {
@@ -725,10 +722,10 @@ Resources:
 
               setup_letsencrypt() {
                   install -d /usr/share/nginx/html
-                  /opt/certbot-auto --debug --non-interactive certonly --agree-tos --register-unsafely-without-email --webroot -w /usr/share/nginx/html --keep -d $JENKINS_HOST
+                  certbot --debug --non-interactive certonly --agree-tos --register-unsafely-without-email --webroot -w /usr/share/nginx/html --keep -d $JENKINS_HOST
                   ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/fullchain.pem /etc/nginx/ssl/certificate.crt
                   ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/privkey.pem   /etc/nginx/ssl/certificate.key
-                  printf '#!/bin/sh\n/opt/certbot-auto renew\nservice nginx restart\n' > /etc/cron.daily/certbot
+                  printf '#!/bin/sh\ncertbot renew\nservice openresty reload\n' > /etc/cron.daily/certbot
                   chmod 755 /etc/cron.daily/certbot
                   service openresty stop
                   sleep 2

--- a/IaC/psmdb.cd/JenkinsStack.yml
+++ b/IaC/psmdb.cd/JenkinsStack.yml
@@ -472,19 +472,16 @@ Resources:
 
                   wget -O /etc/yum.repos.d/jenkins.repo https://pkg.jenkins.io/redhat-stable/jenkins.repo
                   rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io.key
+                  amazon-linux-extras install epel -y
                   yum -y update --security
                   amazon-linux-extras install -y nginx1.12
-                  yum -y install java-1.8.0-openjdk-1.8.0.265.b01 jenkins-2.249.3 git yum-cron aws-cli xfsprogs
+                  yum -y install java-1.8.0-openjdk-1.8.0.265.b01 jenkins-2.249.3 certbot git yum-cron aws-cli xfsprogs
 
                   sed -i 's/update_cmd = default/update_cmd = security/' /etc/yum/yum-cron.conf
                   sed -i 's/apply_updates = no/apply_updates = yes/'     /etc/yum/yum-cron.conf
                   echo "exclude=java*" >> /etc/yum/yum-cron.conf
                   chkconfig yum-cron on
                   service yum-cron start
-
-                  wget https://dl.eff.org/certbot-auto -O /opt/certbot-auto
-                  chmod 755 /opt/certbot-auto
-                  touch /etc/redhat-release
               }
 
               volume_state() {
@@ -639,10 +636,10 @@ Resources:
               }
 
               setup_letsencrypt() {
-                  /opt/certbot-auto --debug --non-interactive certonly --agree-tos --register-unsafely-without-email --webroot -w /usr/share/nginx/html --keep -d $JENKINS_HOST
+                  certbot --debug --non-interactive certonly --agree-tos --register-unsafely-without-email --webroot -w /usr/share/nginx/html --keep -d $JENKINS_HOST
                   ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/fullchain.pem /etc/nginx/ssl/certificate.crt
                   ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/privkey.pem   /etc/nginx/ssl/certificate.key
-                  printf '#!/bin/sh\n/opt/certbot-auto renew\nservice nginx restart\n' > /etc/cron.daily/certbot
+                  printf '#!/bin/sh\ncertbot renew\nservice nginx restart\n' > /etc/cron.daily/certbot
                   chmod 755 /etc/cron.daily/certbot
                   service nginx stop
                   sleep 2

--- a/IaC/pt.cd/JenkinsStack.yml
+++ b/IaC/pt.cd/JenkinsStack.yml
@@ -470,19 +470,16 @@ Resources:
 
                   wget -O /etc/yum.repos.d/jenkins.repo https://pkg.jenkins.io/redhat-stable/jenkins.repo
                   rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io.key
+                  amazon-linux-extras install epel -y
                   yum -y update --security
                   amazon-linux-extras install -y nginx1.12
-                  yum -y install java-1.8.0-openjdk-1.8.0.265.b01 jenkins-2.249.3 git yum-cron aws-cli xfsprogs
+                  yum -y install java-1.8.0-openjdk-1.8.0.265.b01 jenkins-2.249.3 certbot git yum-cron aws-cli xfsprogs
 
                   sed -i 's/update_cmd = default/update_cmd = security/' /etc/yum/yum-cron.conf
                   sed -i 's/apply_updates = no/apply_updates = yes/'     /etc/yum/yum-cron.conf
                   echo "exclude=java*" >> /etc/yum/yum-cron.conf
                   chkconfig yum-cron on
                   service yum-cron start
-
-                  wget https://dl.eff.org/certbot-auto -O /opt/certbot-auto
-                  chmod 755 /opt/certbot-auto
-                  touch /etc/redhat-release
               }
 
               volume_state() {
@@ -637,10 +634,10 @@ Resources:
               }
 
               setup_letsencrypt() {
-                  /opt/certbot-auto --debug --non-interactive certonly --agree-tos --register-unsafely-without-email --webroot -w /usr/share/nginx/html --keep -d $JENKINS_HOST
+                  certbot --debug --non-interactive certonly --agree-tos --register-unsafely-without-email --webroot -w /usr/share/nginx/html --keep -d $JENKINS_HOST
                   ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/fullchain.pem /etc/nginx/ssl/certificate.crt
                   ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/privkey.pem   /etc/nginx/ssl/certificate.key
-                  printf '#!/bin/sh\n/opt/certbot-auto renew\nservice nginx restart\n' > /etc/cron.daily/certbot
+                  printf '#!/bin/sh\ncertbot renew\nservice nginx restart\n' > /etc/cron.daily/certbot
                   chmod 755 /etc/cron.daily/certbot
                   service nginx stop
                   sleep 2

--- a/IaC/pxb.cd/terraform/master_user_data.sh
+++ b/IaC/pxb.cd/terraform/master_user_data.sh
@@ -28,17 +28,14 @@ install_software() {
 
     yum -y update --security
     amazon-linux-extras install -y nginx1.12
-    yum -y install java-1.8.0-openjdk-1.8.0.265.b01 jenkins-2.249.3 git yum-cron aws-cli xfsprogs
+    amazon-linux-extras install -y epel
+    yum -y install java-1.8.0-openjdk-1.8.0.265.b01 jenkins-2.249.3 certbot git yum-cron aws-cli xfsprogs
 
     sed -i 's/update_cmd = default/update_cmd = security/' /etc/yum/yum-cron.conf
     sed -i 's/apply_updates = no/apply_updates = yes/'     /etc/yum/yum-cron.conf
     echo "exclude=java*" >> /etc/yum/yum-cron.conf
     chkconfig yum-cron on
     service yum-cron start
-
-    wget https://dl.eff.org/certbot-auto -O /opt/certbot-auto
-    chmod 755 /opt/certbot-auto
-    touch /etc/redhat-release
 }
 
 volume_state() {
@@ -191,10 +188,10 @@ setup_nginx() {
 }
 
 setup_letsencrypt() {
-    /opt/certbot-auto --debug --non-interactive certonly --agree-tos --register-unsafely-without-email --webroot -w /usr/share/nginx/html --keep -d $JENKINS_HOST
+    certbot --debug --non-interactive certonly --agree-tos --register-unsafely-without-email --webroot -w /usr/share/nginx/html --keep -d $JENKINS_HOST
     ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/fullchain.pem /etc/nginx/ssl/certificate.crt
     ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/privkey.pem   /etc/nginx/ssl/certificate.key
-    printf '#!/bin/sh\n/opt/certbot-auto renew\nservice nginx restart\n' > /etc/cron.daily/certbot
+    printf '#!/bin/sh\ncertbot renew\nservice nginx restart\n' > /etc/cron.daily/certbot
     chmod 755 /etc/cron.daily/certbot
     service nginx stop
     sleep 2

--- a/IaC/pxc.cd/JenkinsStack.yml
+++ b/IaC/pxc.cd/JenkinsStack.yml
@@ -516,18 +516,15 @@ Resources:
                   rpm --import https://openresty.org/package/pubkey.gpg
                   wget -O /etc/yum.repos.d/jenkins.repo https://pkg.jenkins.io/redhat-stable/jenkins.repo
                   rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io.key
+                  amazon-linux-extras install epel -y
                   yum -y update --security
-                  yum -y install java-1.8.0-openjdk-1.8.0.265.b01 jenkins-2.249.3 git yum-cron aws-cli xfsprogs openresty
+                  yum -y install java-1.8.0-openjdk-1.8.0.265.b01 jenkins-2.249.3 certbot git yum-cron aws-cli xfsprogs openresty
 
                   sed -i 's/update_cmd = default/update_cmd = security/' /etc/yum/yum-cron.conf
                   sed -i 's/apply_updates = no/apply_updates = yes/'     /etc/yum/yum-cron.conf
                   echo "exclude=java*" >> /etc/yum/yum-cron.conf
                   chkconfig yum-cron on
                   service yum-cron start
-
-                  wget https://dl.eff.org/certbot-auto -O /opt/certbot-auto
-                  chmod 755 /opt/certbot-auto
-                  touch /etc/redhat-release
               }
 
               volume_state() {
@@ -708,10 +705,10 @@ Resources:
 
               setup_letsencrypt() {
                   install -d /usr/share/nginx/html
-                  /opt/certbot-auto --debug --non-interactive certonly --agree-tos --register-unsafely-without-email --webroot -w /usr/share/nginx/html --keep -d $JENKINS_HOST
+                  certbot --debug --non-interactive certonly --agree-tos --register-unsafely-without-email --webroot -w /usr/share/nginx/html --keep -d $JENKINS_HOST
                   ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/fullchain.pem /etc/nginx/ssl/certificate.crt
                   ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/privkey.pem   /etc/nginx/ssl/certificate.key
-                  echo '/opt/certbot-auto renew' > /etc/cron.daily/certbot
+                  echo 'certbot renew; service openresty reload' > /etc/cron.daily/certbot
                   chmod 755 /etc/cron.daily/certbot
                   service openresty stop
                   sleep 2

--- a/IaC/pxc.cd/JenkinsStack.yml
+++ b/IaC/pxc.cd/JenkinsStack.yml
@@ -708,7 +708,7 @@ Resources:
                   certbot --debug --non-interactive certonly --agree-tos --register-unsafely-without-email --webroot -w /usr/share/nginx/html --keep -d $JENKINS_HOST
                   ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/fullchain.pem /etc/nginx/ssl/certificate.crt
                   ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/privkey.pem   /etc/nginx/ssl/certificate.key
-                  echo 'certbot renew; service openresty reload' > /etc/cron.daily/certbot
+                  printf '#!/bin/sh\ncertbot renew\nservice openresty reload\n' > /etc/cron.daily/certbot
                   chmod 755 /etc/cron.daily/certbot
                   service openresty stop
                   sleep 2

--- a/IaC/rel.cd/JenkinsStack.yml
+++ b/IaC/rel.cd/JenkinsStack.yml
@@ -533,18 +533,15 @@ Resources:
                   rpm --import https://openresty.org/package/pubkey.gpg
                   wget -O /etc/yum.repos.d/jenkins.repo https://pkg.jenkins.io/redhat-stable/jenkins.repo
                   rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io.key
+                  amazon-linux-extras install epel -y
                   yum -y update --security
-                  yum -y install java-1.8.0-openjdk-1.8.0.265.b01 jenkins-2.249.3 git yum-cron aws-cli xfsprogs openresty
+                  yum -y install java-1.8.0-openjdk-1.8.0.265.b01 jenkins-2.249.3 certbot git yum-cron aws-cli xfsprogs openresty
 
                   sed -i 's/update_cmd = default/update_cmd = security/' /etc/yum/yum-cron.conf
                   sed -i 's/apply_updates = no/apply_updates = yes/'     /etc/yum/yum-cron.conf
                   echo "exclude=java*" >> /etc/yum/yum-cron.conf
                   chkconfig yum-cron on
                   service yum-cron start
-
-                  wget https://dl.eff.org/certbot-auto -O /opt/certbot-auto
-                  chmod 755 /opt/certbot-auto
-                  touch /etc/redhat-release
               }
 
               volume_state() {
@@ -721,10 +718,10 @@ Resources:
 
               setup_letsencrypt() {
                   install -d /usr/share/nginx/html
-                  /opt/certbot-auto --debug --non-interactive certonly --agree-tos --register-unsafely-without-email --webroot -w /usr/share/nginx/html --keep -d $JENKINS_HOST
+                  certbot --debug --non-interactive certonly --agree-tos --register-unsafely-without-email --webroot -w /usr/share/nginx/html --keep -d $JENKINS_HOST
                   ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/fullchain.pem /etc/nginx/ssl/certificate.crt
                   ln -f -s /etc/letsencrypt/live/$JENKINS_HOST/privkey.pem   /etc/nginx/ssl/certificate.key
-                  printf '#!/bin/sh\n/opt/certbot-auto renew\nservice nginx restart\n' > /etc/cron.daily/certbot
+                  printf '#!/bin/sh\ncertbot renew\nservice openresty reload\n' > /etc/cron.daily/certbot
                   chmod 755 /etc/cron.daily/certbot
                   service openresty stop
                   sleep 2


### PR DESCRIPTION
Deployed on rel:
```
/etc/letsencrypt/live/rel.cd.percona.com/fullchain.pem
Your key file has been saved at:
/etc/letsencrypt/live/rel.cd.percona.com/privkey.pem
Your cert will expire on 2021-04-13. To obtain a new or tweaked version of this certificate in the future, simply run certbot again. To non-interactively renew *all* of your certificates, run "certbot renew"
2021-01-13 15:57:26,586:DEBUG:certbot._internal.reporter:Reporting to user: If you like Certbot, please consider supporting our work by:
```