### PR TITLE
ENG-981: Correct Jenkins warnings on cloud init

### DIFF
--- a/IaC/cloud.cd/init.groovy.d/cloud.groovy
+++ b/IaC/cloud.cd/init.groovy.d/cloud.groovy
@@ -99,7 +99,7 @@ initMap['docker'] = '''
     sudo yum -y remove java-1.7.0-openjdk
 
     if ! $(aws --version | grep -q 'aws-cli/2'); then
-        find /tmp -maxdepth 1 -name "*aws*" -exec rm -rf {} \;
+        find /tmp -maxdepth 1 -name "*aws*" -exec rm -rf {} +
         
         until curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip"; do
             sleep 1

--- a/IaC/fb.cd/init.groovy.d/cloud.groovy
+++ b/IaC/fb.cd/init.groovy.d/cloud.groovy
@@ -76,7 +76,7 @@ initMap['docker'] = '''
     sudo yum -y remove java-1.7.0-openjdk
 
     if ! $(aws --version | grep -q 'aws-cli/2'); then
-        find /tmp -maxdepth 1 -name "*aws*" -exec rm -rf {} \;
+        find /tmp -maxdepth 1 -name "*aws*" -exec rm -rf {} +
         
         until curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip"; do
             sleep 1

--- a/IaC/ps.cd/init.groovy.d/cloud-ps3.groovy
+++ b/IaC/ps.cd/init.groovy.d/cloud-ps3.groovy
@@ -109,7 +109,7 @@ initMap['docker'] = '''
     sudo yum -y remove java-1.7.0-openjdk
 
     if ! $(aws --version | grep -q 'aws-cli/2'); then
-        find /tmp -maxdepth 1 -name "*aws*" -exec rm -rf {} \;
+        find /tmp -maxdepth 1 -name "*aws*" -exec rm -rf {} +
 
         until curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip"; do
             sleep 1

--- a/IaC/ps56.cd/init.groovy.d/cloud.groovy
+++ b/IaC/ps56.cd/init.groovy.d/cloud.groovy
@@ -110,7 +110,7 @@ initMap['docker'] = '''
     sudo yum -y remove java-1.7.0-openjdk
 
     if ! $(aws --version | grep -q 'aws-cli/2'); then
-        find /tmp -maxdepth 1 -name "*aws*" -exec rm -rf {} \;
+        find /tmp -maxdepth 1 -name "*aws*" -exec rm -rf {} +
 
         until curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip"; do
             sleep 1

--- a/IaC/ps57.cd/init.groovy.d/cloud.groovy
+++ b/IaC/ps57.cd/init.groovy.d/cloud.groovy
@@ -124,7 +124,7 @@ initMap['docker'] = '''
     sudo yum -y remove java-1.7.0-openjdk
 
     if ! $(aws --version | grep -q 'aws-cli/2'); then
-        find /tmp -maxdepth 1 -name "*aws*" -exec rm -rf {} \;
+        find /tmp -maxdepth 1 -name "*aws*" -exec rm -rf {} +
 
         until curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip"; do
             sleep 1

--- a/IaC/ps80.cd/init.groovy.d/cloud.groovy
+++ b/IaC/ps80.cd/init.groovy.d/cloud.groovy
@@ -156,7 +156,7 @@ initMap['docker'] = '''
     sudo yum -y remove java-1.7.0-openjdk
 
     if ! $(aws --version | grep -q 'aws-cli/2'); then
-        find /tmp -maxdepth 1 -name "*aws*" -exec rm -rf {} \;
+        find /tmp -maxdepth 1 -name "*aws*" -exec rm -rf {} +
 
         until curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip"; do
             sleep 1

--- a/IaC/pxb.cd/init.groovy.d/cloud.groovy
+++ b/IaC/pxb.cd/init.groovy.d/cloud.groovy
@@ -81,7 +81,7 @@ initMap['docker'] = '''
     sudo yum -y remove java-1.7.0-openjdk
 
     if ! $(aws --version | grep -q 'aws-cli/2'); then
-        find /tmp -maxdepth 1 -name "*aws*" -exec rm -rf {} \;
+        find /tmp -maxdepth 1 -name "*aws*" -exec rm -rf {} +
 
         until curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip"; do
             sleep 1

--- a/IaC/pxc.cd/init.groovy.d/cloud.groovy
+++ b/IaC/pxc.cd/init.groovy.d/cloud.groovy
@@ -113,7 +113,7 @@ initMap['docker'] = '''
     sudo yum -y remove java-1.7.0-openjdk
 
     if ! $(aws --version | grep -q 'aws-cli/2'); then
-        find /tmp -maxdepth 1 -name "*aws*" -exec rm -rf {} \;
+        find /tmp -maxdepth 1 -name "*aws*" -exec rm -rf {} +
 
         until curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip"; do
             sleep 1

--- a/IaC/rel.cd/init.groovy.d/cloud.groovy
+++ b/IaC/rel.cd/init.groovy.d/cloud.groovy
@@ -127,7 +127,7 @@ initMap['docker'] = '''
     sudo yum -y remove java-1.7.0-openjdk
 
     if ! $(aws --version | grep -q 'aws-cli/2'); then
-        find /tmp -maxdepth 1 -name "*aws*" -exec rm -rf {} \;
+        find /tmp -maxdepth 1 -name "*aws*" -exec rm -rf {} +
 
         until curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip"; do
             sleep 1


### PR DESCRIPTION
```
2021-03-04 12:02:53.124+0000 [id=31]	WARNING	j.util.groovy.GroovyHookScript#execute: Failed to run script file:/mnt/pxb.cd.percona.com/init.groovy.d/cloud.groovy
org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
/mnt/pxb.cd.percona.com/init.groovy.d/cloud.groovy: 82: unexpected char: '\' @ line 82, column 61.
   -name "*aws*" -exec rm -rf {} \;
                                 ^
```

On manual deploy it works, but from config side after reboot it can't load it, appeared on rel and pxb