### PR TITLE
PXB-2411: Execute lsb_release only on apt systems for PXB 2.4 and 8.0

### DIFF
--- a/pxb/percona-xtrabackup-2.4-template.yml
+++ b/pxb/percona-xtrabackup-2.4-template.yml
@@ -239,9 +239,11 @@
                 fi
             fi
         elif [[ ${xtrabackuptarget} == "galera57" ]] || [[ ${xtrabackuptarget} == "xtradb57" ]]; then
-            if [[ $(lsb_release -sc) == "xenial" ]] && [[ $(uname -m) == "i686" ]]; then
-                    echo "$(uname -m) is not supported for ${xtrabackuptarget} target, this is a stub we decided to implement in PXB-2368"
-                    exit 0
+            if [ -f /usr/bin/apt-get ]; then
+                if [[ $(lsb_release -sc) == "xenial" ]] && [[ $(uname -m) == "i686" ]]; then
+                        echo "$(uname -m) is not supported for ${xtrabackuptarget} target, this is a stub we decided to implement in PXB-2368"
+                        exit 0
+                fi
             fi
         fi
 
@@ -350,8 +352,10 @@
                 fi
             fi
         elif [[ ${xtrabackuptarget} == "galera57" ]] || [[ ${xtrabackuptarget} == "xtradb57" ]]; then
-            if [[ $(lsb_release -sc) == "xenial" ]] && [[ $(uname -m) == "i686" ]]; then
-                unsupported=true
+            if [ -f /usr/bin/apt-get ]; then
+                if [[ $(lsb_release -sc) == "xenial" ]] && [[ $(uname -m) == "i686" ]]; then
+                    unsupported=true
+                fi
             fi
         fi
 

--- a/pxb/percona-xtrabackup-8.0-template.yml
+++ b/pxb/percona-xtrabackup-8.0-template.yml
@@ -220,9 +220,11 @@
         #!/bin/bash -x
 
         if [[ ${xtrabackuptarget} == "galera57" ]] || [[ ${xtrabackuptarget} == "xtradb80" ]]; then
-            if [[ $(lsb_release -sc) == "xenial" ]] && [[ $(uname -m) == "i686" ]]; then
-                    echo "$(uname -m) is not supported for ${xtrabackuptarget} target, this is a stub we decided to implement in PXB-2368"
-                    exit 0
+            if [ -f /usr/bin/apt-get ]; then
+                if [[ $(lsb_release -sc) == "xenial" ]] && [[ $(uname -m) == "i686" ]]; then
+                        echo "$(uname -m) is not supported for ${xtrabackuptarget} target, this is a stub we decided to implement in PXB-2368"
+                        exit 0
+                fi
             fi
         fi
 
@@ -260,8 +262,10 @@
         fi
 
         if [[ ${xtrabackuptarget} == "galera57" ]] || [[ ${xtrabackuptarget} == "xtradb80" ]]; then
-            if [[ $(lsb_release -sc) == "xenial" ]] && [[ $(uname -m) == "i686" ]]; then
-                unsupported=true
+            if [ -f /usr/bin/apt-get ]; then
+                if [[ $(lsb_release -sc) == "xenial" ]] && [[ $(uname -m) == "i686" ]]; then
+                    unsupported=true
+                fi
             fi
         fi
         if [[ ! -z ${unsupported} ]] && [[ ${unsupported} == true ]]; then
@@ -328,8 +332,10 @@
         cd ${XB_TEST_ROOT_DIR}/test
 
         if [[ ${xtrabackuptarget} == "galera57" ]] || [[ ${xtrabackuptarget} == "xtradb80" ]]; then
-            if [[ $(lsb_release -sc) == "xenial" ]] && [[ $(uname -m) == "i686" ]]; then
-                unsupported=true
+            if [ -f /usr/bin/apt-get ]; then
+                if [[ $(lsb_release -sc) == "xenial" ]] && [[ $(uname -m) == "i686" ]]; then
+                    unsupported=true
+                fi
             fi
         fi
         if [[ ! -z ${unsupported} ]] && [[ ${unsupported} == true ]]; then


### PR DESCRIPTION
Builds: https://pxb.cd.percona.com/view/PXB%208.0/job/percona-xtrabackup-8.0-param-medium/23/
Note, centos 8 failed due to https://github.com/percona/percona-server/commit/933b7d8e42381813be3184a76b4308b50aaa7b1e#diff-ceb99f02755875cbbc03fa36029ddc2cad5ae877881f18eced5a9f7dc79ba028 which is not in release yet
