### PR TITLE
PXB-2509: Correct sphinx errors on PXB build for Debian based OS

### DIFF
--- a/pxc/docker/install-deps
+++ b/pxc/docker/install-deps
@@ -195,7 +195,7 @@ if [ -f /usr/bin/apt-get ]; then
         tzdata check scons libreadline-dev libgcrypt-dev libev-dev zlib1g-dev libasio-dev ncurses-dev \
         libpam-dev vim-common python3-pip libboost-all-dev rsync \
         python3 sysbench libdbd-mysql-perl \
-        patchelf lynx librtmp-dev lsof socat qpress libncurses5 libtinfo5 libxml-simple-perl \
+        patchelf lynx librtmp-dev lsof socat qpress libncurses5 libtinfo5 libxml-simple-perl python3-sphinx \
     "
     
     if [[ ${DIST} != 'focal' ]]; then
@@ -284,8 +284,6 @@ if [ -f /usr/bin/yum ]; then
     else
         pip3 install --upgrade sphinx==1.4
     fi
-else
-    pip3 install --upgrade sphinx==1.4
 fi
 
 export PERL_MM_USE_DEFAULT=1


### PR DESCRIPTION
Builds: https://pxb.cd.percona.com/job/percona-xtrabackup-2.4-compile-pipeline-illiatests/
Failed builds: https://pxb.cd.percona.com/job/percona-xtrabackup-2.4-compile-pipeline/419/parameters/