### PR TITLE
ENG-983: Add needed Lua module for GSuite OAuth and clean up

### DIFF
--- a/IaC/cloud.cd/JenkinsStack.yml
+++ b/IaC/cloud.cd/JenkinsStack.yml
@@ -665,12 +665,6 @@ Resources:
               			  ssl_trusted_certificate     /etc/nginx/ssl/ca-certs.pem;
               			  ssl_dhparam                 /etc/nginx/ssl/dhparam.pem;
 
-              			  set \$ngo_client_id          "<-- SETUP MANUALLY -->";
-              			  set \$ngo_client_secret      "<-- SETUP MANUALLY -->";
-              			  set \$ngo_token_secret       "<-- SETUP MANUALLY -->";
-              			  set \$ngo_domain             percona.com;
-              			  set \$ngo_secure_cookies     true;
-              			  set \$ngo_http_only_cookies  true;
               			  resolver                    8.8.8.8 ipv6=off;
               			  lua_ssl_trusted_certificate /etc/pki/tls/certs/ca-bundle.crt;
               			  lua_ssl_verify_depth        3;
@@ -697,14 +691,6 @@ Resources:
 
                   ln -s /mnt/$JENKINS_HOST/ssl/nginx.conf /usr/local/openresty/nginx/conf/jenkins.conf
                   sed -i'' -e 's/listen/#listen/; s/mime.types/jenkins.conf/' /usr/local/openresty/nginx/conf/nginx.conf
-
-                  wget -O /usr/local/openresty/lualib/resty/http.lua \
-                    https://raw.githubusercontent.com/pintsized/lua-resty-http/master/lib/resty/http.lua
-                  wget -O /usr/local/openresty/lualib/resty/http_headers.lua \
-                    https://raw.githubusercontent.com/pintsized/lua-resty-http/master/lib/resty/http_headers.lua
-                  wget -O /mnt/$JENKINS_HOST/nginx-google-oauth.lua \
-                    https://raw.githubusercontent.com/cloudflare/nginx-google-oauth/master/access.lua
-
                   systemctl enable --now openresty
               }
 

--- a/IaC/fb.cd/JenkinsStack.yml
+++ b/IaC/fb.cd/JenkinsStack.yml
@@ -703,6 +703,8 @@ Resources:
                     https://raw.githubusercontent.com/pintsized/lua-resty-http/master/lib/resty/http.lua
                   wget -O /usr/local/openresty/lualib/resty/http_headers.lua \
                     https://raw.githubusercontent.com/pintsized/lua-resty-http/master/lib/resty/http_headers.lua
+                  wget -O /usr/local/openresty/lualib/resty/http_connect.lua \
+                    https://raw.githubusercontent.com/pintsized/lua-resty-http/master/lib/resty/http_connect.lua 
                   wget -O /mnt/$JENKINS_HOST/nginx-google-oauth.lua \
                     https://raw.githubusercontent.com/cloudflare/nginx-google-oauth/master/access.lua
 

--- a/IaC/pg.cd/JenkinsStack.yml
+++ b/IaC/pg.cd/JenkinsStack.yml
@@ -700,6 +700,8 @@ Resources:
                     https://raw.githubusercontent.com/pintsized/lua-resty-http/master/lib/resty/http.lua
                   wget -O /usr/local/openresty/lualib/resty/http_headers.lua \
                     https://raw.githubusercontent.com/pintsized/lua-resty-http/master/lib/resty/http_headers.lua
+                  wget -O /usr/local/openresty/lualib/resty/http_connect.lua \
+                    https://raw.githubusercontent.com/pintsized/lua-resty-http/master/lib/resty/http_connect.lua 
                   wget -O /mnt/$JENKINS_HOST/nginx-google-oauth.lua \
                     https://raw.githubusercontent.com/cloudflare/nginx-google-oauth/master/access.lua
 

--- a/IaC/pmm.cd/JenkinsStack.yml
+++ b/IaC/pmm.cd/JenkinsStack.yml
@@ -768,11 +768,6 @@ Resources:
                   ln -s /mnt/$JENKINS_HOST/ssl/nginx.conf /usr/local/openresty/nginx/conf/jenkins.conf
                   sed -i'' -e 's/listen/#listen/; s/mime.types/jenkins.conf/' /usr/local/openresty/nginx/conf/nginx.conf
 
-                  wget -O /usr/local/openresty/lualib/resty/http.lua \
-                    https://raw.githubusercontent.com/pintsized/lua-resty-http/master/lib/resty/http.lua
-                  wget -O /usr/local/openresty/lualib/resty/http_headers.lua \
-                    https://raw.githubusercontent.com/pintsized/lua-resty-http/master/lib/resty/http_headers.lua
-
                   systemctl enable --now openresty
               }
 

--- a/IaC/ps.cd/JenkinsStack.yml_ps3
+++ b/IaC/ps.cd/JenkinsStack.yml_ps3
@@ -703,6 +703,8 @@ Resources:
                     https://raw.githubusercontent.com/pintsized/lua-resty-http/master/lib/resty/http.lua
                   wget -O /usr/local/openresty/lualib/resty/http_headers.lua \
                     https://raw.githubusercontent.com/pintsized/lua-resty-http/master/lib/resty/http_headers.lua
+                  wget -O /usr/local/openresty/lualib/resty/http_connect.lua \
+                    https://raw.githubusercontent.com/pintsized/lua-resty-http/master/lib/resty/http_connect.lua 
                   wget -O /mnt/$JENKINS_HOST/nginx-google-oauth.lua \
                     https://raw.githubusercontent.com/cloudflare/nginx-google-oauth/master/access.lua
 

--- a/IaC/ps56.cd/JenkinsStack.yml
+++ b/IaC/ps56.cd/JenkinsStack.yml
@@ -706,6 +706,8 @@ Resources:
                     https://raw.githubusercontent.com/pintsized/lua-resty-http/master/lib/resty/http.lua
                   wget -O /usr/local/openresty/lualib/resty/http_headers.lua \
                     https://raw.githubusercontent.com/pintsized/lua-resty-http/master/lib/resty/http_headers.lua
+                  wget -O /usr/local/openresty/lualib/resty/http_connect.lua \
+                    https://raw.githubusercontent.com/pintsized/lua-resty-http/master/lib/resty/http_connect.lua 
                   wget -O /mnt/$JENKINS_HOST/nginx-google-oauth.lua \
                     https://raw.githubusercontent.com/cloudflare/nginx-google-oauth/master/access.lua
 

--- a/IaC/ps57.cd/JenkinsStack.yml
+++ b/IaC/ps57.cd/JenkinsStack.yml
@@ -705,6 +705,8 @@ Resources:
                     https://raw.githubusercontent.com/pintsized/lua-resty-http/master/lib/resty/http.lua
                   wget -O /usr/local/openresty/lualib/resty/http_headers.lua \
                     https://raw.githubusercontent.com/pintsized/lua-resty-http/master/lib/resty/http_headers.lua
+                  wget -O /usr/local/openresty/lualib/resty/http_connect.lua \
+                    https://raw.githubusercontent.com/pintsized/lua-resty-http/master/lib/resty/http_connect.lua 
                   wget -O /mnt/$JENKINS_HOST/nginx-google-oauth.lua \
                     https://raw.githubusercontent.com/cloudflare/nginx-google-oauth/master/access.lua
 

--- a/IaC/ps80.cd/JenkinsStack.yml
+++ b/IaC/ps80.cd/JenkinsStack.yml
@@ -705,6 +705,8 @@ Resources:
                     https://raw.githubusercontent.com/pintsized/lua-resty-http/master/lib/resty/http.lua
                   wget -O /usr/local/openresty/lualib/resty/http_headers.lua \
                     https://raw.githubusercontent.com/pintsized/lua-resty-http/master/lib/resty/http_headers.lua
+                  wget -O /usr/local/openresty/lualib/resty/http_connect.lua \
+                    https://raw.githubusercontent.com/pintsized/lua-resty-http/master/lib/resty/http_connect.lua 
                   wget -O /mnt/$JENKINS_HOST/nginx-google-oauth.lua \
                     https://raw.githubusercontent.com/cloudflare/nginx-google-oauth/master/access.lua
 

--- a/IaC/pxc.cd/JenkinsStack.yml
+++ b/IaC/pxc.cd/JenkinsStack.yml
@@ -695,6 +695,8 @@ Resources:
                     https://raw.githubusercontent.com/pintsized/lua-resty-http/master/lib/resty/http.lua
                   wget -O /usr/local/openresty/lualib/resty/http_headers.lua \
                     https://raw.githubusercontent.com/pintsized/lua-resty-http/master/lib/resty/http_headers.lua
+                  wget -O /usr/local/openresty/lualib/resty/http_connect.lua \
+                    https://raw.githubusercontent.com/pintsized/lua-resty-http/master/lib/resty/http_connect.lua 
                   wget -O /mnt/$JENKINS_HOST/nginx-google-oauth.lua \
                     https://raw.githubusercontent.com/cloudflare/nginx-google-oauth/master/access.lua
 

--- a/IaC/rel.cd/JenkinsStack.yml
+++ b/IaC/rel.cd/JenkinsStack.yml
@@ -665,16 +665,9 @@ Resources:
               			  ssl_trusted_certificate     /etc/nginx/ssl/ca-certs.pem;
               			  ssl_dhparam                 /etc/nginx/ssl/dhparam.pem;
 
-              			  set \$ngo_client_id          "<-- SETUP MANUALLY -->";
-              			  set \$ngo_client_secret      "<-- SETUP MANUALLY -->";
-              			  set \$ngo_token_secret       "<-- SETUP MANUALLY -->";
-              			  set \$ngo_domain             percona.com;
-              			  set \$ngo_secure_cookies     true;
-              			  set \$ngo_http_only_cookies  true;
               			  resolver                    8.8.8.8 ipv6=off;
               			  lua_ssl_trusted_certificate /etc/pki/tls/certs/ca-bundle.crt;
               			  lua_ssl_verify_depth        3;
-              			  access_by_lua_file          /mnt/$JENKINS_HOST/nginx-google-oauth.lua;
               			  include                     /mnt/$JENKINS_HOST/ssl/*-list.conf;
               			  satisfy                     any;
 
@@ -698,13 +691,6 @@ Resources:
 
                   ln -s /mnt/$JENKINS_HOST/ssl/nginx.conf /usr/local/openresty/nginx/conf/jenkins.conf
                   sed -i'' -e 's/listen/#listen/; s/mime.types/jenkins.conf/' /usr/local/openresty/nginx/conf/nginx.conf
-
-                  wget -O /usr/local/openresty/lualib/resty/http.lua \
-                    https://raw.githubusercontent.com/pintsized/lua-resty-http/master/lib/resty/http.lua
-                  wget -O /usr/local/openresty/lualib/resty/http_headers.lua \
-                    https://raw.githubusercontent.com/pintsized/lua-resty-http/master/lib/resty/http_headers.lua
-                  wget -O /mnt/$JENKINS_HOST/nginx-google-oauth.lua \
-                    https://raw.githubusercontent.com/cloudflare/nginx-google-oauth/master/access.lua
 
                   systemctl enable --now openresty
               }


### PR DESCRIPTION
Removed in Jenkins which are using Github OAuth and implemented a fix for Jenkins which use Google OAuth