### PR TITLE
Cloud - add GKE version parameter for alpha clusters

### DIFF
--- a/cloud/jenkins/pxc_operator_gke_version.groovy
+++ b/cloud/jenkins/pxc_operator_gke_version.groovy
@@ -32,7 +32,7 @@ void runGKEclusterAlpha(String CLUSTER_PREFIX) {
             source $HOME/google-cloud-sdk/path.bash.inc
             gcloud auth activate-service-account alpha-svc-acct@"${GCP_PROJECT}".iam.gserviceaccount.com --key-file=$CLIENT_SECRET_FILE
             gcloud config set project $GCP_PROJECT
-            gcloud alpha container clusters create --release-channel rapid $CLUSTER_NAME-${CLUSTER_PREFIX} --zone us-central1-a --project $GCP_PROJECT --preemptible --machine-type n1-standard-4 --num-nodes=4 --enable-autoscaling --min-nodes=4 --max-nodes=6 --network=jenkins-vpc --subnetwork=jenkins-${CLUSTER_PREFIX}
+            gcloud alpha container clusters create --release-channel rapid $CLUSTER_NAME-${CLUSTER_PREFIX} --cluster-version $GKE_VERSION --zone us-central1-a --project $GCP_PROJECT --preemptible --machine-type n1-standard-4 --num-nodes=4 --enable-autoscaling --min-nodes=4 --max-nodes=6 --network=jenkins-vpc --subnetwork=jenkins-${CLUSTER_PREFIX}
             kubectl create clusterrolebinding cluster-admin-binding1 --clusterrole=cluster-admin --user=\$(gcloud config get-value core/account)
         """
    }


### PR DESCRIPTION
GKE_VERSION is not specified to gcloud command so it starts 1.19 instead of 1.20 for alpha clusters:
```
+ gcloud alpha container clusters create --release-channel rapid jenkins-pxc-ac9c7f9d-basic --zone us-central1-a --project **** --preemptible --machine-type n1-standard-4 --num-nodes=4 --enable-autoscaling --min-nodes=4 --max-nodes=6 --network=jenkins-vpc --subnetwork=jenkins-basic
WARNING: Starting with version 1.19, newly created clusters and node-pools will have COS_CONTAINERD as the default node image when no image type is specified.
...
NAME                        LOCATION       MASTER_VERSION   MASTER_IP      MACHINE_TYPE   NODE_VERSION     NUM_NODES  STATUS
jenkins-pxc-ac9c7f9d-basic  us-central1-a  1.19.7-gke.2503  35.202.93.234  n1-standard-4  1.19.7-gke.2503  4          RUNNING

```