### PR TITLE
Fix failing pmm2-testsuite

### DIFF
--- a/pmm/pmm2-testsuite.groovy
+++ b/pmm/pmm2-testsuite.groovy
@@ -3,6 +3,12 @@ import hudson.slaves.*
 import jenkins.model.Jenkins
 import hudson.plugins.sshslaves.SSHLauncher
 
+library changelog: false, identifier: 'lib@master', retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/Percona-Lab/jenkins-pipelines.git'
+]) _
+
+
 void runStaging(String DOCKER_VERSION, CLIENT_VERSION, CLIENTS, PMM_QA_GIT_BRANCH, PMM_QA_GIT_COMMIT_HASH) {
     stagingJob = build job: 'aws-staging-start', parameters: [
         string(name: 'DOCKER_VERSION', value: DOCKER_VERSION),

--- a/pmm/pmm2-testsuite.groovy
+++ b/pmm/pmm2-testsuite.groovy
@@ -8,7 +8,6 @@ library changelog: false, identifier: 'lib@master', retriever: modernSCM([
     remote: 'https://github.com/Percona-Lab/jenkins-pipelines.git'
 ]) _
 
-
 void runStaging(String DOCKER_VERSION, CLIENT_VERSION, CLIENTS, PMM_QA_GIT_BRANCH, PMM_QA_GIT_COMMIT_HASH) {
     stagingJob = build job: 'aws-staging-start', parameters: [
         string(name: 'DOCKER_VERSION', value: DOCKER_VERSION),


### PR DESCRIPTION
Fixes the issue with new changes for ecr docker tag
```
java.lang.NoSuchMethodError: No such DSL method 'installAWSv2' found among steps
```