### PR TITLE
PXB-2568: Remove `ubuntu:xenial` DOCKER_OS option from PXB pipeline jobs

### DIFF
--- a/pxb/v2/jenkins/percona-xtrabackup-8.0-compile-pipeline.groovy
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.0-compile-pipeline.groovy
@@ -13,7 +13,7 @@ pipeline {
             name: 'BRANCH',
             trim: true)
         choice(
-            choices: 'centos:7\ncentos:8\nubuntu:xenial\nubuntu:bionic\nubuntu:focal\ndebian:stretch\ndebian:buster\nasan',
+            choices: 'centos:7\ncentos:8\nubuntu:bionic\nubuntu:focal\ndebian:stretch\ndebian:buster\nasan',
             description: 'OS version for compilation',
             name: 'DOCKER_OS')
         choice(

--- a/pxb/v2/jenkins/percona-xtrabackup-8.0-compile-pipeline.yml
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.0-compile-pipeline.yml
@@ -27,7 +27,6 @@
         choices:
         - centos:7
         - centos:8
-        - ubuntu:xenial
         - ubuntu:bionic
         - ubuntu:focal
         - debian:stretch

--- a/pxb/v2/jenkins/percona-xtrabackup-8.0-test-param.yml
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.0-test-param.yml
@@ -50,7 +50,6 @@
         values:
         - centos:7
         - centos:8
-        - ubuntu:xenial
         - ubuntu:bionic
         - ubuntu:focal
         - debian:stretch

--- a/pxb/v2/jenkins/percona-xtrabackup-8.0-test-pipeline.groovy
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.0-test-pipeline.groovy
@@ -3,7 +3,7 @@ pipeline_timeout = 10
 pipeline {
     parameters {
         choice(
-            choices: 'centos:7\ncentos:8\nubuntu:xenial\nubuntu:bionic\nubuntu:focal\ndebian:stretch\ndebian:buster\nasan',
+            choices: 'centos:7\ncentos:8\nubuntu:bionic\nubuntu:focal\ndebian:stretch\ndebian:buster\nasan',
             description: 'OS version for compilation',
             name: 'DOCKER_OS')
         choice(


### PR DESCRIPTION
This PR removes the `ubuntu:xenial` option from the Jenkins jobs belonging to the PXB build and test pipeline in the `pxb.cd` instance.