### PR TITLE
Change worker from micro to large for pmm-testsuite

### DIFF
--- a/pmm/pmm2-testsuite.groovy
+++ b/pmm/pmm2-testsuite.groovy
@@ -102,7 +102,7 @@ void fetchAgentLog(String CLIENT_VERSION) {
 
 pipeline {
     agent {
-        label 'micro-amazon'
+        label 'large-amazon'
     }
     parameters {
         string(


### PR DESCRIPTION
We are running out of space due to some new tests that have been added, we have added docker-cleanup too, https://pmm.cd.percona.com/job/pmm2-testsuite/6964/consoleFull