### PR TITLE
Correct spot instances configuration for ps57

### DIFF
--- a/IaC/ps57.cd/init.groovy.d/cloud.groovy
+++ b/IaC/ps57.cd/init.groovy.d/cloud.groovy
@@ -247,14 +247,14 @@ initMap['min-trusty-x64'] = initMap['min-jessie-x64']
 
 capMap = [:]
 capMap['c4.xlarge']  = '60'
-capMap['m5.xlarge']  = '5'
+capMap['m5.large']  = '5'
 capMap['m4.2xlarge'] = '40'
 capMap['r4.4xlarge'] = '40'
-capMap['c5d.xlarge'] = '10'
+capMap['c5d.xlarge'] = '60'
 
 typeMap = [:]
 typeMap['micro-amazon']      = 'm5.large'
-typeMap['docker']            = 'c4.xlarge'
+typeMap['docker']            = 'c5d.xlarge'
 typeMap['docker-32gb']       = 'm4.2xlarge'
 typeMap['docker2']           = 'r4.4xlarge'
 typeMap['min-centos-7-x64']  = typeMap['docker']


### PR DESCRIPTION
Docker executor was failing due to 5-10% interruption rate
Also, this commit includes yesterday's change of M4Large to M5Large due to interruption rate, is used for micro-amazon executor