### PR TITLE
K8SPSMDB-488 - Add parameter for EKS kubernetes version for PSMDB/PXC

### DIFF
--- a/cloud/jenkins/psmdb_operator_eks.groovy
+++ b/cloud/jenkins/psmdb_operator_eks.groovy
@@ -110,6 +110,10 @@ pipeline {
             description: 'percona-server-mongodb-operator repository',
             name: 'GIT_REPO')
         string(
+            defaultValue: '1.20',
+            description: 'EKS kubernetes version',
+            name: 'EKS_VERSION')
+        string(
             defaultValue: '',
             description: 'Operator image: perconalab/percona-server-mongodb-operator:main',
             name: 'PSMDB_OPERATOR_IMAGE')
@@ -201,6 +205,7 @@ kind: ClusterConfig
 metadata:
     name: eks-psmdb-cluster
     region: eu-west-3
+    version: "$EKS_VERSION"
 
 nodeGroups:
     - name: ng-1

--- a/cloud/jenkins/pxc_operator_eks.groovy
+++ b/cloud/jenkins/pxc_operator_eks.groovy
@@ -129,6 +129,10 @@ pipeline {
             defaultValue: 'https://github.com/percona/percona-xtradb-cluster-operator',
             description: 'percona-xtradb-cluster-operator repository',
             name: 'GIT_REPO')
+        string(
+            defaultValue: '1.20',
+            description: 'EKS kubernetes version',
+            name: 'EKS_VERSION')
         choice(
             choices: 'NO\nYES',
             description: 'Run tests with cluster wide',
@@ -238,6 +242,7 @@ kind: ClusterConfig
 metadata:
     name: eks-pxc-cluster
     region: eu-west-3
+    version: "$EKS_VERSION"
 
 nodeGroups:
     - name: ng-1


### PR DESCRIPTION
Adds parameter for EKS Kubernetes version for PSMDB/PXC operator tests.
Current latest is `1.20`, but the default is `1.19` and the previous jenkins job was running on current default.