### PR TITLE
PS-7730: Add package-testing-ps* jobs

### DIFF
--- a/ps/jenkins/package-testing-ps-5.7.groovy
+++ b/ps/jenkins/package-testing-ps-5.7.groovy
@@ -15,20 +15,6 @@ List all_nodes = [
     "micro-amazon",
 ]
 
-Map product_nodes = [
-    ps56: [
-        "min-stretch-x64",
-        "min-centos-6-x64",
-        "min-centos-7-x64",
-        "min-xenial-x64",
-        "min-bionic-x64",
-        "micro-amazon",
-    ],
-    ps57: all_nodes,
-    ps80: all_nodes,
-    client_test: all_nodes,
-]
-
 product_to_test = params.product_to_test
 
 List nodes_to_test = []
@@ -44,7 +30,6 @@ void runNodeBuild(String node_to_test) {
         parameters: [
             string(name: "product_to_test", value: product_to_test),
             string(name: "install_repo", value: params.install_repo),
-            string(name: "client_to_test", value: params.client_to_test),
             string(name: "node_to_test", value: node_to_test),
             string(name: "action_to_test", value: params.action_to_test)
         ],
@@ -59,7 +44,7 @@ pipeline {
     parameters {
         choice(
             name: "product_to_test",
-            choices: ["ps57", "ps56", "client_test"],
+            choices: ["ps57", "client_test"],
             description: "Product for which the packages will be tested"
         )
 
@@ -67,12 +52,6 @@ pipeline {
             name: "install_repo",
             choices: ["testing", "main", "experimental"],
             description: "Repo to use in install test"
-        )
-
-        choice(
-            name: "client_to_test",
-            choices: ["ps57", "ps56"],
-            description: "Client to check (only when client_test is selected)"
         )
 
         choice(
@@ -103,13 +82,6 @@ pipeline {
                 stage("Debian Stretch") {
                     when {
                         expression {
-                            product_nodes[product_to_test].contains("min-stretch-x64")
-                        }
-                        expression { (
-                            (product_to_test != "client_test") ||
-                            (product_nodes[client_to_test].contains("min-stretch-x64"))
-                        ) }
-                        expression {
                             nodes_to_test.contains("min-stretch-x64")
                         }
                     }
@@ -121,13 +93,6 @@ pipeline {
 
                 stage("Debian Buster") {
                     when {
-                        expression {
-                            product_nodes[product_to_test].contains("min-buster-x64")
-                        }
-                        expression { (
-                            (product_to_test != "client_test") ||
-                            (product_nodes[client_to_test].contains("min-buster-x64"))
-                        ) }
                         expression {
                             nodes_to_test.contains("min-buster-x64")
                         }
@@ -141,13 +106,6 @@ pipeline {
                 stage("Centos 6") {
                     when {
                         expression {
-                            product_nodes[product_to_test].contains("min-centos-6-x64")
-                        }
-                        expression { (
-                            (product_to_test != "client_test") ||
-                            (product_nodes[client_to_test].contains("min-centos-6-x64"))
-                        ) }
-                        expression {
                             nodes_to_test.contains("min-centos-6-x64")
                         }
                     }
@@ -159,13 +117,6 @@ pipeline {
 
                 stage("Centos 7") {
                     when {
-                        expression {
-                            product_nodes[product_to_test].contains("min-centos-7-x64")
-                        }
-                        expression { (
-                            (product_to_test != "client_test") ||
-                            (product_nodes[client_to_test].contains("min-centos-7-x64"))
-                        ) }
                         expression {
                             nodes_to_test.contains("min-centos-7-x64")
                         }
@@ -179,13 +130,6 @@ pipeline {
                 stage("Centos 8") {
                     when {
                         expression {
-                            product_nodes[product_to_test].contains("min-centos-8-x64")
-                        }
-                        expression { (
-                            (product_to_test != "client_test") ||
-                            (product_nodes[client_to_test].contains("min-centos-8-x64"))
-                        ) }
-                        expression {
                             nodes_to_test.contains("min-centos-8-x64")
                         }
                     }
@@ -197,13 +141,6 @@ pipeline {
 
                 stage("Ubuntu Xenial") {
                     when {
-                        expression {
-                            product_nodes[product_to_test].contains("min-xenial-x64")
-                        }
-                        expression { (
-                            (product_to_test != "client_test") ||
-                            (product_nodes[client_to_test].contains("min-xenial-x64"))
-                        ) }
                         expression {
                             nodes_to_test.contains("min-xenial-x64")
                         }
@@ -217,13 +154,6 @@ pipeline {
                 stage("Ubuntu Bionic") {
                     when {
                         expression {
-                            product_nodes[product_to_test].contains("min-bionic-x64")
-                        }
-                        expression { (
-                            (product_to_test != "client_test") ||
-                            (product_nodes[client_to_test].contains("min-bionic-x64"))
-                        ) }
-                        expression {
                             nodes_to_test.contains("min-bionic-x64")
                         }
                     }
@@ -236,13 +166,6 @@ pipeline {
                 stage("Ubuntu Focal") {
                     when {
                         expression {
-                            product_nodes[product_to_test].contains("min-focal-x64")
-                        }
-                        expression { (
-                            (product_to_test != "client_test") ||
-                            (product_nodes[client_to_test].contains("min-focal-x64"))
-                        ) }
-                        expression {
                             nodes_to_test.contains("min-focal-x64")
                         }
                     }
@@ -254,13 +177,6 @@ pipeline {
 
                 stage("Amazon Linux") {
                     when {
-                        expression {
-                            product_nodes[product_to_test].contains("micro-amazon")
-                        }
-                        expression { (
-                            (product_to_test != "client_test") ||
-                            (product_nodes[client_to_test].contains("micro-amazon"))
-                        ) }
                         expression {
                             nodes_to_test.contains("micro-amazon")
                         }

--- a/ps/jenkins/package-testing-ps-5.7.groovy
+++ b/ps/jenkins/package-testing-ps-5.7.groovy
@@ -1,0 +1,276 @@
+library changelog: false, identifier: 'lib@master', retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/Percona-Lab/jenkins-pipelines.git'
+]) _
+
+List all_nodes = [
+    "min-stretch-x64",
+    "min-buster-x64",
+    "min-centos-6-x64",
+    "min-centos-7-x64",
+    "min-centos-8-x64",
+    "min-xenial-x64",
+    "min-bionic-x64",
+    "min-focal-x64",
+    "micro-amazon",
+]
+
+Map product_nodes = [
+    ps56: [
+        "min-stretch-x64",
+        "min-centos-6-x64",
+        "min-centos-7-x64",
+        "min-xenial-x64",
+        "min-bionic-x64",
+        "micro-amazon",
+    ],
+    ps57: all_nodes,
+    ps80: all_nodes,
+    client_test: all_nodes,
+]
+
+product_to_test = params.product_to_test
+
+List nodes_to_test = []
+if (params.node_to_test == "all") {
+    nodes_to_test = all_nodes
+} else {
+    nodes_to_test = [params.node_to_test]
+}
+
+void runNodeBuild(String node_to_test) {
+    build(
+        job: 'package-testing-ps57-build',
+        parameters: [
+            string(name: "product_to_test", value: product_to_test),
+            string(name: "install_repo", value: params.install_repo),
+            string(name: "client_to_test", value: params.client_to_test),
+            string(name: "node_to_test", value: node_to_test),
+            string(name: "action_to_test", value: params.action_to_test)
+        ],
+        propagate: true,
+        wait: true
+    )
+}
+
+pipeline {
+    agent none
+
+    parameters {
+        choice(
+            name: "product_to_test",
+            choices: ["ps57", "ps56", "client_test"],
+            description: "Product for which the packages will be tested"
+        )
+
+        choice(
+            name: "install_repo",
+            choices: ["testing", "main", "experimental"],
+            description: "Repo to use in install test"
+        )
+
+        choice(
+            name: "client_to_test",
+            choices: ["ps57", "ps56"],
+            description: "Client to check (only when client_test is selected)"
+        )
+
+        choice(
+            name: "node_to_test",
+            choices: ["all"] + all_nodes,
+            description: "Node in which to test the product"
+        )
+
+        choice(
+            name: "action_to_test",
+            choices: ["all", "install", "upgrade", "maj-upgrade-to", "maj-upgrade-from"],
+            description: "Action to test on the product"
+        )
+    }
+
+    stages {
+        stage("Prepare") {
+            steps {
+                script {
+                    currentBuild.displayName = "#${BUILD_NUMBER}-${product_to_test}-${params.install_repo}"
+                    currentBuild.description = "action: ${params.action_to_test} node: ${params.node_to_test}"
+                }
+            }
+        }
+
+        stage("Run parallel") {
+            parallel {
+                stage("Debian Stretch") {
+                    when {
+                        expression {
+                            product_nodes[product_to_test].contains("min-stretch-x64")
+                        }
+                        expression { (
+                            (product_to_test != "client_test") ||
+                            (product_nodes[client_to_test].contains("min-stretch-x64"))
+                        ) }
+                        expression {
+                            nodes_to_test.contains("min-stretch-x64")
+                        }
+                    }
+
+                    steps {
+                        runNodeBuild("min-stretch-x64")
+                    }
+                }
+
+                stage("Debian Buster") {
+                    when {
+                        expression {
+                            product_nodes[product_to_test].contains("min-buster-x64")
+                        }
+                        expression { (
+                            (product_to_test != "client_test") ||
+                            (product_nodes[client_to_test].contains("min-buster-x64"))
+                        ) }
+                        expression {
+                            nodes_to_test.contains("min-buster-x64")
+                        }
+                    }
+
+                    steps {
+                        runNodeBuild("min-buster-x64")
+                    }
+                }
+
+                stage("Centos 6") {
+                    when {
+                        expression {
+                            product_nodes[product_to_test].contains("min-centos-6-x64")
+                        }
+                        expression { (
+                            (product_to_test != "client_test") ||
+                            (product_nodes[client_to_test].contains("min-centos-6-x64"))
+                        ) }
+                        expression {
+                            nodes_to_test.contains("min-centos-6-x64")
+                        }
+                    }
+
+                    steps {
+                        runNodeBuild("min-centos-6-x64")
+                    }
+                }
+
+                stage("Centos 7") {
+                    when {
+                        expression {
+                            product_nodes[product_to_test].contains("min-centos-7-x64")
+                        }
+                        expression { (
+                            (product_to_test != "client_test") ||
+                            (product_nodes[client_to_test].contains("min-centos-7-x64"))
+                        ) }
+                        expression {
+                            nodes_to_test.contains("min-centos-7-x64")
+                        }
+                    }
+
+                    steps {
+                        runNodeBuild("min-centos-7-x64")
+                    }
+                }
+
+                stage("Centos 8") {
+                    when {
+                        expression {
+                            product_nodes[product_to_test].contains("min-centos-8-x64")
+                        }
+                        expression { (
+                            (product_to_test != "client_test") ||
+                            (product_nodes[client_to_test].contains("min-centos-8-x64"))
+                        ) }
+                        expression {
+                            nodes_to_test.contains("min-centos-8-x64")
+                        }
+                    }
+
+                    steps {
+                        runNodeBuild("min-centos-8-x64")
+                    }
+                }
+
+                stage("Ubuntu Xenial") {
+                    when {
+                        expression {
+                            product_nodes[product_to_test].contains("min-xenial-x64")
+                        }
+                        expression { (
+                            (product_to_test != "client_test") ||
+                            (product_nodes[client_to_test].contains("min-xenial-x64"))
+                        ) }
+                        expression {
+                            nodes_to_test.contains("min-xenial-x64")
+                        }
+                    }
+
+                    steps {
+                        runNodeBuild("min-xenial-x64")
+                    }
+                }
+
+                stage("Ubuntu Bionic") {
+                    when {
+                        expression {
+                            product_nodes[product_to_test].contains("min-bionic-x64")
+                        }
+                        expression { (
+                            (product_to_test != "client_test") ||
+                            (product_nodes[client_to_test].contains("min-bionic-x64"))
+                        ) }
+                        expression {
+                            nodes_to_test.contains("min-bionic-x64")
+                        }
+                    }
+
+                    steps {
+                        runNodeBuild("min-bionic-x64")
+                    }
+                }
+
+                stage("Ubuntu Focal") {
+                    when {
+                        expression {
+                            product_nodes[product_to_test].contains("min-focal-x64")
+                        }
+                        expression { (
+                            (product_to_test != "client_test") ||
+                            (product_nodes[client_to_test].contains("min-focal-x64"))
+                        ) }
+                        expression {
+                            nodes_to_test.contains("min-focal-x64")
+                        }
+                    }
+
+                    steps {
+                        runNodeBuild("min-focal-x64")
+                    }
+                }
+
+                stage("Amazon Linux") {
+                    when {
+                        expression {
+                            product_nodes[product_to_test].contains("micro-amazon")
+                        }
+                        expression { (
+                            (product_to_test != "client_test") ||
+                            (product_nodes[client_to_test].contains("micro-amazon"))
+                        ) }
+                        expression {
+                            nodes_to_test.contains("micro-amazon")
+                        }
+                    }
+
+                    steps {
+                        runNodeBuild("micro-amazon")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ps/jenkins/package-testing-ps-5.7.groovy
+++ b/ps/jenkins/package-testing-ps-5.7.groovy
@@ -12,7 +12,7 @@ List all_nodes = [
     "min-xenial-x64",
     "min-bionic-x64",
     "min-focal-x64",
-    "micro-amazon",
+    "min-amazon-2-x64",
 ]
 
 product_to_test = params.product_to_test
@@ -178,12 +178,12 @@ pipeline {
                 stage("Amazon Linux") {
                     when {
                         expression {
-                            nodes_to_test.contains("micro-amazon")
+                            nodes_to_test.contains("min-amazon-2-x64")
                         }
                     }
 
                     steps {
-                        runNodeBuild("micro-amazon")
+                        runNodeBuild("min-amazon-2-x64")
                     }
                 }
             }

--- a/ps/jenkins/package-testing-ps-5.7.yml
+++ b/ps/jenkins/package-testing-ps-5.7.yml
@@ -18,3 +18,40 @@
                 wipe-workspace: true
         lightweight-checkout: true
         script-path: ps/jenkins/package-testing-ps-5.7.groovy
+    parameters:
+        - choice:
+            name: product_to_test
+            choices:
+                - "ps57"
+                - "client_test"
+            description: "Product for which the packages will be tested"
+        - choice:
+            name: install_repo
+            choices:
+                - "testing"
+                - "main"
+                - "experimental"
+            description: "Repo to use in install test"
+        - choice:
+            name: node_to_test
+            choices:
+                - "all"
+                - "min-stretch-x64"
+                - "min-buster-x64"
+                - "min-centos-6-x64"
+                - "min-centos-7-x64"
+                - "min-centos-8-x64"
+                - "min-xenial-x64"
+                - "min-bionic-x64"
+                - "min-focal-x64"
+                - "micro-amazon"
+            description: "Node in which to test the product"
+        - choice:
+            name: action_to_test
+            choices:
+                - "all"
+                - "install"
+                - "upgrade"
+                - "maj-upgrade-to"
+                - "maj-upgrade-from"
+            description: "Action to test on the product"

--- a/ps/jenkins/package-testing-ps-5.7.yml
+++ b/ps/jenkins/package-testing-ps-5.7.yml
@@ -44,7 +44,7 @@
                 - "min-xenial-x64"
                 - "min-bionic-x64"
                 - "min-focal-x64"
-                - "micro-amazon"
+                - "min-amazon-2-x64"
             description: "Node in which to test the product"
         - choice:
             name: action_to_test

--- a/ps/jenkins/package-testing-ps-5.7.yml
+++ b/ps/jenkins/package-testing-ps-5.7.yml
@@ -1,0 +1,20 @@
+- job:
+    name: package-testing-ps57
+    project-type: pipeline
+    description: |
+        Do not edit this job through the web!
+    properties:
+        - build-discarder:
+            artifact-days-to-keep: -1
+            artifact-num-to-keep: 10
+            days-to-keep: -1
+            num-to-keep: 10
+    pipeline-scm:
+        scm:
+            - git:
+                url: https://github.com/Percona-Lab/jenkins-pipelines.git
+                branches:
+                    - 'master'
+                wipe-workspace: true
+        lightweight-checkout: true
+        script-path: ps/jenkins/package-testing-ps-5.7.groovy

--- a/ps/jenkins/package-testing-ps-8.0.groovy
+++ b/ps/jenkins/package-testing-ps-8.0.groovy
@@ -12,7 +12,7 @@ List all_nodes = [
     "min-xenial-x64",
     "min-bionic-x64",
     "min-focal-x64",
-    "micro-amazon",
+    "min-amazon-2-x64",
 ]
 
 product_to_test = params.product_to_test
@@ -178,12 +178,12 @@ pipeline {
                 stage("Amazon Linux") {
                     when {
                         expression {
-                            nodes_to_test.contains("micro-amazon")
+                            nodes_to_test.contains("min-amazon-2-x64")
                         }
                     }
 
                     steps {
-                        runNodeBuild("micro-amazon")
+                        runNodeBuild("min-amazon-2-x64")
                     }
                 }
             }

--- a/ps/jenkins/package-testing-ps-8.0.groovy
+++ b/ps/jenkins/package-testing-ps-8.0.groovy
@@ -1,0 +1,192 @@
+library changelog: false, identifier: 'lib@master', retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/Percona-Lab/jenkins-pipelines.git'
+]) _
+
+List all_nodes = [
+    "min-stretch-x64",
+    "min-buster-x64",
+    "min-centos-6-x64",
+    "min-centos-7-x64",
+    "min-centos-8-x64",
+    "min-xenial-x64",
+    "min-bionic-x64",
+    "min-focal-x64",
+    "micro-amazon",
+]
+
+product_to_test = params.product_to_test
+
+List nodes_to_test = []
+if (params.node_to_test == "all") {
+    nodes_to_test = all_nodes
+} else {
+    nodes_to_test = [params.node_to_test]
+}
+
+void runNodeBuild(String node_to_test) {
+    build(
+        job: 'package-testing-ps80-build',
+        parameters: [
+            string(name: "product_to_test", value: product_to_test),
+            string(name: "install_repo", value: params.install_repo),
+            string(name: "node_to_test", value: node_to_test),
+            string(name: "action_to_test", value: params.action_to_test)
+        ],
+        propagate: true,
+        wait: true
+    )
+}
+
+pipeline {
+    agent none
+
+    parameters {
+        choice(
+            name: "product_to_test",
+            choices: ["ps80", "client_test"],
+            description: "Product for which the packages will be tested"
+        )
+
+        choice(
+            name: "install_repo",
+            choices: ["testing", "main", "experimental"],
+            description: "Repo to use in install test"
+        )
+
+        choice(
+            name: "node_to_test",
+            choices: ["all"] + all_nodes,
+            description: "Node in which to test the product"
+        )
+
+        choice(
+            name: "action_to_test",
+            choices: ["all", "install", "upgrade", "maj-upgrade-to"],
+            description: "Action to test on the product"
+        )
+    }
+
+    stages {
+        stage("Prepare") {
+            steps {
+                script {
+                    currentBuild.displayName = "#${BUILD_NUMBER}-${product_to_test}-${params.install_repo}"
+                    currentBuild.description = "action: ${params.action_to_test} node: ${params.node_to_test}"
+                }
+            }
+        }
+
+        stage("Run parallel") {
+            parallel {
+                stage("Debian Stretch") {
+                    when {
+                        expression {
+                            nodes_to_test.contains("min-stretch-x64")
+                        }
+                    }
+
+                    steps {
+                        runNodeBuild("min-stretch-x64")
+                    }
+                }
+
+                stage("Debian Buster") {
+                    when {
+                        expression {
+                            nodes_to_test.contains("min-buster-x64")
+                        }
+                    }
+
+                    steps {
+                        runNodeBuild("min-buster-x64")
+                    }
+                }
+
+                stage("Centos 6") {
+                    when {
+                        expression {
+                            nodes_to_test.contains("min-centos-6-x64")
+                        }
+                    }
+
+                    steps {
+                        runNodeBuild("min-centos-6-x64")
+                    }
+                }
+
+                stage("Centos 7") {
+                    when {
+                        expression {
+                            nodes_to_test.contains("min-centos-7-x64")
+                        }
+                    }
+
+                    steps {
+                        runNodeBuild("min-centos-7-x64")
+                    }
+                }
+
+                stage("Centos 8") {
+                    when {
+                        expression {
+                            nodes_to_test.contains("min-centos-8-x64")
+                        }
+                    }
+
+                    steps {
+                        runNodeBuild("min-centos-8-x64")
+                    }
+                }
+
+                stage("Ubuntu Xenial") {
+                    when {
+                        expression {
+                            nodes_to_test.contains("min-xenial-x64")
+                        }
+                    }
+
+                    steps {
+                        runNodeBuild("min-xenial-x64")
+                    }
+                }
+
+                stage("Ubuntu Bionic") {
+                    when {
+                        expression {
+                            nodes_to_test.contains("min-bionic-x64")
+                        }
+                    }
+
+                    steps {
+                        runNodeBuild("min-bionic-x64")
+                    }
+                }
+
+                stage("Ubuntu Focal") {
+                    when {
+                        expression {
+                            nodes_to_test.contains("min-focal-x64")
+                        }
+                    }
+
+                    steps {
+                        runNodeBuild("min-focal-x64")
+                    }
+                }
+
+                stage("Amazon Linux") {
+                    when {
+                        expression {
+                            nodes_to_test.contains("micro-amazon")
+                        }
+                    }
+
+                    steps {
+                        runNodeBuild("micro-amazon")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ps/jenkins/package-testing-ps-8.0.yml
+++ b/ps/jenkins/package-testing-ps-8.0.yml
@@ -1,0 +1,20 @@
+- job:
+    name: package-testing-ps80
+    project-type: pipeline
+    description: |
+        Do not edit this job through the web!
+    properties:
+        - build-discarder:
+            artifact-days-to-keep: -1
+            artifact-num-to-keep: 10
+            days-to-keep: -1
+            num-to-keep: 10
+    pipeline-scm:
+        scm:
+            - git:
+                url: https://github.com/Percona-Lab/jenkins-pipelines.git
+                branches:
+                    - 'master'
+                wipe-workspace: true
+        lightweight-checkout: true
+        script-path: ps/jenkins/package-testing-ps-8.0.groovy

--- a/ps/jenkins/package-testing-ps-8.0.yml
+++ b/ps/jenkins/package-testing-ps-8.0.yml
@@ -18,3 +18,39 @@
                 wipe-workspace: true
         lightweight-checkout: true
         script-path: ps/jenkins/package-testing-ps-8.0.groovy
+    parameters:
+        - choice:
+            name: product_to_test
+            choices:
+                - "ps80"
+                - "client_test"
+            description: "Product for which the packages will be tested"
+        - choice:
+            name: install_repo
+            choices:
+                - "testing"
+                - "main"
+                - "experimental"
+            description: "Repo to use in install test"
+        - choice:
+            name: node_to_test
+            choices:
+                - "all"
+                - "min-stretch-x64"
+                - "min-buster-x64"
+                - "min-centos-6-x64"
+                - "min-centos-7-x64"
+                - "min-centos-8-x64"
+                - "min-xenial-x64"
+                - "min-bionic-x64"
+                - "min-focal-x64"
+                - "micro-amazon"
+            description: "Node in which to test the product"
+        - choice:
+            name: action_to_test
+            choices:
+                - "all"
+                - "install"
+                - "upgrade"
+                - "maj-upgrade-to"
+            description: "Action to test on the product"

--- a/ps/jenkins/package-testing-ps-8.0.yml
+++ b/ps/jenkins/package-testing-ps-8.0.yml
@@ -44,7 +44,7 @@
                 - "min-xenial-x64"
                 - "min-bionic-x64"
                 - "min-focal-x64"
-                - "micro-amazon"
+                - "min-amazon-2-x64"
             description: "Node in which to test the product"
         - choice:
             name: action_to_test

--- a/ps/jenkins/package-testing-ps-build-5.7.groovy
+++ b/ps/jenkins/package-testing-ps-build-5.7.groovy
@@ -119,6 +119,10 @@ void runPlaybook(String action_to_test) {
 pipeline {
     agent none
 
+    options {
+        skipDefaultCheckout()
+    }
+
     parameters {
         choice(
             name: "product_to_test",
@@ -163,6 +167,7 @@ pipeline {
                     }
 
                     when {
+                        beforeAgent true
                         expression {
                             product_actions[params.product_to_test].contains("install")
                         }
@@ -182,6 +187,7 @@ pipeline {
                     }
 
                     when {
+                        beforeAgent true
                         expression {
                             product_actions[params.product_to_test].contains("upgrade")
                         }
@@ -201,6 +207,7 @@ pipeline {
                     }
 
                     when {
+                        beforeAgent true
                         expression {
                             product_actions[params.product_to_test].contains("maj-upgrade-to")
                         }
@@ -220,6 +227,7 @@ pipeline {
                     }
 
                     when {
+                        beforeAgent true
                         expression {
                             product_actions[params.product_to_test].contains("maj-upgrade-from")
                         }

--- a/ps/jenkins/package-testing-ps-build-5.7.groovy
+++ b/ps/jenkins/package-testing-ps-build-5.7.groovy
@@ -64,6 +64,11 @@ void setup_package_tests() {
 
 List all_nodes = node_setups.keySet().collect()
 
+List ps56_excluded_nodes = [
+    "min-centos-8-x64",
+    "min-focal-x64",
+]
+
 List all_actions = [
     "install",
     "upgrade",
@@ -213,6 +218,9 @@ pipeline {
                         }
                         expression {
                             actions_to_test.contains("maj-upgrade-to")
+                        }
+                        expression {
+                            !(ps56_excluded_nodes.contains(params.node_to_test))
                         }
                     }
 

--- a/ps/jenkins/package-testing-ps-build-5.7.groovy
+++ b/ps/jenkins/package-testing-ps-build-5.7.groovy
@@ -19,12 +19,19 @@ setup_amazon_package_tests = { ->
     '''
 }
 
-setup_debian_package_tests = { ->
+setup_stretch_package_tests = { ->
     sh '''
         sudo apt-get update
         sudo apt-get install -y dirmngr gnupg2
         echo "deb http://ppa.launchpad.net/ansible/ansible/ubuntu trusty main" | sudo tee -a /etc/apt/sources.list > /dev/null
         sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367
+        sudo apt-get update
+        sudo apt-get install -y ansible git wget
+    '''
+}
+
+setup_buster_package_tests = { ->
+    sh '''
         sudo apt-get update
         sudo apt-get install -y ansible git wget
     '''
@@ -40,8 +47,8 @@ setup_ubuntu_package_tests = { ->
 }
 
 node_setups = [
-    "min-stretch-x64": setup_debian_package_tests,
-    "min-buster-x64": setup_debian_package_tests,
+    "min-stretch-x64": setup_stretch_package_tests,
+    "min-buster-x64": setup_buster_package_tests,
     "min-centos-6-x64": setup_rhel_package_tests,
     "min-centos-7-x64": setup_rhel_package_tests,
     "min-centos-8-x64": setup_rhel_package_tests,

--- a/ps/jenkins/package-testing-ps-build-5.7.groovy
+++ b/ps/jenkins/package-testing-ps-build-5.7.groovy
@@ -1,0 +1,244 @@
+library changelog: false, identifier: 'lib@master', retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/Percona-Lab/jenkins-pipelines.git'
+]) _
+
+setup_rhel_package_tests = { ->
+    sh '''
+        sudo yum install -y epel-release
+        sudo yum -y update
+        sudo yum install -y ansible git wget
+    '''
+}
+
+setup_amazon_package_tests = { ->
+    sh '''
+        sudo amazon-linux-extras install epel
+        sudo yum -y update
+        sudo yum install -y ansible git wget
+    '''
+}
+
+setup_debian_package_tests = { ->
+    sh '''
+        sudo apt-get install -y dirmngr gnupg2
+        echo "deb http://ppa.launchpad.net/ansible/ansible/ubuntu trusty main" | sudo tee -a /etc/apt/sources.list > /dev/null
+        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367
+        sudo apt update -y
+        sudo apt-get install -y ansible git wget
+    '''
+}
+
+setup_ubuntu_package_tests = { ->
+    sh '''
+        sudo apt update
+        sudo apt install software-properties-common
+        sudo apt-add-repository --yes --update ppa:ansible/ansible
+        sudo apt-get install -y ansible git wget
+    '''
+}
+
+node_setups = [
+    "min-stretch-x64": setup_debian_package_tests,
+    "min-buster-x64": setup_debian_package_tests,
+    "min-centos-6-x64": setup_rhel_package_tests,
+    "min-centos-7-x64": setup_rhel_package_tests,
+    "min-centos-8-x64": setup_rhel_package_tests,
+    "min-xenial-x64": setup_ubuntu_package_tests,
+    "min-bionic-x64": setup_ubuntu_package_tests,
+    "min-focal-x64": setup_ubuntu_package_tests,
+    "micro-amazon": setup_amazon_package_tests,
+]
+
+void setup_package_tests() {
+    node_setups[params.node_to_test]()
+}
+
+List all_nodes = node_setups.keySet().collect()
+
+List all_actions = [
+    "install",
+    "upgrade",
+    "maj-upgrade-to",
+    "maj-upgrade-from",
+]
+
+Map product_nodes = [
+    ps56: [
+        "min-stretch-x64",
+        "min-centos-6-x64",
+        "min-centos-7-x64",
+        "min-xenial-x64",
+        "min-bionic-x64",
+        "micro-amazon",
+    ],
+    ps57: all_nodes,
+    client_test: all_nodes,
+]
+
+product_action_playbooks = [
+    ps56: [
+        install: "common_56.yml",
+        upgrade: "common_56_upgrade.yml",
+    ],
+    ps57: [
+        install: "common_57.yml",
+        upgrade: "common_57_upgrade.yml",
+        "maj-upgrade-to": "common_57_major_upgrade_to.yml",
+        "maj-upgrade-from": "common_57_major_upgrade_from.yml",
+    ],
+    client_test: [
+        install: "client_test.yml",
+        upgrade: "client_test_upgrade.yml",
+    ]
+]
+
+Map product_actions = product_action_playbooks.collectEntries { key, value ->
+    [key, value.keySet().collect()]
+}
+
+List actions_to_test = []
+if (params.action_to_test == "all") {
+    actions_to_test = all_actions
+} else {
+    actions_to_test = [params.action_to_test]
+}
+
+void runPlaybook(String action_to_test) {
+    def playbook = product_action_playbooks[params.product_to_test][action_to_test]
+    def playbook_path = "package-testing/playbooks/${playbook}"
+
+    setup_package_tests()
+
+    sh '''
+        git clone --depth 1 https://github.com/Percona-QA/package-testing
+    '''
+
+    sh """
+        export install_repo="\${install_repo}"
+        export client_to_test="\${client_to_test}"
+        ansible-playbook \
+        --connection=local \
+        --inventory 127.0.0.1, \
+        --limit 127.0.0.1 \
+        ${playbook_path}
+    """
+}
+
+pipeline {
+    agent none
+
+    parameters {
+        choice(
+            name: "product_to_test",
+            choices: ["ps56", "ps57", "client_test"],
+            description: "Product for which the packages will be tested"
+        )
+
+        choice(
+            name: "install_repo",
+            choices: ["testing", "main", "experimental"],
+            description: "Repo to use in install test"
+        )
+
+        choice(
+            name: "client_to_test",
+            choices: ["ps56", "ps57"],
+            description: "Client to check (only when client_test is selected)"
+        )
+
+        choice(
+            name: "node_to_test",
+            choices: all_nodes,
+            description: "Node in which to test the product"
+        )
+
+        choice(
+            name: "action_to_test",
+            choices: ["all"] + all_actions,
+            description: "Action to test on the product"
+        )
+    }
+
+    stages {
+        stage("Prepare") {
+            steps {
+                script {
+                    currentBuild.displayName = "#${BUILD_NUMBER}-${params.product_to_test}-${params.install_repo}-${params.node_to_test}"
+                    currentBuild.description = "action: ${params.action_to_test}"
+
+                    if (!(product_nodes[params.product_to_test].contains(params.node_to_test))) {
+                        error "The product ${params.product_to_test} cannot be tested on node ${params.node_to_test}"
+                    }
+                    if (
+                        (params.product_to_test == "client_test") &&
+                        !(product_nodes[params.client_to_test].contains(params.node_to_test))
+                    ) {
+                        error "The ${params.client_to_test} client cannot be tested on node ${params.node_to_test}" 
+                    }
+                }
+            }
+        }
+
+        stage("Run parallel") {
+            parallel {
+                stage("Install") {
+                    agent {
+                        label params.node_to_test
+                    }
+
+                    when {
+                        expression {
+                            product_actions[params.product_to_test].contains("install")
+                        }
+                        expression {
+                            actions_to_test.contains("install")
+                        }
+                    }
+
+                    steps {
+                        runPlaybook("install")
+                    }
+                }
+
+                stage("Upgrade") {
+                    agent {
+                        label params.node_to_test
+                    }
+
+                    when {
+                        expression {
+                            product_actions[params.product_to_test].contains("upgrade")
+                        }
+                        expression {
+                            actions_to_test.contains("upgrade")
+                        }
+                    }
+
+                    steps {
+                        runPlaybook("upgrade")
+                    }
+                }
+
+                stage("Major upgrade to") {
+                    agent {
+                        label params.node_to_test
+                    }
+
+                    when {
+                        expression {
+                            product_actions[params.product_to_test].contains("maj-upgrade-to")
+                        }
+                        expression {
+                            actions_to_test.contains("maj-upgrade-to")
+                        }
+                    }
+
+                    steps {
+                        runPlaybook("maj-upgrade-to")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ps/jenkins/package-testing-ps-build-5.7.groovy
+++ b/ps/jenkins/package-testing-ps-build-5.7.groovy
@@ -21,18 +21,19 @@ setup_amazon_package_tests = { ->
 
 setup_debian_package_tests = { ->
     sh '''
+        sudo apt-get update
         sudo apt-get install -y dirmngr gnupg2
         echo "deb http://ppa.launchpad.net/ansible/ansible/ubuntu trusty main" | sudo tee -a /etc/apt/sources.list > /dev/null
         sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367
-        sudo apt update -y
+        sudo apt-get update
         sudo apt-get install -y ansible git wget
     '''
 }
 
 setup_ubuntu_package_tests = { ->
     sh '''
-        sudo apt update
-        sudo apt install software-properties-common
+        sudo apt-get update
+        sudo apt-get install -y software-properties-common
         sudo apt-add-repository --yes --update ppa:ansible/ansible
         sudo apt-get install -y ansible git wget
     '''

--- a/ps/jenkins/package-testing-ps-build-5.7.groovy
+++ b/ps/jenkins/package-testing-ps-build-5.7.groovy
@@ -47,7 +47,7 @@ node_setups = [
     "min-xenial-x64": setup_ubuntu_package_tests,
     "min-bionic-x64": setup_ubuntu_package_tests,
     "min-focal-x64": setup_ubuntu_package_tests,
-    "micro-amazon": setup_amazon_package_tests,
+    "min-amazon-2-x64": setup_amazon_package_tests,
 ]
 
 void setup_package_tests() {

--- a/ps/jenkins/package-testing-ps-build-5.7.yml
+++ b/ps/jenkins/package-testing-ps-build-5.7.yml
@@ -1,0 +1,22 @@
+- job:
+    name: package-testing-ps57-build
+    project-type: pipeline
+    description: |
+        Use package-testing-ps to run in all nodes
+        Do not edit this job through the web!
+    concurrent: true
+    properties:
+        - build-discarder:
+            artifact-days-to-keep: -1
+            artifact-num-to-keep: 10
+            days-to-keep: -1
+            num-to-keep: 50
+    pipeline-scm:
+        scm:
+            - git:
+                url: https://github.com/Percona-Lab/jenkins-pipelines.git
+                branches:
+                    - 'master'
+                wipe-workspace: true
+        lightweight-checkout: true
+        script-path: ps/jenkins/package-testing-ps-build-5.7.groovy

--- a/ps/jenkins/package-testing-ps-build-5.7.yml
+++ b/ps/jenkins/package-testing-ps-build-5.7.yml
@@ -20,3 +20,39 @@
                 wipe-workspace: true
         lightweight-checkout: true
         script-path: ps/jenkins/package-testing-ps-build-5.7.groovy
+    parameters:
+        - choice:
+            name: product_to_test
+            choices:
+                - "ps57"
+                - "client_test"
+            description: "Product for which the packages will be tested"
+        - choice:
+            name: install_repo
+            choices:
+                - "testing"
+                - "main"
+                - "experimental"
+            description: "Repo to use in install test"
+        - choice:
+            name: node_to_test
+            choices:
+                - "min-stretch-x64"
+                - "min-buster-x64"
+                - "min-centos-6-x64"
+                - "min-centos-7-x64"
+                - "min-centos-8-x64"
+                - "min-xenial-x64"
+                - "min-bionic-x64"
+                - "min-focal-x64"
+                - "micro-amazon"
+            description: "Node in which to test the product"
+        - choice:
+            name: action_to_test
+            choices:
+                - "all"
+                - "install"
+                - "upgrade"
+                - "maj-upgrade-to"
+                - "maj-upgrade-from"
+            description: "Action to test on the product"

--- a/ps/jenkins/package-testing-ps-build-5.7.yml
+++ b/ps/jenkins/package-testing-ps-build-5.7.yml
@@ -45,7 +45,7 @@
                 - "min-xenial-x64"
                 - "min-bionic-x64"
                 - "min-focal-x64"
-                - "micro-amazon"
+                - "min-amazon-2-x64"
             description: "Node in which to test the product"
         - choice:
             name: action_to_test

--- a/ps/jenkins/package-testing-ps-build-8.0.groovy
+++ b/ps/jenkins/package-testing-ps-build-8.0.groovy
@@ -19,12 +19,19 @@ setup_amazon_package_tests = { ->
     '''
 }
 
-setup_debian_package_tests = { ->
+setup_stretch_package_tests = { ->
     sh '''
         sudo apt-get update
         sudo apt-get install -y dirmngr gnupg2
         echo "deb http://ppa.launchpad.net/ansible/ansible/ubuntu trusty main" | sudo tee -a /etc/apt/sources.list > /dev/null
         sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367
+        sudo apt-get update
+        sudo apt-get install -y ansible git wget
+    '''
+}
+
+setup_buster_package_tests = { ->
+    sh '''
         sudo apt-get update
         sudo apt-get install -y ansible git wget
     '''
@@ -40,8 +47,8 @@ setup_ubuntu_package_tests = { ->
 }
 
 node_setups = [
-    "min-stretch-x64": setup_debian_package_tests,
-    "min-buster-x64": setup_debian_package_tests,
+    "min-stretch-x64": setup_stretch_package_tests,
+    "min-buster-x64": setup_buster_package_tests,
     "min-centos-6-x64": setup_rhel_package_tests,
     "min-centos-7-x64": setup_rhel_package_tests,
     "min-centos-8-x64": setup_rhel_package_tests,

--- a/ps/jenkins/package-testing-ps-build-8.0.groovy
+++ b/ps/jenkins/package-testing-ps-build-8.0.groovy
@@ -117,6 +117,10 @@ void runPlaybook(String action_to_test) {
 pipeline {
     agent none
 
+    options {
+        skipDefaultCheckout()
+    }
+
     parameters {
         choice(
             name: "product_to_test",
@@ -161,6 +165,7 @@ pipeline {
                     }
 
                     when {
+                        beforeAgent true
                         expression {
                             product_actions[params.product_to_test].contains("install")
                         }
@@ -180,6 +185,7 @@ pipeline {
                     }
 
                     when {
+                        beforeAgent true
                         expression {
                             product_actions[params.product_to_test].contains("upgrade")
                         }
@@ -199,6 +205,7 @@ pipeline {
                     }
 
                     when {
+                        beforeAgent true
                         expression {
                             product_actions[params.product_to_test].contains("maj-upgrade-to")
                         }

--- a/ps/jenkins/package-testing-ps-build-8.0.groovy
+++ b/ps/jenkins/package-testing-ps-build-8.0.groovy
@@ -21,18 +21,19 @@ setup_amazon_package_tests = { ->
 
 setup_debian_package_tests = { ->
     sh '''
+        sudo apt-get update
         sudo apt-get install -y dirmngr gnupg2
         echo "deb http://ppa.launchpad.net/ansible/ansible/ubuntu trusty main" | sudo tee -a /etc/apt/sources.list > /dev/null
         sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367
-        sudo apt update -y
+        sudo apt-get update
         sudo apt-get install -y ansible git wget
     '''
 }
 
 setup_ubuntu_package_tests = { ->
     sh '''
-        sudo apt update
-        sudo apt install software-properties-common
+        sudo apt-get update
+        sudo apt-get install -y software-properties-common
         sudo apt-add-repository --yes --update ppa:ansible/ansible
         sudo apt-get install -y ansible git wget
     '''

--- a/ps/jenkins/package-testing-ps-build-8.0.groovy
+++ b/ps/jenkins/package-testing-ps-build-8.0.groovy
@@ -47,7 +47,7 @@ node_setups = [
     "min-xenial-x64": setup_ubuntu_package_tests,
     "min-bionic-x64": setup_ubuntu_package_tests,
     "min-focal-x64": setup_ubuntu_package_tests,
-    "micro-amazon": setup_amazon_package_tests,
+    "min-amazon-2-x64": setup_amazon_package_tests,
 ]
 
 void setup_package_tests() {

--- a/ps/jenkins/package-testing-ps-build-8.0.groovy
+++ b/ps/jenkins/package-testing-ps-build-8.0.groovy
@@ -1,0 +1,209 @@
+library changelog: false, identifier: 'lib@master', retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/Percona-Lab/jenkins-pipelines.git'
+]) _
+
+setup_rhel_package_tests = { ->
+    sh '''
+        sudo yum install -y epel-release
+        sudo yum -y update
+        sudo yum install -y ansible git wget
+    '''
+}
+
+setup_amazon_package_tests = { ->
+    sh '''
+        sudo amazon-linux-extras install epel
+        sudo yum -y update
+        sudo yum install -y ansible git wget
+    '''
+}
+
+setup_debian_package_tests = { ->
+    sh '''
+        sudo apt-get install -y dirmngr gnupg2
+        echo "deb http://ppa.launchpad.net/ansible/ansible/ubuntu trusty main" | sudo tee -a /etc/apt/sources.list > /dev/null
+        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367
+        sudo apt update -y
+        sudo apt-get install -y ansible git wget
+    '''
+}
+
+setup_ubuntu_package_tests = { ->
+    sh '''
+        sudo apt update
+        sudo apt install software-properties-common
+        sudo apt-add-repository --yes --update ppa:ansible/ansible
+        sudo apt-get install -y ansible git wget
+    '''
+}
+
+node_setups = [
+    "min-stretch-x64": setup_debian_package_tests,
+    "min-buster-x64": setup_debian_package_tests,
+    "min-centos-6-x64": setup_rhel_package_tests,
+    "min-centos-7-x64": setup_rhel_package_tests,
+    "min-centos-8-x64": setup_rhel_package_tests,
+    "min-xenial-x64": setup_ubuntu_package_tests,
+    "min-bionic-x64": setup_ubuntu_package_tests,
+    "min-focal-x64": setup_ubuntu_package_tests,
+    "micro-amazon": setup_amazon_package_tests,
+]
+
+void setup_package_tests() {
+    node_setups[params.node_to_test]()
+}
+
+List all_nodes = node_setups.keySet().collect()
+
+List all_actions = [
+    "install",
+    "upgrade",
+    "maj-upgrade-to",
+]
+
+product_action_playbooks = [
+    ps80: [
+        install: "ps_80.yml",
+        upgrade: "ps_80_upgrade.yml",
+        "maj-upgrade-to": "ps_80_major_upgrade_to.yml",
+    ],
+    client_test: [
+        install: "client_test.yml",
+        upgrade: "client_test_upgrade.yml",
+    ]
+]
+
+Map product_actions = product_action_playbooks.collectEntries { key, value ->
+    [key, value.keySet().collect()]
+}
+
+List actions_to_test = []
+if (params.action_to_test == "all") {
+    actions_to_test = all_actions
+} else {
+    actions_to_test = [params.action_to_test]
+}
+
+void runPlaybook(String action_to_test) {
+    def playbook = product_action_playbooks[params.product_to_test][action_to_test]
+    def playbook_path = "package-testing/playbooks/${playbook}"
+
+    setup_package_tests()
+
+    sh '''
+        git clone --depth 1 https://github.com/Percona-QA/package-testing
+    '''
+
+    sh """
+        export install_repo="\${install_repo}"
+        export client_to_test="ps80"
+        ansible-playbook \
+        --connection=local \
+        --inventory 127.0.0.1, \
+        --limit 127.0.0.1 \
+        ${playbook_path}
+    """
+}
+
+pipeline {
+    agent none
+
+    parameters {
+        choice(
+            name: "product_to_test",
+            choices: ["ps80", "client_test"],
+            description: "Product for which the packages will be tested"
+        )
+
+        choice(
+            name: "install_repo",
+            choices: ["testing", "main", "experimental"],
+            description: "Repo to use in install test"
+        )
+
+        choice(
+            name: "node_to_test",
+            choices: all_nodes,
+            description: "Node in which to test the product"
+        )
+
+        choice(
+            name: "action_to_test",
+            choices: ["all"] + all_actions,
+            description: "Action to test on the product"
+        )
+    }
+
+    stages {
+        stage("Prepare") {
+            steps {
+                script {
+                    currentBuild.displayName = "#${BUILD_NUMBER}-${params.product_to_test}-${params.install_repo}-${params.node_to_test}"
+                    currentBuild.description = "action: ${params.action_to_test}"
+                }
+            }
+        }
+
+        stage("Run parallel") {
+            parallel {
+                stage("Install") {
+                    agent {
+                        label params.node_to_test
+                    }
+
+                    when {
+                        expression {
+                            product_actions[params.product_to_test].contains("install")
+                        }
+                        expression {
+                            actions_to_test.contains("install")
+                        }
+                    }
+
+                    steps {
+                        runPlaybook("install")
+                    }
+                }
+
+                stage("Upgrade") {
+                    agent {
+                        label params.node_to_test
+                    }
+
+                    when {
+                        expression {
+                            product_actions[params.product_to_test].contains("upgrade")
+                        }
+                        expression {
+                            actions_to_test.contains("upgrade")
+                        }
+                    }
+
+                    steps {
+                        runPlaybook("upgrade")
+                    }
+                }
+
+                stage("Major upgrade to") {
+                    agent {
+                        label params.node_to_test
+                    }
+
+                    when {
+                        expression {
+                            product_actions[params.product_to_test].contains("maj-upgrade-to")
+                        }
+                        expression {
+                            actions_to_test.contains("maj-upgrade-to")
+                        }
+                    }
+
+                    steps {
+                        runPlaybook("maj-upgrade-to")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ps/jenkins/package-testing-ps-build-8.0.yml
+++ b/ps/jenkins/package-testing-ps-build-8.0.yml
@@ -45,7 +45,7 @@
                 - "min-xenial-x64"
                 - "min-bionic-x64"
                 - "min-focal-x64"
-                - "micro-amazon"
+                - "min-amazon-2-x64"
             description: "Node in which to test the product"
         - choice:
             name: action_to_test

--- a/ps/jenkins/package-testing-ps-build-8.0.yml
+++ b/ps/jenkins/package-testing-ps-build-8.0.yml
@@ -20,3 +20,38 @@
                 wipe-workspace: true
         lightweight-checkout: true
         script-path: ps/jenkins/package-testing-ps-build-8.0.groovy
+    parameters:
+        - choice:
+            name: product_to_test
+            choices:
+                - "ps80"
+                - "client_test"
+            description: "Product for which the packages will be tested"
+        - choice:
+            name: install_repo
+            choices:
+                - "testing"
+                - "main"
+                - "experimental"
+            description: "Repo to use in install test"
+        - choice:
+            name: node_to_test
+            choices:
+                - "min-stretch-x64"
+                - "min-buster-x64"
+                - "min-centos-6-x64"
+                - "min-centos-7-x64"
+                - "min-centos-8-x64"
+                - "min-xenial-x64"
+                - "min-bionic-x64"
+                - "min-focal-x64"
+                - "micro-amazon"
+            description: "Node in which to test the product"
+        - choice:
+            name: action_to_test
+            choices:
+                - "all"
+                - "install"
+                - "upgrade"
+                - "maj-upgrade-to"
+            description: "Action to test on the product"

--- a/ps/jenkins/package-testing-ps-build-8.0.yml
+++ b/ps/jenkins/package-testing-ps-build-8.0.yml
@@ -1,0 +1,22 @@
+- job:
+    name: package-testing-ps80-build
+    project-type: pipeline
+    description: |
+        Use package-testing-ps to run in all nodes
+        Do not edit this job through the web!
+    concurrent: true
+    properties:
+        - build-discarder:
+            artifact-days-to-keep: -1
+            artifact-num-to-keep: 10
+            days-to-keep: -1
+            num-to-keep: 50
+    pipeline-scm:
+        scm:
+            - git:
+                url: https://github.com/Percona-Lab/jenkins-pipelines.git
+                branches:
+                    - 'master'
+                wipe-workspace: true
+        lightweight-checkout: true
+        script-path: ps/jenkins/package-testing-ps-build-8.0.groovy


### PR DESCRIPTION
This PR adds Jenkins jobs, destined for the `ps80.cd` and `ps57.cd` instances, that run the package-testing PS playbooks, much like how the `package-testing-ps` job in the old Jenkins does it, although it uses the pipeline syntax to do so instead of the matrix configuration plugin.

I have tried to follow [the instructions in Confluence](https://confluence.percona.com/pages/viewpage.action?pageId=60783651) to the best of my ability. A few questions remain:

- I have placed the `.yml` and `.groovy` files under `ps/jenkins`, where there seem to be similar jobs that exist in the same instances. Is this the right place?
- After this PR is merged, I will run `jenkins-jobs` as described in the Confluence instructions to create the jobs in the instances. How do I make them end up in the right folder (in this case, "QA")? Is there anything else that needs to be done, so that after a reboot, the jobs end up in the right instance?