### PR TITLE
PXB-2524: Correct cmake_bin variable for CentOS 8

### DIFF
--- a/pxb/percona-xtrabackup-8.0-template.yml
+++ b/pxb/percona-xtrabackup-8.0-template.yml
@@ -214,7 +214,12 @@
             fi
 
             if [ -f '/usr/bin/yum' ]; then
-                cmake_bin='cmake3'
+                RHEL=$(rpm --eval %rhel)
+                if [[ "${RHEL}" -eq 8 ]]; then
+                    cmake_bin='cmake'
+                else
+                    cmake_bin='cmake3'
+                fi
             else
                 cmake_bin='cmake'
             fi


### PR DESCRIPTION
Builds: https://pxb.cd.percona.com/view/PXB%208.0/job/percona-xtrabackup-8.0-param-medium/80/