### PR TITLE
PXB-2469: Add Perl-DBD-MySQL for CentOS 8 on PXB8.0 template job

### DIFF
--- a/pxb/percona-xtrabackup-8.0-template.yml
+++ b/pxb/percona-xtrabackup-8.0-template.yml
@@ -41,8 +41,8 @@
                 PKGLIST+=" libcurl-devel cmake libaio-devel zlib-devel libev-devel bison make gcc"
                 PKGLIST+=" rpm-build libgcrypt-devel ncurses-devel readline-devel openssl-devel gcc-c++"
                 PKGLIST+=" vim-common rpmlint wget ncurses-compat-libs python2 python2-setuptools python2-wheel"
-                PKGLIST+=" lz4 lz4-devel"
-                until yum -y install ${PKGLIST}; do
+                PKGLIST+=" lz4 lz4-devel perl-DBD-MySQL"
+                until sudo yum -y install ${PKGLIST}; do
                     echo "waiting"
                     sleep 1
                 done


### PR DESCRIPTION
Build URL: https://pxb.cd.percona.com/view/PXB%208.0/job/percona-xtrabackup-8.0-param-medium/BUILD_TYPE=debug,Host=min-centos-8-x64,xtrabackuptarget=innodb80/60/console

```
version_check                            w2	[passed]    25
```

Failed before: https://pxb.cd.percona.com/view/PXB%208.0/job/percona-xtrabackup-8.0-param-medium/56/BUILD_TYPE=release,Host=min-centos-8-x64,xtrabackuptarget=innodb80/testReport/(root)/t_version_check/sh/ 