### PR TITLE
PS-7851: Add Debian Bullseye support to PS package testing

### DIFF
--- a/ps/jenkins/package-testing-ps-5.7.groovy
+++ b/ps/jenkins/package-testing-ps-5.7.groovy
@@ -6,6 +6,7 @@ library changelog: false, identifier: 'lib@master', retriever: modernSCM([
 List all_nodes = [
     "min-stretch-x64",
     "min-buster-x64",
+    "min-bullseye-x64",
     "min-centos-6-x64",
     "min-centos-7-x64",
     "min-centos-8-x64",
@@ -100,6 +101,18 @@ pipeline {
 
                     steps {
                         runNodeBuild("min-buster-x64")
+                    }
+                }
+
+                stage("Debian Bullseye") {
+                    when {
+                        expression {
+                            nodes_to_test.contains("min-bullseye-x64")
+                        }
+                    }
+
+                    steps {
+                        runNodeBuild("min-bullseye-x64")
                     }
                 }
 

--- a/ps/jenkins/package-testing-ps-5.7.yml
+++ b/ps/jenkins/package-testing-ps-5.7.yml
@@ -38,6 +38,7 @@
                 - "all"
                 - "min-stretch-x64"
                 - "min-buster-x64"
+                - "min-bullseye-x64"
                 - "min-centos-6-x64"
                 - "min-centos-7-x64"
                 - "min-centos-8-x64"

--- a/ps/jenkins/package-testing-ps-8.0.groovy
+++ b/ps/jenkins/package-testing-ps-8.0.groovy
@@ -6,6 +6,7 @@ library changelog: false, identifier: 'lib@master', retriever: modernSCM([
 List all_nodes = [
     "min-stretch-x64",
     "min-buster-x64",
+    "min-bullseye-x64",
     "min-centos-6-x64",
     "min-centos-7-x64",
     "min-centos-8-x64",
@@ -100,6 +101,18 @@ pipeline {
 
                     steps {
                         runNodeBuild("min-buster-x64")
+                    }
+                }
+
+                stage("Debian Bullseye") {
+                    when {
+                        expression {
+                            nodes_to_test.contains("min-bullseye-x64")
+                        }
+                    }
+
+                    steps {
+                        runNodeBuild("min-bullseye-x64")
                     }
                 }
 

--- a/ps/jenkins/package-testing-ps-8.0.yml
+++ b/ps/jenkins/package-testing-ps-8.0.yml
@@ -38,6 +38,7 @@
                 - "all"
                 - "min-stretch-x64"
                 - "min-buster-x64"
+                - "min-bullseye-x64"
                 - "min-centos-6-x64"
                 - "min-centos-7-x64"
                 - "min-centos-8-x64"

--- a/ps/jenkins/package-testing-ps-build-5.7.groovy
+++ b/ps/jenkins/package-testing-ps-build-5.7.groovy
@@ -30,7 +30,7 @@ setup_stretch_package_tests = { ->
     '''
 }
 
-setup_buster_package_tests = { ->
+setup_debian_package_tests = { ->
     sh '''
         sudo apt-get update
         sudo apt-get install -y ansible git wget
@@ -48,7 +48,8 @@ setup_ubuntu_package_tests = { ->
 
 node_setups = [
     "min-stretch-x64": setup_stretch_package_tests,
-    "min-buster-x64": setup_buster_package_tests,
+    "min-buster-x64": setup_debian_package_tests,
+    "min-bullseye-x64": setup_debian_package_tests,
     "min-centos-6-x64": setup_rhel_package_tests,
     "min-centos-7-x64": setup_rhel_package_tests,
     "min-centos-8-x64": setup_rhel_package_tests,

--- a/ps/jenkins/package-testing-ps-build-5.7.yml
+++ b/ps/jenkins/package-testing-ps-build-5.7.yml
@@ -39,6 +39,7 @@
             choices:
                 - "min-stretch-x64"
                 - "min-buster-x64"
+                - "min-bullseye-x64"
                 - "min-centos-6-x64"
                 - "min-centos-7-x64"
                 - "min-centos-8-x64"

--- a/ps/jenkins/package-testing-ps-build-8.0.groovy
+++ b/ps/jenkins/package-testing-ps-build-8.0.groovy
@@ -30,7 +30,7 @@ setup_stretch_package_tests = { ->
     '''
 }
 
-setup_buster_package_tests = { ->
+setup_debian_package_tests = { ->
     sh '''
         sudo apt-get update
         sudo apt-get install -y ansible git wget
@@ -48,7 +48,8 @@ setup_ubuntu_package_tests = { ->
 
 node_setups = [
     "min-stretch-x64": setup_stretch_package_tests,
-    "min-buster-x64": setup_buster_package_tests,
+    "min-buster-x64": setup_debian_package_tests,
+    "min-bullseye-x64": setup_debian_package_tests,
     "min-centos-6-x64": setup_rhel_package_tests,
     "min-centos-7-x64": setup_rhel_package_tests,
     "min-centos-8-x64": setup_rhel_package_tests,

--- a/ps/jenkins/package-testing-ps-build-8.0.yml
+++ b/ps/jenkins/package-testing-ps-build-8.0.yml
@@ -39,6 +39,7 @@
             choices:
                 - "min-stretch-x64"
                 - "min-buster-x64"
+                - "min-bullseye-x64"
                 - "min-centos-6-x64"
                 - "min-centos-7-x64"
                 - "min-centos-8-x64"


### PR DESCRIPTION
This PR adds support for Debian 11 "Bullseye" to the PS 8.0 and PS 5.7 package testing Jenkins jobs.