### PR TITLE
PXC-3632: Run PXC param job weekly for 8.0 and 5.7

### DIFF
--- a/pxc/jenkins/param.yml
+++ b/pxc/jenkins/param.yml
@@ -4,6 +4,8 @@
     defaults: global
     description: |
         Do not edit this job through the web!
+    triggers:
+    - timed: "@weekly"
     disabled: false
     concurrent: true
     auth-token: pxc80testmtr

--- a/pxc/jenkins/param57.yml
+++ b/pxc/jenkins/param57.yml
@@ -4,6 +4,8 @@
     defaults: global
     description: |
         Do not edit this job through the web!
+    triggers:
+    - timed: "@weekly"
     disabled: false
     concurrent: true
     auth-token: pxc57testmtr


### PR DESCRIPTION
This PR adds a weekly schedule trigger to the PXC build jobs for 8.0 and 5.7. 

Verified that the change is correctly added to the configuration on https://pxc.cd.percona.com/job/wip-noemi-pxc-8.0-param/ and https://pxc.cd.percona.com/job/wip-noemi-pxc-5.7-param/.

It should be possible to merge this PR and #1160 in any order, since their changes don't overlap, but if there's any issues let me know and I'll rebase.