### PR TITLE
CLOUD-628 - Remove service-per-pod test in psmdb_operator_minikube.groovy

### DIFF
--- a/cloud/jenkins/psmdb_operator_minikube.groovy
+++ b/cloud/jenkins/psmdb_operator_minikube.groovy
@@ -237,7 +237,6 @@ pipeline {
                     runTest('security-context')
                     runTest('self-healing')
                     runTest('self-healing-chaos')
-                    runTest('service-per-pod')
                     runTest('smart-update')
                     runTest('upgrade-consistency')
                     runTest('users')


### PR DESCRIPTION
It doesn't work because of load balancer support.