### PR TITLE
PS-7851: Exclude Bullseye from tests using PS 5.6

### DIFF
--- a/ps/jenkins/package-testing-ps-build-5.7.groovy
+++ b/ps/jenkins/package-testing-ps-build-5.7.groovy
@@ -66,6 +66,7 @@ void setup_package_tests() {
 List all_nodes = node_setups.keySet().collect()
 
 List ps56_excluded_nodes = [
+    "min-bullseye-x64",
     "min-centos-8-x64",
     "min-focal-x64",
 ]


### PR DESCRIPTION
This PR is a fixup for #1146: there will never be a 5.6 build for Bullseye, so tests running on Bullseye should not attempt to test upgrading from 5.6.