### PR TITLE
ENG-1010: Backport automatic download of boost from ps-build to PXC/PXB pipelines

### DIFF
--- a/pxb/v2/local/build-binary
+++ b/pxb/v2/local/build-binary
@@ -42,6 +42,9 @@ wget_loop() {
     fi
 }
 
+BOOST_VERSION=$(grep 'SET(BOOST_PACKAGE_NAME' ${SOURCEDIR}/cmake/boost.cmake | sed -re 's/.*([0-9]+_[0-9]+_[0-9]+).*/\1/')
+wget_loop "boost_${BOOST_VERSION}.tar.gz" "http://downloads.sourceforge.net/boost/boost/${BOOST_VERSION//_/.}/boost_${BOOST_VERSION}.tar.gz"
+
 # ------------------------------------------------------------------------------
 # Set OS/Arch flags
 # ------------------------------------------------------------------------------

--- a/pxc/local/build-binary-pxc57
+++ b/pxc/local/build-binary-pxc57
@@ -44,6 +44,9 @@ wget_loop() {
     fi
 }
 
+BOOST_VERSION=$(grep 'SET(BOOST_PACKAGE_NAME' ${SOURCEDIR}/cmake/boost.cmake | sed -re 's/.*([0-9]+_[0-9]+_[0-9]+).*/\1/')
+wget_loop "boost_${BOOST_VERSION}.tar.gz" "http://downloads.sourceforge.net/boost/boost/${BOOST_VERSION//_/.}/boost_${BOOST_VERSION}.tar.gz"
+
 # ------------------------------------------------------------------------------
 # Set OS/Arch flags
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
This feature implemented in: https://github.com/Percona-Lab/ps-build/blob/8.0/local/build-binary#L54
I haven't implemented this feature for pxc56/57 as it uses build-binary script from PXC repo