### PR TITLE
ENG-989: Update psmdb.cd to 2.277.1

### DIFF
--- a/IaC/psmdb.cd/JenkinsStack.yml
+++ b/IaC/psmdb.cd/JenkinsStack.yml
@@ -34,7 +34,7 @@ Parameters:
 Mappings:
   AmazonLinux2:
     us-west-2:
-      x64: ami-0e999cbd62129e3b1
+      x64: ami-05b622b5fa0269787
 
 Resources:
 
@@ -475,7 +475,7 @@ Resources:
                   amazon-linux-extras install epel -y
                   yum -y update --security
                   amazon-linux-extras install -y nginx1.12
-                  yum -y install java-1.8.0-openjdk jenkins-2.263.3 certbot git yum-cron aws-cli xfsprogs
+                  yum -y install java-1.8.0-openjdk jenkins-2.277.1 certbot git yum-cron aws-cli xfsprogs
 
                   sed -i 's/update_cmd = default/update_cmd = security/' /etc/yum/yum-cron.conf
                   sed -i 's/apply_updates = no/apply_updates = yes/'     /etc/yum/yum-cron.conf

--- a/IaC/psmdb.cd/init.groovy.d/cloud.groovy
+++ b/IaC/psmdb.cd/init.groovy.d/cloud.groovy
@@ -22,14 +22,14 @@ netMap['us-west-2b'] = 'subnet-03136d8c244f56036'
 netMap['us-west-2c'] = 'subnet-09103aa8678a054f7'
 
 imageMap = [:]
-imageMap['micro-amazon'] = 'ami-09c5e030f74651050'
+imageMap['micro-amazon'] = 'ami-05b622b5fa0269787'
 imageMap['min-centos-6-x64'] = 'ami-0362922178e02e9f3'
 imageMap['min-centos-7-x64'] = 'ami-0686851c4e7b1a8e1'
-imageMap['min-stretch-x64'] = 'ami-02230925ee31677e3'
-imageMap['min-xenial-x64'] = 'ami-076cbb27c223df09a'
-imageMap['min-bionic-x64'] = 'ami-025102f49d03bec05'
+imageMap['min-stretch-x64'] = 'ami-0ada74f78fa02ad0d'
+imageMap['min-xenial-x64'] = 'ami-0ee876776acf64c80'
+imageMap['min-bionic-x64'] = 'ami-007f3fc421aeb286e'
 imageMap['psmdb'] = imageMap['min-xenial-x64']
-imageMap['psmdb-bionic'] = 'ami-025102f49d03bec05'
+imageMap['psmdb-bionic'] = imageMap['min-bionic-x64']
 imageMap['docker'] = imageMap['micro-amazon']
 imageMap['docker-32gb'] = imageMap['micro-amazon']
 


### PR DESCRIPTION
Deployed with plugins and workers update

URLS:
https://psmdb.cd.percona.com/job/percona-server-for-mongodb-3.6-trunk/74/
https://psmdb.cd.percona.com/job/percona-server-for-mongodb-4.0-trunk/88/
https://psmdb.cd.percona.com/job/percona-server-for-mongodb-4.2-trunk/62/