### PR TITLE
PXC-3558: Add ability to checkout latest PXB80 without specifying

### DIFF
--- a/pxc/jenkins/pxc80-pipeline.groovy
+++ b/pxc/jenkins/pxc80-pipeline.groovy
@@ -22,6 +22,10 @@ pipeline {
             description: 'Tag/Branch for PXB80 repository',
             name: 'PXB80_BRANCH',
             trim: true)
+        booleanParam(
+            defaultValue: false, 
+            description: 'If checked, the PXB80_BRANCH will be ignored and latest available version will be used',
+            name: 'PXB80_LATEST') 
         string(
             defaultValue: 'https://github.com/percona/percona-xtrabackup',
             description: 'URL to PXB24 repository',

--- a/pxc/jenkins/pxc80-pipeline.yml
+++ b/pxc/jenkins/pxc80-pipeline.yml
@@ -30,6 +30,10 @@
         name: PXB80_BRANCH
         default: percona-xtrabackup-8.0.12
         description: Tag/Branch for PXB80 repository
+    - bool:
+        name: PXB80_LATEST
+        default: false
+        description: "If checked, the PXB80_BRANCH will be ignored and latest available version will be used"
     - string:
         name: PXB24_REPO
         default: https://github.com/percona/percona-xtrabackup

--- a/pxc/local/checkout
+++ b/pxc/local/checkout
@@ -115,6 +115,10 @@ if [ "$SOURCE_NAME" == 'PXB80' -o "$SOURCE_NAME" == 'ALL' ]; then
         git reset --hard
         git clean -xdf
 
+        if [[ ${PXB80_LATEST} == "true" ]]; then
+            git checkout 8.0
+            unset PXB80_BRANCH && PXB80_BRANCH="$(git describe --tags --abbrev=0)"
+        fi
         if [ -n "${PXB80_BRANCH}" ]; then
             git checkout "${PXB80_BRANCH}" -b "tag-${PXB80_BRANCH}"
         fi


### PR DESCRIPTION
Builds: https://pxc.cd.percona.com/job/pxc-8.0-pipeline-pxc-3558/2/
(Please ignore failed tests, I've disabled them for this run, pay attention to tag which was used for PXB80 and how it was overwritten)