### PR TITLE
Remove rs-shard-migration test for PSMDBO minikube

### DIFF
--- a/cloud/jenkins/psmdb_operator_minikube.groovy
+++ b/cloud/jenkins/psmdb_operator_minikube.groovy
@@ -234,7 +234,6 @@ pipeline {
                     runTest('smart-update')
                     runTest('version-service')
                     runTest('users')
-                    runTest('rs-shard-migration')
                     runTest('data-sharded')
             }
             post {


### PR DESCRIPTION
This test cannot work because of antiAffinity on minikube.