### PR TITLE
PXC-3633: Add ASAN support to PXC builds

### DIFF
--- a/pxc/docker/run-build-pxc
+++ b/pxc/docker/run-build-pxc
@@ -25,6 +25,7 @@ docker run --rm \
     export TAG='${TAG}'
     export DIST_NAME='${DIST_NAME}'
     export SSL_VER='${SSL_VER}'
+    export WITH_ASAN='${WITH_ASAN}'
 
     mkdir /tmp/results
    

--- a/pxc/docker/run-build-pxc56
+++ b/pxc/docker/run-build-pxc56
@@ -25,6 +25,7 @@ docker run --rm \
     export TAG='${TAG}'
     export DIST_NAME='${DIST_NAME}'
     export SSL_VER='${SSL_VER}'
+    export WITH_ASAN='${WITH_ASAN}'
 
     mkdir /tmp/results
    

--- a/pxc/docker/run-build-pxc57
+++ b/pxc/docker/run-build-pxc57
@@ -25,6 +25,7 @@ docker run --rm \
     export TAG='${TAG}'
     export DIST_NAME='${DIST_NAME}'
     export SSL_VER='${SSL_VER}'
+    export WITH_ASAN='${WITH_ASAN}'
 
     mkdir /tmp/results
    

--- a/pxc/jenkins/param.yml
+++ b/pxc/jenkins/param.yml
@@ -62,6 +62,12 @@
         - "yes"
         - "no"
         description: Run mysql-test-run.pl
+    - choice:
+        name: WITH_ASAN
+        choices:
+        - "no"
+        - "yes"
+        description: Build with ASAN
     - string:
         name: PARALLEL_RUN
         default: "4"

--- a/pxc/jenkins/param56.yml
+++ b/pxc/jenkins/param56.yml
@@ -63,6 +63,12 @@
         - "no"
         description: Run mysql-test-run.pl
     - choice:
+        name: WITH_ASAN
+        choices:
+        - "no"
+        - "yes"
+        description: Build with ASAN
+    - choice:
         name: HOTBACKUP_TESTING
         choices:
         - "yes"

--- a/pxc/jenkins/param57.yml
+++ b/pxc/jenkins/param57.yml
@@ -54,6 +54,12 @@
         - "yes"
         - "no"
         description: Run mysql-test-run.pl
+    - choice:
+        name: WITH_ASAN
+        choices:
+        - "no"
+        - "yes"
+        description: Build with ASAN
     - string:
         name: PARALLEL_RUN
         default: "4"

--- a/pxc/jenkins/pxc56-pipeline.groovy
+++ b/pxc/jenkins/pxc56-pipeline.groovy
@@ -60,6 +60,10 @@ pipeline {
             choices: 'yes\nno',
             description: 'Run mysql-test-run.pl',
             name: 'DEFAULT_TESTING')
+        choice(
+            choices: 'no\nyes',
+            description: 'Build with ASAN',
+            name: 'WITH_ASAN')
         string(
             defaultValue: '--unit-tests-report --big-test --suite=galera,galera_3nodes,sys_vars',
             description: 'mysql-test-run.pl options, for options like: --big-test --only-big-test --nounit-tests --unit-tests-report',

--- a/pxc/jenkins/pxc57-pipeline.groovy
+++ b/pxc/jenkins/pxc57-pipeline.groovy
@@ -50,6 +50,10 @@ pipeline {
             choices: 'yes\nno',
             description: 'Run mysql-test-run.pl',
             name: 'DEFAULT_TESTING')
+        choice(
+            choices: 'no\nyes',
+            description: 'Build with ASAN',
+            name: 'WITH_ASAN')
 		string(
 		    defaultValue: '4',
 		    description: 'mtr can start n parallel server and distrbute workload among them. More parallelism is better but extra parallelism (beyond CPU power) will have less effect. This value is used for all test suites except Galera specific suites.',

--- a/pxc/jenkins/pxc57-pipeline.yml
+++ b/pxc/jenkins/pxc57-pipeline.yml
@@ -53,6 +53,12 @@
         - "yes"
         - "no"
         description: Run mysql-test-run.pl
+    - choice:
+        name: WITH_ASAN
+        choices:
+        - "no"
+        - "yes"
+        description: Build with ASAN
     - string:
         name: PARALLEL_RUN
         default: "4"

--- a/pxc/jenkins/pxc80-pipeline.groovy
+++ b/pxc/jenkins/pxc80-pipeline.groovy
@@ -64,6 +64,10 @@ pipeline {
             choices: 'yes\nno',
             description: 'Run mysql-test-run.pl',
             name: 'DEFAULT_TESTING')
+        choice(
+            choices: 'no\nyes',
+            description: 'Build with ASAN',
+            name: 'WITH_ASAN')
         string(
             defaultValue: '4',
             description: 'mtr can start n parallel server and distrbute workload among them. More parallelism is better but extra parallelism (beyond CPU power) will have less effect. This value is used for all test suites except Galera specific suites.',

--- a/pxc/jenkins/pxc80-pipeline.yml
+++ b/pxc/jenkins/pxc80-pipeline.yml
@@ -65,6 +65,12 @@
         - "yes"
         - "no"
         description: Run mysql-test-run.pl
+    - choice:
+        name: WITH_ASAN
+        choices:
+        - "no"
+        - "yes"
+        description: Build with ASAN
     - string:
         name: PARALLEL_RUN
         default: "4"

--- a/pxc/local/build-binary-pxc
+++ b/pxc/local/build-binary-pxc
@@ -17,6 +17,7 @@ TAG=${TAG:-}
 DIST_NAME=${DIST_NAME:-}
 SSL_VER=${SSL_VER:-}
 TARGET_CFLAGS=${TARGET_CFLAGS:-}
+WITH_ASAN=${WITH_ASAN:-no}
 
 
 # ------------------------------------------------------------------------------
@@ -78,6 +79,10 @@ if [[ "${CMAKE_BUILD_TYPE}" = "Debug" ]]; then
 fi
 if [[ "${ANALYZER_OPTS}" = *WITH_VALGRIND=ON* ]]; then
     BUILD_COMMENT+="-valgrind"
+fi
+if [[ "${WITH_ASAN}" = "yes" ]]; then
+    CMAKE_OPTS+=" -DWITH_ASAN=ON"
+    BUILD_COMMENT+="-asan"
 fi
 
 OS_VERSION=$(lsb_release -d -s)

--- a/pxc/local/build-binary-pxc56
+++ b/pxc/local/build-binary-pxc56
@@ -17,6 +17,7 @@ TAG=${TAG:-}
 DIST_NAME=${DIST_NAME:-}
 SSL_VER=${SSL_VER:-}
 TARGET_CFLAGS=${TARGET_CFLAGS:-}
+WITH_ASAN=${WITH_ASAN:-no}
 
 
 # ------------------------------------------------------------------------------
@@ -50,6 +51,10 @@ if [[ "${CMAKE_BUILD_TYPE}" = "Debug" ]]; then
 fi
 if [[ "${ANALYZER_OPTS}" = *WITH_VALGRIND=ON* ]]; then
     BUILD_COMMENT+="-valgrind"
+fi
+if [[ "${WITH_ASAN}" = "yes" ]]; then
+    CMAKE_OPTS+=" -DWITH_ASAN=ON"
+    BUILD_COMMENT+="-asan"
 fi
 
 OS_VERSION=$(lsb_release -d -s)

--- a/pxc/local/build-binary-pxc57
+++ b/pxc/local/build-binary-pxc57
@@ -17,6 +17,7 @@ TAG=${TAG:-}
 DIST_NAME=${DIST_NAME:-}
 SSL_VER=${SSL_VER:-}
 TARGET_CFLAGS=${TARGET_CFLAGS:-}
+WITH_ASAN=${WITH_ASAN:-no}
 
 
 # ------------------------------------------------------------------------------
@@ -62,6 +63,10 @@ if [[ "${CMAKE_BUILD_TYPE}" = "Debug" ]]; then
 fi
 if [[ "${ANALYZER_OPTS}" = *WITH_VALGRIND=ON* ]]; then
     BUILD_COMMENT+="-valgrind"
+fi
+if [[ "${WITH_ASAN}" = "yes" ]]; then
+    CMAKE_OPTS+=" -DWITH_ASAN=ON"
+    BUILD_COMMENT+="-asan"
 fi
 
 OS_VERSION=$(lsb_release -d -s)


### PR DESCRIPTION
This PR adds ASAN support to the PXC build param/pipeline jobs.

Test builds can be found at wip-noemi-pxc-{[8.0](https://pxc.cd.percona.com/job/wip-noemi-pxc-8.0-pipeline/),[5.7](https://pxc.cd.percona.com/job/wip-noemi-pxc-5.7-pipeline/),[5.6](https://pxc.cd.percona.com/job/wip-noemi-pxc-5.6-pipeline/)}-pipeline and wip-noemi-pxc-{[8.0](https://pxc.cd.percona.com/job/wip-noemi-pxc-8.0-param/),[5.7](https://pxc.cd.percona.com/job/wip-noemi-pxc-5.7-param/),[5.6](https://pxc.cd.percona.com/job/wip-noemi-pxc-5.6-param/)}-param.