### PR TITLE
PMM-6014 Push RC to experimental repo for pmm2-client packages

### DIFF
--- a/pmm/pmm2-client-autobuild.groovy
+++ b/pmm/pmm2-client-autobuild.groovy
@@ -43,6 +43,7 @@ pipeline {
                     def versionTag = sh(returnStdout: true, script: "cat VERSION").trim()
                     if ("${DESTINATION}" == "laboratory") {
                         env.DOCKER_LATEST_TAG = "${versionTag}-rc${BUILD_NUMBER}"
+                        env.DOCKER_RC_TAG = "${versionTag}-rc"
                     } else {
                         env.DOCKER_LATEST_TAG = "dev-latest"
                     }
@@ -96,7 +97,12 @@ pipeline {
 
                         ./build/bin/build-client-docker
 
-                        docker tag  \\${DOCKER_CLIENT_TAG} perconalab/pmm-client:${DOCKER_LATEST_TAG}
+                        if [[ \$DESTINATION == testing* ]]; then
+                            echo "Testing Repo"
+                            docker tag  \\${DOCKER_CLIENT_TAG} perconalab/pmm-client:${DOCKER_LATEST_TAG}
+                        else
+                            docker tag  \\${DOCKER_CLIENT_TAG} perconalab/pmm-client:${DOCKER_LATEST_TAG} perconalab/pmm-client:${DOCKER_RC_TAG}
+                        fi
                         docker push \\${DOCKER_CLIENT_TAG}
                         docker push perconalab/pmm-client:${DOCKER_LATEST_TAG}
                         docker rmi  \\${DOCKER_CLIENT_TAG}

--- a/pmm/pmm2-client-autobuild.groovy
+++ b/pmm/pmm2-client-autobuild.groovy
@@ -13,7 +13,7 @@ pipeline {
             description: 'Tag/Branch for pmm-submodules repository',
             name: 'GIT_BRANCH')
         choice(
-            choices: 'testing\nlaboratory',
+            choices: ['testing', 'laboratory'],
             description: 'publish result package to internal (testing) or external (laboratory) repository',
             name: 'DESTINATION')
     }
@@ -39,6 +39,15 @@ pipeline {
                     git rev-parse --short HEAD > shortCommit
                     echo "UPLOAD/${DESTINATION}/${JOB_NAME}/pmm2/\$(cat VERSION)/${GIT_BRANCH}/\$(cat shortCommit)/${BUILD_NUMBER}" > uploadPath
                 '''
+                script {
+                    def versionTag = sh(returnStdout: true, script: "cat VERSION").trim()
+                    if ("${DESTINATION}" == "laboratory") {
+                        env.DOCKER_LATEST_TAG = "${versionTag}-rc${BUILD_NUMBER}"
+                    } else {
+                        env.DOCKER_LATEST_TAG = "dev-latest"
+                    }
+                }
+
                 archiveArtifacts 'uploadPath'
                 stash includes: 'uploadPath', name: 'uploadPath'
                 archiveArtifacts 'shortCommit'
@@ -87,11 +96,11 @@ pipeline {
 
                         ./build/bin/build-client-docker
 
-                        docker tag  \\${DOCKER_CLIENT_TAG} perconalab/pmm-client:dev-latest
+                        docker tag  \\${DOCKER_CLIENT_TAG} perconalab/pmm-client:${DOCKER_LATEST_TAG}
                         docker push \\${DOCKER_CLIENT_TAG}
-                        docker push perconalab/pmm-client:dev-latest
+                        docker push perconalab/pmm-client:${DOCKER_LATEST_TAG}
                         docker rmi  \\${DOCKER_CLIENT_TAG}
-                        docker rmi  perconalab/pmm-client:dev-latest
+                        docker rmi  perconalab/pmm-client:${DOCKER_LATEST_TAG}
                     "
                 '''
                 stash includes: 'results/docker/CLIENT_TAG', name: 'CLIENT_IMAGE'

--- a/pmm/pmm2-client-autobuild.groovy
+++ b/pmm/pmm2-client-autobuild.groovy
@@ -88,29 +88,27 @@ pipeline {
                         "
                     """
                 }
-                sh """
+                sh '''
                     sg docker -c "
                         set -o xtrace
 
                         export PUSH_DOCKER=1
-                        export DOCKER_CLIENT_TAG=perconalab/pmm-client:\$(date -u '+%Y%m%d%H%M')
+                        export DOCKER_CLIENT_TAG=perconalab/pmm-client:$(date -u '+%Y%m%d%H%M')
 
                         ./build/bin/build-client-docker
 
-                        if [[ \$DESTINATION == testing* ]]; then
-                            echo "Testing Repo"
-                            docker tag  \${DOCKER_CLIENT_TAG} perconalab/pmm-client:\${DOCKER_LATEST_TAG}
-                        else
-                            docker tag  \${DOCKER_CLIENT_TAG} perconalab/pmm-client:\${DOCKER_LATEST_TAG} perconalab/pmm-client:\${DOCKER_RC_TAG}
+                        if [ ! -z \${DOCKER_RC_TAG+x} ]; then
+                            docker tag  \\${DOCKER_CLIENT_TAG} perconalab/pmm-client:\${DOCKER_RC_TAG}
                             docker push perconalab/pmm-client:\${DOCKER_RC_TAG}
                             docker rmi perconalab/pmm-client:\${DOCKER_RC_TAG}
                         fi
-                        docker push \${DOCKER_CLIENT_TAG}
+                        docker tag  \\${DOCKER_CLIENT_TAG} perconalab/pmm-client:\${DOCKER_LATEST_TAG}
+                        docker push \\${DOCKER_CLIENT_TAG}
                         docker push perconalab/pmm-client:\${DOCKER_LATEST_TAG}
-                        docker rmi  \${DOCKER_CLIENT_TAG}
+                        docker rmi  \\${DOCKER_CLIENT_TAG}
                         docker rmi  perconalab/pmm-client:\${DOCKER_LATEST_TAG}
                     "
-                """
+                '''
                 stash includes: 'results/docker/CLIENT_TAG', name: 'CLIENT_IMAGE'
                 archiveArtifacts 'results/docker/CLIENT_TAG'
             }

--- a/pmm/pmm2-client-autobuild.groovy
+++ b/pmm/pmm2-client-autobuild.groovy
@@ -88,27 +88,29 @@ pipeline {
                         "
                     """
                 }
-                sh '''
+                sh """
                     sg docker -c "
                         set -o xtrace
 
                         export PUSH_DOCKER=1
-                        export DOCKER_CLIENT_TAG=perconalab/pmm-client:$(date -u '+%Y%m%d%H%M')
+                        export DOCKER_CLIENT_TAG=perconalab/pmm-client:\$(date -u '+%Y%m%d%H%M')
 
                         ./build/bin/build-client-docker
 
                         if [[ \$DESTINATION == testing* ]]; then
                             echo "Testing Repo"
-                            docker tag  \\${DOCKER_CLIENT_TAG} perconalab/pmm-client:${DOCKER_LATEST_TAG}
+                            docker tag  \${DOCKER_CLIENT_TAG} perconalab/pmm-client:\${DOCKER_LATEST_TAG}
                         else
-                            docker tag  \\${DOCKER_CLIENT_TAG} perconalab/pmm-client:${DOCKER_LATEST_TAG} perconalab/pmm-client:${DOCKER_RC_TAG}
+                            docker tag  \${DOCKER_CLIENT_TAG} perconalab/pmm-client:\${DOCKER_LATEST_TAG} perconalab/pmm-client:\${DOCKER_RC_TAG}
+                            docker push perconalab/pmm-client:\${DOCKER_RC_TAG}
+                            docker rmi perconalab/pmm-client:\${DOCKER_RC_TAG}
                         fi
-                        docker push \\${DOCKER_CLIENT_TAG}
-                        docker push perconalab/pmm-client:${DOCKER_LATEST_TAG}
-                        docker rmi  \\${DOCKER_CLIENT_TAG}
-                        docker rmi  perconalab/pmm-client:${DOCKER_LATEST_TAG}
+                        docker push \${DOCKER_CLIENT_TAG}
+                        docker push perconalab/pmm-client:\${DOCKER_LATEST_TAG}
+                        docker rmi  \${DOCKER_CLIENT_TAG}
+                        docker rmi  perconalab/pmm-client:\${DOCKER_LATEST_TAG}
                     "
-                '''
+                """
                 stash includes: 'results/docker/CLIENT_TAG', name: 'CLIENT_IMAGE'
                 archiveArtifacts 'results/docker/CLIENT_TAG'
             }

--- a/pmm/pmm2-server-autobuild.groovy
+++ b/pmm/pmm2-server-autobuild.groovy
@@ -62,6 +62,7 @@ pipeline {
                     def versionTag = sh(returnStdout: true, script: "cat VERSION").trim()
                     if ("${DESTINATION}" == "testing") {
                         env.DOCKER_LATEST_TAG = "${versionTag}-rc${BUILD_NUMBER}"
+                        env.DOCKER_RC_TAG = "${versionTag}-rc"
                     } else {
                         env.DOCKER_LATEST_TAG = "dev-latest"
                     }
@@ -173,6 +174,11 @@ pipeline {
 
                         ./build/bin/build-server-docker
 
+                        if [ ! -z \${DOCKER_RC_TAG+x} ]; then
+                            docker tag  \\${DOCKER_TAG} perconalab/pmm-server:${DOCKER_RC_TAG}
+                            docker push perconalab/pmm-server:\${DOCKER_RC_TAG}
+                            docker rmi perconalab/pmm-server:\${DOCKER_RC_TAG}
+                        fi
                         docker tag  \\${DOCKER_TAG} perconalab/pmm-server:${DOCKER_LATEST_TAG}
                         docker push \\${DOCKER_TAG}
                         docker push perconalab/pmm-server:${DOCKER_LATEST_TAG}


### PR DESCRIPTION
WIP, please don't merge. 

Update pmm-client docker tags accordingly for RC. 

1) Adds a default RC tag to always get the latest RC candidate -> ex. 2.16.0-rc
2) Uses Experimental Repo to push RC pmm2-client packages -> Don't need to use laboratory 

Changes both pmm-server and pmm-client auto-build job for the release branch. 