### PR TITLE
PMM-4679 tag pmm2 as latest, remove latest for pmm1

### DIFF
--- a/pmm/pmm-server-release.groovy
+++ b/pmm/pmm-server-release.groovy
@@ -174,20 +174,15 @@ pipeline {
                         docker tag \${DOCKER_VERSION} percona/pmm-server:\${VERSION}
                         docker tag \${DOCKER_VERSION} percona/pmm-server:\${DOCKER_MID}
                         docker tag \${DOCKER_VERSION} percona/pmm-server:\${TOP_VER}
-                        docker tag \${DOCKER_VERSION} percona/pmm-server:latest
                         docker push percona/pmm-server:\${VERSION}
                         docker push percona/pmm-server:\${DOCKER_MID}
                         docker push percona/pmm-server:\${TOP_VER}
-                        if [ \${TOP_VER} = 1 ]; then
-                            docker push percona/pmm-server:latest
-                        fi
+
                         docker save percona/pmm-server:\${VERSION} | xz > pmm-server-\${VERSION}.docker
 
                         docker pull \${DOCKER_CLIENT_VERSION}
                         docker tag \${DOCKER_CLIENT_VERSION} perconalab/pmm-client:\${VERSION}
-                        docker tag \${DOCKER_CLIENT_VERSION} perconalab/pmm-client:latest
                         docker push perconalab/pmm-client:\${VERSION}
-                        docker push perconalab/pmm-client:latest
                         docker save perconalab/pmm-client:\${VERSION} | xz > pmm-client-\${VERSION}.docker
                     "
                 """

--- a/pmm/pmm2-server-release.groovy
+++ b/pmm/pmm2-server-release.groovy
@@ -185,14 +185,21 @@ pipeline {
                         docker push percona/pmm-server:\${DOCKER_MID}
                         docker push percona/pmm-server:\${TOP_VER}
 
+                        docker tag \${DOCKER_VERSION} perconalab/pmm-server:\${VERSION}
+                        docker tag \${DOCKER_VERSION} perconalab/pmm-server:\${DOCKER_MID}
+                        docker tag \${DOCKER_VERSION} perconalab/pmm-server:\${TOP_VER}
+                        docker push perconalab/pmm-server:\${VERSION}
+                        docker push perconalab/pmm-server:\${DOCKER_MID}
+                        docker push perconalab/pmm-server:\${TOP_VER}
+
                         docker save percona/pmm-server:\${VERSION} | xz > pmm-server-\${VERSION}.docker
 
                         # push pmm-client
                         docker pull \${DOCKER_CLIENT_VERSION}
-                        docker tag \${DOCKER_CLIENT_VERSION} perconalab/pmm-client:latest
-                        docker push perconalab/pmm-client:latest
                         docker tag \${DOCKER_CLIENT_VERSION} percona/pmm-client:latest
                         docker push percona/pmm-client:latest
+                        docker tag \${DOCKER_CLIENT_VERSION} perconalab/pmm-client:latest
+                        docker push perconalab/pmm-client:latest
 
                         docker tag \${DOCKER_CLIENT_VERSION} percona/pmm-client:\${VERSION}
                         docker tag \${DOCKER_CLIENT_VERSION} percona/pmm-client:\${DOCKER_MID}

--- a/pmm/pmm2-server-release.groovy
+++ b/pmm/pmm2-server-release.groovy
@@ -172,22 +172,27 @@ pipeline {
                     sg docker -c "
                         set -ex
                         docker pull \${DOCKER_VERSION}
+                        if [ \${TOP_VER} -gt 1 ]; then
+                            docker tag \${DOCKER_VERSION} percona/pmm-server:latest
+                            docker push percona/pmm-server:latest
+                            docker tag \${DOCKER_VERSION} perconalab/pmm-server:latest
+                            docker push perconalab/pmm-server:latest
+                        fi
                         docker tag \${DOCKER_VERSION} percona/pmm-server:\${VERSION}
                         docker tag \${DOCKER_VERSION} percona/pmm-server:\${DOCKER_MID}
                         docker tag \${DOCKER_VERSION} percona/pmm-server:\${TOP_VER}
                         docker push percona/pmm-server:\${VERSION}
                         docker push percona/pmm-server:\${DOCKER_MID}
                         docker push percona/pmm-server:\${TOP_VER}
-                        if [ \${TOP_VER} = 1 ]; then
-                            docker push percona/pmm-server:latest
-                        fi
+
                         docker save percona/pmm-server:\${VERSION} | xz > pmm-server-\${VERSION}.docker
 
                         docker pull \${DOCKER_CLIENT_VERSION}
-
-                        if [ \${TOP_VER} = 1 ]; then
+                        if [ \${TOP_VER} -gt 1 ]; then
                             docker tag \${DOCKER_CLIENT_VERSION} perconalab/pmm-client:latest
                             docker push perconalab/pmm-client:latest
+                            docker tag \${DOCKER_CLIENT_VERSION} percona/pmm-client:latest
+                            docker push percona/pmm-client:latest
                         fi
 
                         docker tag \${DOCKER_CLIENT_VERSION} percona/pmm-client:\${VERSION}

--- a/pmm/pmm2-server-release.groovy
+++ b/pmm/pmm2-server-release.groovy
@@ -175,22 +175,20 @@ pipeline {
                         docker pull \${DOCKER_VERSION}
                         docker tag \${DOCKER_VERSION} percona/pmm-server:latest
                         docker push percona/pmm-server:latest
-                        docker tag \${DOCKER_VERSION} perconalab/pmm-server:latest
-                        docker push perconalab/pmm-server:latest
 
-                        docker tag \${DOCKER_VERSION} percona/pmm-server:\${VERSION}
-                        docker tag \${DOCKER_VERSION} percona/pmm-server:\${DOCKER_MID}
                         docker tag \${DOCKER_VERSION} percona/pmm-server:\${TOP_VER}
-                        docker push percona/pmm-server:\${VERSION}
-                        docker push percona/pmm-server:\${DOCKER_MID}
+                        docker tag \${DOCKER_VERSION} percona/pmm-server:\${DOCKER_MID}
+                        docker tag \${DOCKER_VERSION} percona/pmm-server:\${VERSION}
                         docker push percona/pmm-server:\${TOP_VER}
+                        docker push percona/pmm-server:\${DOCKER_MID}
+                        docker push percona/pmm-server:\${VERSION}
 
-                        docker tag \${DOCKER_VERSION} perconalab/pmm-server:\${VERSION}
-                        docker tag \${DOCKER_VERSION} perconalab/pmm-server:\${DOCKER_MID}
                         docker tag \${DOCKER_VERSION} perconalab/pmm-server:\${TOP_VER}
-                        docker push perconalab/pmm-server:\${VERSION}
-                        docker push perconalab/pmm-server:\${DOCKER_MID}
+                        docker tag \${DOCKER_VERSION} perconalab/pmm-server:\${DOCKER_MID}
+                        docker tag \${DOCKER_VERSION} perconalab/pmm-server:\${VERSION}
                         docker push perconalab/pmm-server:\${TOP_VER}
+                        docker push perconalab/pmm-server:\${DOCKER_MID}
+                        docker push perconalab/pmm-server:\${VERSION}
 
                         docker save percona/pmm-server:\${VERSION} | xz > pmm-server-\${VERSION}.docker
 
@@ -198,22 +196,20 @@ pipeline {
                         docker pull \${DOCKER_CLIENT_VERSION}
                         docker tag \${DOCKER_CLIENT_VERSION} percona/pmm-client:latest
                         docker push percona/pmm-client:latest
-                        docker tag \${DOCKER_CLIENT_VERSION} perconalab/pmm-client:latest
-                        docker push perconalab/pmm-client:latest
 
-                        docker tag \${DOCKER_CLIENT_VERSION} percona/pmm-client:\${VERSION}
-                        docker tag \${DOCKER_CLIENT_VERSION} percona/pmm-client:\${DOCKER_MID}
                         docker tag \${DOCKER_CLIENT_VERSION} percona/pmm-client:\${TOP_VER}
-                        docker push percona/pmm-client:\${VERSION}
-                        docker push percona/pmm-client:\${DOCKER_MID}
+                        docker tag \${DOCKER_CLIENT_VERSION} percona/pmm-client:\${DOCKER_MID}
+                        docker tag \${DOCKER_CLIENT_VERSION} percona/pmm-client:\${VERSION}
                         docker push percona/pmm-client:\${TOP_VER}
+                        docker push percona/pmm-client:\${DOCKER_MID}
+                        docker push percona/pmm-client:\${VERSION}
 
-                        docker tag \${DOCKER_CLIENT_VERSION} perconalab/pmm-client:\${VERSION}
-                        docker tag \${DOCKER_CLIENT_VERSION} perconalab/pmm-client:\${DOCKER_MID}
                         docker tag \${DOCKER_CLIENT_VERSION} perconalab/pmm-client:\${TOP_VER}
-                        docker push perconalab/pmm-client:\${VERSION}
-                        docker push perconalab/pmm-client:\${DOCKER_MID}
+                        docker tag \${DOCKER_CLIENT_VERSION} perconalab/pmm-client:\${DOCKER_MID}
+                        docker tag \${DOCKER_CLIENT_VERSION} perconalab/pmm-client:\${VERSION}
                         docker push perconalab/pmm-client:\${TOP_VER}
+                        docker push perconalab/pmm-client:\${DOCKER_MID}
+                        docker push perconalab/pmm-client:\${VERSION}
 
                         docker save percona/pmm-client:\${VERSION} | xz > pmm-client-\${VERSION}.docker
                     "

--- a/pmm/pmm2-server-release.groovy
+++ b/pmm/pmm2-server-release.groovy
@@ -171,13 +171,13 @@ pipeline {
                     DOCKER_MID="\$TOP_VER.\$MID_VER"
                     sg docker -c "
                         set -ex
+                        # push pmm-server
                         docker pull \${DOCKER_VERSION}
-                        if [ \${TOP_VER} -gt 1 ]; then
-                            docker tag \${DOCKER_VERSION} percona/pmm-server:latest
-                            docker push percona/pmm-server:latest
-                            docker tag \${DOCKER_VERSION} perconalab/pmm-server:latest
-                            docker push perconalab/pmm-server:latest
-                        fi
+                        docker tag \${DOCKER_VERSION} percona/pmm-server:latest
+                        docker push percona/pmm-server:latest
+                        docker tag \${DOCKER_VERSION} perconalab/pmm-server:latest
+                        docker push perconalab/pmm-server:latest
+
                         docker tag \${DOCKER_VERSION} percona/pmm-server:\${VERSION}
                         docker tag \${DOCKER_VERSION} percona/pmm-server:\${DOCKER_MID}
                         docker tag \${DOCKER_VERSION} percona/pmm-server:\${TOP_VER}
@@ -187,13 +187,12 @@ pipeline {
 
                         docker save percona/pmm-server:\${VERSION} | xz > pmm-server-\${VERSION}.docker
 
+                        # push pmm-client
                         docker pull \${DOCKER_CLIENT_VERSION}
-                        if [ \${TOP_VER} -gt 1 ]; then
-                            docker tag \${DOCKER_CLIENT_VERSION} perconalab/pmm-client:latest
-                            docker push perconalab/pmm-client:latest
-                            docker tag \${DOCKER_CLIENT_VERSION} percona/pmm-client:latest
-                            docker push percona/pmm-client:latest
-                        fi
+                        docker tag \${DOCKER_CLIENT_VERSION} perconalab/pmm-client:latest
+                        docker push perconalab/pmm-client:latest
+                        docker tag \${DOCKER_CLIENT_VERSION} percona/pmm-client:latest
+                        docker push percona/pmm-client:latest
 
                         docker tag \${DOCKER_CLIENT_VERSION} percona/pmm-client:\${VERSION}
                         docker tag \${DOCKER_CLIENT_VERSION} percona/pmm-client:\${DOCKER_MID}


### PR DESCRIPTION
- PMM2 server and client docker images get the tag `:latest` by default
- stop tagging PMM1 server and docker images with `:latest` 

DO NOT MERGE! Hold off until the release of v2.15