### PR TITLE
PXC-3683: Set python3 for focal by default

### DIFF
--- a/pxc/docker/install-deps
+++ b/pxc/docker/install-deps
@@ -252,6 +252,10 @@ if [ -f /usr/bin/apt-get ]; then
     apt-get -y purge librtmp-dev || true
     apt-get -y install automake bzip2 cmake make g++ gcc git openssl libssl-dev libgnutls28-dev libtool patch patchelf python
     apt-get -y clean
+
+    if [[ ${DIST} == 'focal' ]]; then
+        update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+    fi
 fi
 
 if [ ! -f /usr/local/lib/libeatmydata.so ]; then


### PR DESCRIPTION
Builds: https://pxc.cd.percona.com/job/pxc-5.7-pipeline-PXC-3683/6/

This needed, because we install python-mysqldb module via pip3, and it's not available for python2 on focal
