### PR TITLE
ENG-977: Correct typo in matrix.groovy for cloud.cd

### DIFF
--- a/IaC/cloud.cd/init.groovy.d/matrix.groovy
+++ b/IaC/cloud.cd/init.groovy.d/matrix.groovy
@@ -146,7 +146,7 @@ authz_strategy_config = [
         'percona': ['Overall Read','Agent Build','Agent Connect','Agent Provision','Job Discover','Job Read','Job Build','Job Cancel','Job Workspace','View Read'],
         'percona*Build Engineers': ['Overall Administer'],
         'percona*iit': ['Overall Administer'],
-        'percona*cloud-team': ['Overall Read','Agent Build','Agent Configure','Agent Connect','Agent Create','Agent Delete','Agent Disconnect','Job Build','Job Cancel','Job Configure','Job Create','Job Delete','Job Discover','Job Move','Job Read','Job Workspace','Run Delete','Run Update','Run Replay','View Configure','View Create','View Delete','View Read','SCM Tag'],
+        'percona*Cloud team': ['Overall Read','Agent Build','Agent Configure','Agent Connect','Agent Create','Agent Delete','Agent Disconnect','Job Build','Job Cancel','Job Configure','Job Create','Job Delete','Job Discover','Job Move','Job Read','Job Workspace','Run Delete','Run Update','Run Replay','View Configure','View Create','View Delete','View Read','SCM Tag'],
         'percona*ext-jazzserve': ['Overall Read','Agent Build','Agent Connect','Agent Provision','Job Discover','Job Read','Job Build','Job Cancel','Job Workspace','View Read'],     
     ]
 ]


### PR DESCRIPTION
Corrected typo for proper permissions on cloud