### PR TITLE
New for PMM (all) - copy HTML from publish branch

### DIFF
--- a/pmm/pmm-documentation.groovy
+++ b/pmm/pmm-documentation.groovy
@@ -45,9 +45,6 @@ pipeline {
     post {
         always {
             // stop staging
-            sh '''
-                sudo chmod 777 -R ./
-            '''
             deleteDir()
         }
     }

--- a/pmm/pmm-documentation.groovy
+++ b/pmm/pmm-documentation.groovy
@@ -8,8 +8,8 @@ pipeline {
             description: 'Tag/Branch for build',
             name: 'BRANCH_NAME')
         choice(
-            choices: ['test.percona.com'],
-            description: 'Publish to test server',
+            choices: ['test.percona.com', 'percona.com'],
+            description: 'Publish to test or production server',
             name: 'PUBLISH_TARGET')
     }
     options {

--- a/pmm/pmm-documentation.groovy
+++ b/pmm/pmm-documentation.groovy
@@ -22,8 +22,7 @@ pipeline {
                     sudo chmod 777 -R ./
                 """
                 git poll: false, branch: BRANCH_NAME, url: 'https://github.com/percona/pmm-doc.git'
-            stash name: "html-files", includes: "**"
-
+                stash name: "html-files", includes: "**"
             }
         }
         stage('Doc Publish'){
@@ -44,7 +43,6 @@ pipeline {
     }
     post {
         always {
-            // stop staging
             deleteDir()
         }
     }

--- a/pmm/pmm-documentation.groovy
+++ b/pmm/pmm-documentation.groovy
@@ -1,0 +1,54 @@
+pipeline {
+    agent {
+        label 'micro-amazon'
+    }
+    parameters {
+        string(
+            defaultValue: 'publish',
+            description: 'Tag/Branch for build',
+            name: 'BRANCH_NAME')
+        choice(
+            choices: ['test.percona.com'],
+            description: 'Publish to test server',
+            name: 'PUBLISH_TARGET')
+    }
+    options {
+        buildDiscarder(logRotator(daysToKeepStr: '14', numToKeepStr: '5'))
+    }
+    stages {
+        stage('Checkout') {
+            steps {
+                sh """
+                    sudo chmod 777 -R ./
+                """
+                git poll: false, branch: BRANCH_NAME, url: 'https://github.com/percona/pmm-doc.git'
+            stash name: "html-files", includes: "**"
+
+            }
+        }
+        stage('Doc Publish'){
+            agent {
+                label 'vbox-01.ci.percona.com'
+            }
+            steps{
+                unstash "html-files"
+                withCredentials([sshUserPrivateKey(credentialsId: 'jenkins-deploy', keyFileVariable: 'KEY_PATH', passphraseVariable: '', usernameVariable: 'USER')]) {
+                    sh '''
+                        echo BRANCH=${BRANCH_NAME}
+                        DEST_HOST='docs-rsync-endpoint.int.percona.com'
+                        rsync --delete-before -avzr -O -e "ssh -o StrictHostKeyChecking=no -p2222 -i \${KEY_PATH}" ./* \${USER}@\${DEST_HOST}:/data/websites_data/\${PUBLISH_TARGET}/doc/percona-monitoring-and-management/
+                    '''
+                }
+            }
+        }
+    }
+    post {
+        always {
+            // stop staging
+            sh '''
+                sudo chmod 777 -R ./
+            '''
+            deleteDir()
+        }
+    }
+}

--- a/pmm/pmm-documentation.groovy
+++ b/pmm/pmm-documentation.groovy
@@ -8,6 +8,7 @@ pipeline {
             description: 'Tag/Branch for build',
             name: 'BRANCH_NAME')
         choice(
+            defaultValue: 'test.percona.com',
             choices: ['test.percona.com', 'percona.com'],
             description: 'Publish to test or production server',
             name: 'PUBLISH_TARGET')


### PR DESCRIPTION
New approach to publishing PMM docs.
Assumes completely built HTML is in publish branch.
Copies all to target web host as-is (no Docker or static website build steps).
Testing at https://pmm.cd.percona.com/job/pmm-documentation/