### PR TITLE
Fix Config generation issue with latest minikube version

### DIFF
--- a/pmm/kubernetes-cluster-staging.groovy
+++ b/pmm/kubernetes-cluster-staging.groovy
@@ -127,7 +127,7 @@ pipeline {
                                 set -o errexit
                                 set -o xtrace
                                 sudo yum -y install curl
-                                sudo curl -Lo /usr/local/sbin/minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
+                                sudo curl -Lo /usr/local/sbin/minikube https://github.com/kubernetes/minikube/releases/download/v1.16.0/minikube-linux-amd64
                                 sudo chmod +x /usr/local/sbin/minikube
                                 sudo ln -s /usr/local/sbin/minikube /usr/sbin/minikube
                                 alias kubectl='minikube kubectl --'
@@ -151,6 +151,7 @@ pipeline {
                                 set -o xtrace
                                 export PATH=\$PATH:/usr/sbin
                                 minikube version
+                                rm ~/.kube/config && minikube delete
                                 minikube config set cpus 8
                                 minikube config set memory 29000
                                 minikube config set kubernetes-version 1.16.15

--- a/pmm/kubernetes-cluster-staging.groovy
+++ b/pmm/kubernetes-cluster-staging.groovy
@@ -69,7 +69,7 @@ pipeline {
 
         stage('Run VM') {
             steps {
-                launchSpotInstance('c4.4xlarge', '0.1448', 50)
+                launchSpotInstance('c4.4xlarge', '0.1548', 50)
                 withCredentials([sshUserPrivateKey(credentialsId: 'aws-jenkins', keyFileVariable: 'KEY_PATH', passphraseVariable: '', usernameVariable: 'USER')]) {
                     sh """
                         until ssh -i "${KEY_PATH}" -o ConnectTimeout=1 -o StrictHostKeyChecking=no ${USER}@\$(cat IP) 'java -version; sudo yum install -y java-1.8.0-openjdk; sudo /usr/sbin/alternatives --set java /usr/lib/jvm/jre-1.8.0-openjdk.x86_64/bin/java; java -version;' ; do


### PR DESCRIPTION
To use a fixed version of minikube until we know the latest one works as expected, to avoid errors like the one we get for config generation. 

Tested here: https://pmm.cd.percona.com/view/all/job/kubernetes-cluster-staging-tests/7/console

Please see https://jira.percona.com/browse/PMM-7404 understand the reason to do this. 