### PR TITLE
Manually set OpenShift4 version used in cloud tests

### DIFF
--- a/cloud/jenkins/psmdb_operator_aws_openshift-4.groovy
+++ b/cloud/jenkins/psmdb_operator_aws_openshift-4.groovy
@@ -100,6 +100,10 @@ void installRpms() {
 pipeline {
     parameters {
         string(
+            defaultValue: '4.6.23',
+            description: 'OpenShift version to use',
+            name: 'OS_VERSION')
+        string(
             defaultValue: 'main',
             description: 'Tag/Branch for percona/percona-server-mongodb-operator repository',
             name: 'GIT_BRANCH')
@@ -158,10 +162,9 @@ pipeline {
                     curl -s https://get.helm.sh/helm-v3.2.3-linux-amd64.tar.gz \
                         | sudo tar -C /usr/local/bin --strip-components 1 -zvxpf -
 
-                    VERSION=$(curl --silent 'https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/release.txt' | grep 'Version:' | awk '{print $2}')
-                    curl -s -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux-$VERSION.tar.gz \
+                    curl -s -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux-$OS_VERSION.tar.gz \
                         | sudo tar -C /usr/local/bin --wildcards -zxvpf -
-                    curl -s -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-install-linux-$VERSION.tar.gz \
+                    curl -s -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-install-linux-$OS_VERSION.tar.gz \
                         | sudo tar -C /usr/local/bin  --wildcards -zxvpf -
 
                     sudo sh -c "curl -s -L https://github.com/mikefarah/yq/releases/download/3.3.2/yq_linux_amd64 > /usr/local/bin/yq"

--- a/cloud/jenkins/pxc_operator_aws_openshift-4.groovy
+++ b/cloud/jenkins/pxc_operator_aws_openshift-4.groovy
@@ -120,6 +120,10 @@ void installRpms() {
 pipeline {
     parameters {
         string(
+            defaultValue: '4.6.23',
+            description: 'OpenShift version to use',
+            name: 'OS_VERSION')
+        string(
             defaultValue: 'main',
             description: 'Tag/Branch for percona/percona-xtradb-cluster-operator repository',
             name: 'GIT_BRANCH')
@@ -197,10 +201,9 @@ pipeline {
                     sudo sh -c "curl -s -L https://github.com/mikefarah/yq/releases/download/3.3.2/yq_linux_amd64 > /usr/local/bin/yq"
                     sudo chmod +x /usr/local/bin/yq
 
-                    VERSION=$(curl --silent 'https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/release.txt' | grep 'Version:' | awk '{print $2}')
-                    curl -s -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux-$VERSION.tar.gz \
+                    curl -s -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux-$OS_VERSION.tar.gz \
                         | sudo tar -C /usr/local/bin --wildcards -zxvpf -
-                    curl -s -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-install-linux-$VERSION.tar.gz \
+                    curl -s -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-install-linux-$OS_VERSION.tar.gz \
                         | sudo tar -C /usr/local/bin  --wildcards -zxvpf -
                 '''
 


### PR DESCRIPTION
Our current OpenShift4 tests use the latest stable OpenShift version which is now 4.7 and it is based on kubernetes 1.20. Officially we support OpenShift 4.6 (which is based on kubernetes 1.19) so we need to be able to specify version used.