### PR TITLE
PXC-3698: Error log indicates wrong Galera build commit hash

### DIFF
--- a/pxc/local/build-binary-pxc
+++ b/pxc/local/build-binary-pxc
@@ -102,7 +102,15 @@ PRODUCT="Percona-XtraDB-Cluster_$MYSQL_VERSION-$PERCONA_SERVER_VERSION"
 TOKUDB_BACKUP_VERSION="${MYSQL_VERSION}${MYSQL_VERSION_EXTRA}"
 PRODUCT_FULL="Percona-XtraDB-Cluster_${MYSQL_VERSION}-${PERCONA_SERVER_VERSION}${BUILD_COMMENT}-${TAG}$(uname -s)${DIST_NAME}.${TARGET_ARCH}${SSL_VER}"
 COMMENT="Percona XtraDB Cluster binar  (GPL), Release ${MYSQL_VERSION_EXTRA#-}, Revision ${REVISION:-}${BUILD_COMMENT}"
-GALERA_REVISION=$(cat "$SOURCEDIR/percona-xtradb-cluster-galera/GALERA-REVISION")
+if [[ -n "$(which git)" ]] && [[ -f "$SOURCEDIR/percona-xtradb-cluster-galera/.git" ]]; then
+    pushd $SOURCEDIR/percona-xtradb-cluster-galera
+    GALERA_REVISION=$(git rev-parse --short HEAD)
+    popd
+else
+    # When in troubles while getting Galera commit hash, fall back to well known
+    # and distinguishable value.
+    GALERA_REVISION="0000000"
+fi
 PERCONA_SERVER_EXTENSION="$(echo $MYSQL_VERSION_EXTRA | sed 's/^-//')"
 
 if [[ "${OS_VERSION}" = *"CentOS release 6."* ]] || [[ "${OS_VERSION}" = *"CentOS Linux release 7."* ]]; then


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3698

1. Try to get actual Galera repo commit hash
2. If not possible fallback to '0000000' value

@dutow @Sudokamikaze @vorsel , I'm adding all of you guys as the reviewers, because this change needs touching 3 pieces (there will be 3 PRs):
1. Dev Jenkins build script
2. pxc_builder.sh and build-binary.sh scripts used by release/packaging Jenkins pipeline
3. Galera repository