### PR TITLE
PXC-3662: Convert non-UTF-8 chars into browser readable UTF-8

### DIFF
--- a/pxc/local/test-binary-pxc
+++ b/pxc/local/test-binary-pxc
@@ -121,4 +121,10 @@ if [[ "${DEFAULT_TESTING}" != "no" ]]; then
     fi
 fi
 
+# Convert Latin1(ISO-8859-1) into browser readable UTF-8
+for file in $(find ${WORKDIR_ABS}/ -maxdepth 1 -name "*.xml"); do
+    iconv -c -t UTF-8 ${file} | tr -cd '[:print:]\n\r' > ${file}-converted
+    mv ${file}-converted ${file}
+done
+
 exit $status

--- a/pxc/local/test-binary-pxc56
+++ b/pxc/local/test-binary-pxc56
@@ -81,4 +81,10 @@ if [[ "${DEFAULT_TESTING}" != "no" ]]; then
         --junit-package="${DOCKER_OS}.${CMAKE_BUILD_TYPE}.mtr.xml" || true   
 fi
 
+# Convert Latin1(ISO-8859-1) into browser readable UTF-8
+for file in $(find ${WORKDIR_ABS}/ -maxdepth 1 -name "*.xml"); do
+    iconv -c -t UTF-8 ${file} | tr -cd '[:print:]\n\r' > ${file}-converted
+    mv ${file}-converted ${file}
+done
+
 exit $status

--- a/pxc/local/test-binary-pxc57
+++ b/pxc/local/test-binary-pxc57
@@ -114,4 +114,10 @@ if [[ "${DEFAULT_TESTING}" != "no" ]]; then
     fi
 fi
 
+# Convert Latin1(ISO-8859-1) into browser readable UTF-8
+for file in $(find ${WORKDIR_ABS}/ -maxdepth 1 -name "*.xml"); do
+    iconv -c -t UTF-8 ${file} | tr -cd '[:print:]\n\r' > ${file}-converted
+    mv ${file}-converted ${file}
+done
+
 exit $status


### PR DESCRIPTION
Builds: https://pxc.cd.percona.com/job/pxc-5.7-pipeline-PXC-3662/8/