### PR TITLE
Fix: check if nvm exists, upgrade node to v12.20.1

### DIFF
--- a/pmm/pmm2-testsuite.groovy
+++ b/pmm/pmm2-testsuite.groovy
@@ -134,11 +134,13 @@ pipeline {
                 deleteDir()
                 slackSend channel: '#pmm-ci', color: '#FFFF00', message: "[${JOB_NAME}]: build started - ${BUILD_URL}"
                 sh '''
-                    curl -o - https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
+                    if [ ! -f ~/.nvm/nvm.sh ]; then
+                        curl -o - https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | bash
+                    ]
                     . ~/.nvm/nvm.sh
-                    nvm install 12.14.1
+                    nvm install 12.20.1
                     sudo rm -f /usr/bin/node
-                    sudo ln -s ~/.nvm/versions/node/v12.14.1/bin/node /usr/bin/node
+                    sudo ln -s ~/.nvm/versions/node/v12.20.1/bin/node /usr/bin/node
                     npm install tap-junit
                 '''
             }


### PR DESCRIPTION
The script fails to install nvm because when it already exists (ex: https://pmm.cd.percona.com/job/pmm2-testsuite/4912/console), so we need to perform a check to see if nvm is present.
NodeJS upgraded to latest LTS v12.20.1.