### PR TITLE
PMM-8364 merge pmm-server and percona images content

### DIFF
--- a/pmm/pmm-ami.groovy
+++ b/pmm/pmm-ami.groovy
@@ -8,7 +8,7 @@ pipeline {
     parameters {
         string(
             defaultValue: 'master',
-            description: 'Tag/Branch for percona-images repository',
+            description: 'Tag/Branch for pmm-server repository',
             name: 'GIT_BRANCH')
     }
     options {
@@ -23,7 +23,7 @@ pipeline {
         stage('Prepare') {
             steps {
                 slackSend botUser: true, channel: '#pmm-ci', color: '#FFFF00', message: "[${specName}]: build started - ${BUILD_URL}"
-                git poll: true, branch: GIT_BRANCH, url: "https://github.com/Percona-Lab/percona-images.git"
+                git poll: true, branch: GIT_BRANCH, url: "https://github.com/percona/pmm-server.git"
                 sh """
                     make clean
                     make deps

--- a/pmm/pmm-ovf.groovy
+++ b/pmm/pmm-ovf.groovy
@@ -8,7 +8,7 @@ pipeline {
     parameters {
         string(
             defaultValue: 'master',
-            description: 'Tag/Branch for percona-images repository',
+            description: 'Tag/Branch for pmm-server repository',
             name: 'GIT_BRANCH')
     }
     options {
@@ -23,7 +23,7 @@ pipeline {
         stage('Prepare') {
             steps {
                 slackSend botUser: true, channel: '#pmm-ci', color: '#FFFF00', message: "[${specName}]: build started - ${BUILD_URL}"
-                git poll: true, branch: GIT_BRANCH, url: "https://github.com/Percona-Lab/percona-images.git"
+                git poll: true, branch: GIT_BRANCH, url: "https://github.com/percona/pmm-server.git"
                 sh """
                     make clean
                     make fetch

--- a/pmm/pmm2-ami.groovy
+++ b/pmm/pmm2-ami.groovy
@@ -15,7 +15,7 @@ pipeline {
         string(
             defaultValue: 'PMM-2.0',
             description: 'Tag/Branch for pmm-server repository',
-            name: 'GIT_BRANCH')
+            name: 'PMM_SERVER_BRANCH')
         choice(
             choices: ['no', 'yes'],
             description: "Build Release Candidate?",
@@ -33,7 +33,7 @@ pipeline {
         stage('Prepare') {
             steps {
                 slackSend botUser: true, channel: '#pmm-ci', color: '#FFFF00', message: "[${specName}]: build started - ${BUILD_URL}"
-                git poll: true, branch: GIT_BRANCH, url: "https://github.com/percona/pmm-server.git"
+                git poll: true, branch: PMM_SERVER_BRANCH, url: "https://github.com/percona/pmm-server.git"
                 sh """
                     make clean
                     make deps

--- a/pmm/pmm2-ami.groovy
+++ b/pmm/pmm2-ami.groovy
@@ -14,7 +14,7 @@ pipeline {
     parameters {
         string(
             defaultValue: 'master',
-            description: 'Tag/Branch for percona-images repository',
+            description: 'Tag/Branch for pmm-server repository',
             name: 'GIT_BRANCH')
         choice(
             choices: ['no', 'yes'],
@@ -33,7 +33,7 @@ pipeline {
         stage('Prepare') {
             steps {
                 slackSend botUser: true, channel: '#pmm-ci', color: '#FFFF00', message: "[${specName}]: build started - ${BUILD_URL}"
-                git poll: true, branch: GIT_BRANCH, url: "https://github.com/Percona-Lab/percona-images.git"
+                git poll: true, branch: GIT_BRANCH, url: "https://github.com/percona/pmm-server.git"
                 sh """
                     make clean
                     make deps

--- a/pmm/pmm2-ami.groovy
+++ b/pmm/pmm2-ami.groovy
@@ -13,7 +13,7 @@ pipeline {
     }
     parameters {
         string(
-            defaultValue: 'master',
+            defaultValue: 'PMM-2.0',
             description: 'Tag/Branch for pmm-server repository',
             name: 'GIT_BRANCH')
         choice(

--- a/pmm/pmm2-ovf.groovy
+++ b/pmm/pmm2-ovf.groovy
@@ -9,7 +9,7 @@ pipeline {
         string(
             defaultValue: 'master',
             description: 'Tag/Branch for pmm-server repository',
-            name: 'GIT_BRANCH')
+            name: 'PMM_SERVER_BRANCH')
         choice(
             choices: ['no', 'yes'],
             description: "Build Release Candidate?",
@@ -27,7 +27,7 @@ pipeline {
         stage('Prepare') {
             steps {
                 slackSend botUser: true, channel: '#pmm-ci', color: '#FFFF00', message: "[${specName}]: build started - ${BUILD_URL}"
-                git poll: true, branch: GIT_BRANCH, url: "https://github.com/percona/pmm-server.git"
+                git poll: true, branch: PMM_SERVER_BRANCH, url: "https://github.com/percona/pmm-server.git"
                 sh """
                     make clean
                     make fetch

--- a/pmm/pmm2-ovf.groovy
+++ b/pmm/pmm2-ovf.groovy
@@ -7,7 +7,7 @@ pipeline {
     }
     parameters {
         string(
-            defaultValue: 'master',
+            defaultValue: 'PMM-2.0',
             description: 'Tag/Branch for pmm-server repository',
             name: 'PMM_SERVER_BRANCH')
         choice(

--- a/pmm/pmm2-ovf.groovy
+++ b/pmm/pmm2-ovf.groovy
@@ -8,7 +8,7 @@ pipeline {
     parameters {
         string(
             defaultValue: 'master',
-            description: 'Tag/Branch for percona-images repository',
+            description: 'Tag/Branch for pmm-server repository',
             name: 'GIT_BRANCH')
         choice(
             choices: ['no', 'yes'],
@@ -27,7 +27,7 @@ pipeline {
         stage('Prepare') {
             steps {
                 slackSend botUser: true, channel: '#pmm-ci', color: '#FFFF00', message: "[${specName}]: build started - ${BUILD_URL}"
-                git poll: true, branch: GIT_BRANCH, url: "https://github.com/Percona-Lab/percona-images.git"
+                git poll: true, branch: GIT_BRANCH, url: "https://github.com/percona/pmm-server.git"
                 sh """
                     make clean
                     make fetch

--- a/pmm/pmm2-prepare-release-candidate.groovy
+++ b/pmm/pmm2-prepare-release-candidate.groovy
@@ -25,14 +25,14 @@ void runPMM2ClientAutobuild(String SUBMODULES_GIT_BRANCH, String DESTINATION) {
 
 void runPMM2AMIBuild(String SUBMODULES_GIT_BRANCH, String RELEASE_CANDIDATE) {
     pmm2AMI = build job: 'pmm2-ami', parameters: [
-        string(name: 'GIT_BRANCH', value: SUBMODULES_GIT_BRANCH),
+        string(name: 'PMM_SERVER_BRANCH', value: SUBMODULES_GIT_BRANCH),
         string(name: 'RELEASE_CANDIDATE', value: RELEASE_CANDIDATE)
     ]
 }
 
 void runPMM2OVFBuild(String SUBMODULES_GIT_BRANCH, String RELEASE_CANDIDATE) {
     pmm2OVF = build job: 'pmm2-ovf', parameters: [
-        string(name: 'GIT_BRANCH', value: SUBMODULES_GIT_BRANCH),
+        string(name: 'PMM_SERVER_BRANCH', value: SUBMODULES_GIT_BRANCH),
         string(name: 'RELEASE_CANDIDATE', value: RELEASE_CANDIDATE)
     ]
 }

--- a/pmm/pmm2-prepare-release-candidate.groovy
+++ b/pmm/pmm2-prepare-release-candidate.groovy
@@ -49,12 +49,7 @@ def pmm_submodules() {
         "grafana-dashboards",
         "pmm-api-tests",
         "pmm-ui-tests",
-        "pmm-qa"
-    ]
-}
-
-def dependent_submodules() {
-    return [
+        "pmm-qa",
         "mysqld_exporter",
         "grafana",
         "dbaas-controller",
@@ -72,10 +67,6 @@ def dependent_submodules() {
 void deleteReleaseBranches(String VERSION, String GIT_BRANCH) {
 
     pmm_submodules().each { submodule ->
-        println "Deleting Release branch for : $submodule"
-        deleteBranch(submodule, 'release-' + VERSION)
-    }
-    dependent_submodules().each { submodule ->
         println "Deleting Release branch for : $submodule"
         deleteBranch(submodule, 'pmm-' + VERSION)
     }
@@ -99,10 +90,6 @@ void setupReleaseBranches(String VERSION, String GIT_BRANCH) {
         git checkout \${RELEASE_BRANCH}
     '''
     pmm_submodules().each { submodule ->
-        println "Preparing Release branch for Submodule: $submodule"
-        createBranch(submodule, 'release-' + VERSION)
-    }
-    dependent_submodules().each { submodule ->
         println "Preparing Release branch for Submodule: $submodule"
         createBranch(submodule, 'pmm-' + VERSION)
     }

--- a/pmm/pmm2-prepare-release-candidate.groovy
+++ b/pmm/pmm2-prepare-release-candidate.groovy
@@ -3,36 +3,36 @@ library changelog: false, identifier: 'lib@master', retriever: modernSCM([
     remote: 'https://github.com/Percona-Lab/jenkins-pipelines.git'
 ]) _
 
-void runSubmodulesRewind(String GIT_BRANCH) {
+void runSubmodulesRewind(String SUBMODULES_GIT_BRANCH) {
     rewindSubmodule = build job: 'pmm2-rewind-submodules-fb', propagate: false, parameters: [
-        string(name: 'GIT_BRANCH', value: GIT_BRANCH)
+        string(name: 'GIT_BRANCH', value: SUBMODULES_GIT_BRANCH)
     ]
 }
 
-void runPMM2ServerAutobuild(String GIT_BRANCH, String DESTINATION) {
+void runPMM2ServerAutobuild(String SUBMODULES_GIT_BRANCH, String DESTINATION) {
     pmm2Server = build job: 'pmm2-server-autobuild', parameters: [
-        string(name: 'GIT_BRANCH', value: GIT_BRANCH),
+        string(name: 'GIT_BRANCH', value: SUBMODULES_GIT_BRANCH),
         string(name: 'DESTINATION', value: DESTINATION)
     ]
 }
 
-void runPMM2ClientAutobuild(String GIT_BRANCH, String DESTINATION) {
+void runPMM2ClientAutobuild(String SUBMODULES_GIT_BRANCH, String DESTINATION) {
     pmm2Client = build job: 'pmm2-client-autobuilds', parameters: [
-        string(name: 'GIT_BRANCH', value: GIT_BRANCH),
+        string(name: 'GIT_BRANCH', value: SUBMODULES_GIT_BRANCH),
         string(name: 'DESTINATION', value: DESTINATION)
     ]
 }
 
-void runPMM2AMIBuild(String GIT_BRANCH, String RELEASE_CANDIDATE) {
+void runPMM2AMIBuild(String SUBMODULES_GIT_BRANCH, String RELEASE_CANDIDATE) {
     pmm2AMI = build job: 'pmm2-ami', parameters: [
-        string(name: 'GIT_BRANCH', value: GIT_BRANCH),
+        string(name: 'GIT_BRANCH', value: SUBMODULES_GIT_BRANCH),
         string(name: 'RELEASE_CANDIDATE', value: RELEASE_CANDIDATE)
     ]
 }
 
-void runPMM2OVFBuild(String GIT_BRANCH, String RELEASE_CANDIDATE) {
+void runPMM2OVFBuild(String SUBMODULES_GIT_BRANCH, String RELEASE_CANDIDATE) {
     pmm2OVF = build job: 'pmm2-ovf', parameters: [
-        string(name: 'GIT_BRANCH', value: GIT_BRANCH),
+        string(name: 'GIT_BRANCH', value: SUBMODULES_GIT_BRANCH),
         string(name: 'RELEASE_CANDIDATE', value: RELEASE_CANDIDATE)
     ]
 }
@@ -64,7 +64,7 @@ def pmm_submodules() {
     ]
 }
 
-void deleteReleaseBranches(String VERSION, String GIT_BRANCH) {
+void deleteReleaseBranches(String VERSION) {
 
     pmm_submodules().each { submodule ->
         println "Deleting Release branch for : $submodule"
@@ -83,7 +83,7 @@ void deleteReleaseBranches(String VERSION, String GIT_BRANCH) {
     }
 }
 
-void setupReleaseBranches(String VERSION, String GIT_BRANCH) {
+void setupReleaseBranches(String VERSION) {
 
     sh '''
         git branch \${RELEASE_BRANCH}
@@ -171,7 +171,7 @@ pipeline {
         string(
             defaultValue: 'PMM-2.0',
             description: 'Prepare Submodules from pmm-submodules branch',
-            name: 'GIT_BRANCH')
+            name: 'SUBMODULES_GIT_BRANCH')
         string(
             defaultValue: '',
             description: 'Release Version',
@@ -200,7 +200,7 @@ pipeline {
             }
             steps {
                 git branch: env.RELEASE_BRANCH, credentialsId: 'GitHub SSH Key', poll: false, url: 'git@github.com:Percona-Lab/pmm-submodules'
-                deleteReleaseBranches(VERSION, GIT_BRANCH)
+                deleteReleaseBranches(VERSION)
             }
         }
         stage('Checkout Submodules and Prepare for creating branches') {
@@ -208,13 +208,13 @@ pipeline {
                 expression { env.EXIST.toInteger() == 0 }
             }
             steps {
-                git branch: GIT_BRANCH, credentialsId: 'GitHub SSH Key', poll: false, url: 'git@github.com:Percona-Lab/pmm-submodules'
+                git branch: SUBMODULES_GIT_BRANCH, credentialsId: 'GitHub SSH Key', poll: false, url: 'git@github.com:Percona-Lab/pmm-submodules'
                 sh """
                     sudo yum install -y git wget jq
                     git config --global user.email "dev-services@percona.com"
                     git config --global user.name "PMM Jenkins"
                 """
-                setupReleaseBranches(VERSION, GIT_BRANCH)
+                setupReleaseBranches(VERSION)
             }
         }
         stage('Rewind Release Submodule') {

--- a/pmm/pmm2-prepare-release-candidate.groovy
+++ b/pmm/pmm2-prepare-release-candidate.groovy
@@ -65,8 +65,7 @@ def dependent_submodules() {
         "proxysql_exporter",
         "rds_exporter",
         "azure_metrics_exporter",
-        "percona-toolkit",
-        "percona-images"
+        "percona-toolkit"
     ]
 }
 

--- a/pmm/pmm2-prepare-release-candidate.groovy
+++ b/pmm/pmm2-prepare-release-candidate.groovy
@@ -186,9 +186,9 @@ pipeline {
             steps {
                 deleteDir()
                 script {
-                    env.RELEASE_BRANCH = 'release-' + VERSION
+                    env.RELEASE_BRANCH = 'pmm-' + VERSION
                     env.EXIST = sh (
-                        script: 'git ls-remote --heads https://github.com/Percona-Lab/pmm-submodules release-\${VERSION} | wc -l',
+                        script: 'git ls-remote --heads https://github.com/Percona-Lab/pmm-submodules pmm-\${VERSION} | wc -l',
                         returnStdout: true
                     ).trim()
                 }


### PR DESCRIPTION
https://github.com/Percona-Lab/pmm-submodules/pull/1892

We have three changes here:
1. We moved the content of percona-images to pmm-server.
2. We use pmm-2.x.y release branch format for ALL repos.
3. I changed the name of GIT_BRANCH to SUBMODULES_GIT_BRANCHES because Jenkins already has GIT_BRANCH variable. I only change it in pmm2-prepare-release-candidate.groovy because we already have an issue with it but I think we'll change it in all pipelines. 