### PR TITLE
Revert "PMM-8266 remove prometheus from autobuild"

### DIFF
--- a/pmm/pmm2-server-autobuild.groovy
+++ b/pmm/pmm2-server-autobuild.groovy
@@ -145,6 +145,7 @@ pipeline {
 
                             # 3rd-party
                             build-server-rpm clickhouse
+                            build-server-rpm prometheus
                             build-server-rpm victoriametrics
                             build-server-rpm alertmanager
                             build-server-rpm grafana


### PR DESCRIPTION
This reverts commit 2f41fc3ca24d2bc862ee298e378dfca4a671b53c.