### PR TITLE
PSQLADM-317 - Allow packages to be downloaded from default CentOS EPE…

### DIFF
--- a/proxysql/build-binary-proxysql
+++ b/proxysql/build-binary-proxysql
@@ -16,9 +16,12 @@ if [ -f /usr/bin/yum ]; then
     fi
     sudo yum -y install wget
     if [[ $RHEL -eq 7 ]]; then
-        sudo wget -O /etc/yum.repos.d/percona-dev.repo http://jenkins.percona.com/yum-repo/percona-dev.repo
-        sudo yum -y install automake bzip2 cmake make gcc-c++ gcc git openssl openssl-devel gnutls gnutls-devel libtool patch
+        sudo yum -y install automake bzip2 cmake3 make gcc-c++ gcc git openssl openssl-devel gnutls gnutls-devel libtool patch
     fi
+  if [ -f /usr/bin/cmake3 ]; then
+    sudo mv /usr/bin/cmake /usr/bin/cmake2
+    sudo ln -s /usr/bin/cmake3 /usr/bin/cmake
+  fi
 fi
 
 WORKDIR_ABS=$(cd ${1:-./build/proxysql}; pwd -P)

--- a/proxysql/qa-proxysql2-pipeline.groovy
+++ b/proxysql/qa-proxysql2-pipeline.groovy
@@ -8,7 +8,7 @@ pipeline {
             name: 'GIT_REPO',
             trim: true)
         string(
-            defaultValue: 'v2.0.17',
+            defaultValue: 'v2.0.18',
             description: 'Tag/Branch for ProxySQL repository',
             name: 'BRANCH',
             trim: true)
@@ -23,7 +23,7 @@ pipeline {
             name: 'PROXYSQL_PACKAGE_BRANCH',
             trim: true)
         string(
-            defaultValue: 'v2.0',
+            defaultValue: 'v2.0.18-dev',
             description: 'Tag/Branch for ProxySQL-admin-tool repository',
             name: 'PAT_TAG',
             trim: true)


### PR DESCRIPTION
…L repo instead of percona-dev repo

Issue:
The proxysql build script was using percona-dev repo for downloading build essentials like cmake. The percona-dev repo had older version
of cmake, causing the build to fail on CentOS

Solution:
Stopped using percona-dev repo and instead pointed to the default CentOS EPEL repo for downloads which has newer version

Misc: Also updated the ProxySQl upstream branch to v2.0.18 and ProxySQL Admin branch to v2.0.18-dev for the pipleline job

Author: Mohit Joshi <mohit.joshi@percona.com>
Reviewed by: Illia Pshonkin <illia.pshonkin@percona.com>