### PR TITLE
Stash specifics; delete before unstashing

### DIFF
--- a/pmm/pmm-documentation.groovy
+++ b/pmm/pmm-documentation.groovy
@@ -34,7 +34,7 @@ pipeline {
                         echo BRANCH=${BRANCH_NAME}
                         ls -l
                         DEST_HOST='docs-rsync-endpoint.int.percona.com'
-                        rsync --delete -vv -azr -O -e "ssh -o StrictHostKeyChecking=no -p2222 -i \${KEY_PATH}" ./* \${USER}@\${DEST_HOST}:/data/websites_data/\${PUBLISH_TARGET}/doc/percona-monitoring-and-management/
+                        rsync --delete -vv -azr -O -e "ssh -o StrictHostKeyChecking=no -p2222 -i \${KEY_PATH}" ./ \${USER}@\${DEST_HOST}:/data/websites_data/\${PUBLISH_TARGET}/doc/percona-monitoring-and-management/
                     '''
                 }
             }

--- a/pmm/pmm-documentation.groovy
+++ b/pmm/pmm-documentation.groovy
@@ -18,11 +18,8 @@ pipeline {
     stages {
         stage('Checkout') {
             steps {
-                sh """
-                    sudo chmod 777 -R ./
-                """
                 git poll: false, branch: BRANCH_NAME, url: 'https://github.com/percona/pmm-doc.git'
-                stash name: "html-files", includes: "**"
+                stash name: "html-files", includes: "1.x/**,2.x/**,versions.json,index.html"
             }
         }
         stage('Doc Publish'){
@@ -30,12 +27,14 @@ pipeline {
                 label 'vbox-01.ci.percona.com'
             }
             steps{
+                deleteDir()
                 unstash "html-files"
                 withCredentials([sshUserPrivateKey(credentialsId: 'jenkins-deploy', keyFileVariable: 'KEY_PATH', passphraseVariable: '', usernameVariable: 'USER')]) {
                     sh '''
                         echo BRANCH=${BRANCH_NAME}
+                        ls -l
                         DEST_HOST='docs-rsync-endpoint.int.percona.com'
-                        rsync --delete-before -avzr -O -e "ssh -o StrictHostKeyChecking=no -p2222 -i \${KEY_PATH}" ./* \${USER}@\${DEST_HOST}:/data/websites_data/\${PUBLISH_TARGET}/doc/percona-monitoring-and-management/
+                        rsync --delete -vv -azr -O -e "ssh -o StrictHostKeyChecking=no -p2222 -i \${KEY_PATH}" ./* \${USER}@\${DEST_HOST}:/data/websites_data/\${PUBLISH_TARGET}/doc/percona-monitoring-and-management/
                     '''
                 }
             }


### PR DESCRIPTION
Changes mainly to eliminate doubt as to why website not being immediately refreshed after rsync.
Changed:
- Remove chmods (I guess not needed as this is just a simple copy of checked out git branch)
- Delete dir before unstashing: Stash was including this repo's files and other miscellaneous rubbish
- ls to see what's actually unstashed
- Stash of specific dirs/files (limits flexibility but will do until this job can be recreated in GHA)
- Change copied path (so rsync deletes EVERYTHING, not just what we copy) - Discovered after looking at web server folder and discovering historical remnants of other rsync's