### PR TITLE
Change PMM.cd's docker worker to t3.xlarge

### DIFF
--- a/IaC/pmm.cd/init.groovy.d/cloud.groovy
+++ b/IaC/pmm.cd/init.groovy.d/cloud.groovy
@@ -312,7 +312,7 @@ typeMap['min-buster-x64']    = typeMap['min-centos-6-x64']
 typeMap['min-stretch-x64']   = typeMap['min-centos-6-x64']
 typeMap['micro-amazon']      = 't3.large'
 typeMap['large-amazon']      = 't3.xlarge'
-typeMap['docker']            = 't3.large'
+typeMap['docker']            = 't3.xlarge'
 
 execMap = [:]
 execMap['min-centos-6-x64']  = '1'


### PR DESCRIPTION
I discussed the PR https://github.com/Percona-Lab/jenkins-pipelines/pull/897 with Puneet regarding installing docker each time and advised to use docker worker, which is designed for such load

But I noticed, that he was using large-amazon, which has t3.xlarge type, and changing to `docker` (which at this moment has t3.large type) will have an performance impact

