### PR TITLE
Bump up PXB `docker-32gb` max instances cap

### DIFF
--- a/IaC/pxb.cd/init.groovy.d/cloud.groovy
+++ b/IaC/pxb.cd/init.groovy.d/cloud.groovy
@@ -258,7 +258,7 @@ initMap['min-focal-x64'] = initMap['debMap']
 capMap = [:]
 capMap['c5.xlarge'] = '40'
 capMap['m4.xlarge'] = '10'
-capMap['m4.2xlarge'] = '10'
+capMap['m4.2xlarge'] = '40'
 capMap['m1.medium'] = '10'
 
 typeMap = [:]


### PR DESCRIPTION
This PR bumps up the maximum amount of `docker-32gb` instances allowed simultaneously in the `pxb.cd` instance. I changed the value from 10 to 40, as it is set to 40 on `pxc.cd`.

When running the `percona-xtrabackup-8.0-multijob` Jenkins job, @altmannmarcelo noticed timeouts in some of the builds. It seems like the `percona-xtrabackup-8.0-test-param` job attempts to launch 32 jobs in parallel, and it will be 36 once Debian 11 support is added. Since the cap is currently set to 10 and the builds take several hours to complete, some of the builds time out before they can have a node assigned to them.