### PR TITLE
PXB-2382: Correct junit2subunitxml errors by executing it by python2

### DIFF
--- a/pxb/jenkins/test-binary-pxb80
+++ b/pxb/jenkins/test-binary-pxb80
@@ -67,5 +67,5 @@ fi
 ./run.sh ${XBTR_ARGS} -f | tee ${WORKSPACE}/xbtr.output
 sudo cp -r ${TEST_DIR}/results ${WORKSPACE}
 cp test_results.subunit ${WORKSPACE}
-cat test_results.subunit | PYTHONPATH=./python:/usr/local/lib/python:$PYTHONPATH ./subunit2junitxml > ${WORKSPACE}/junit.xml || true
+cat test_results.subunit | PYTHONPATH=./python:/usr/local/lib/python:$PYTHONPATH python2 subunit2junitxml > ${WORKSPACE}/junit.xml || true
 exit $status


### PR DESCRIPTION
Build:  https://pxb.cd.percona.com/job/pxb80-single-platform-run-illiatest/CMAKE_BUILD_TYPE=RelWithDebInfo/

This script, requires to be executed by Python2, but sphinx on focal can be executed by python3 only
