### PR TITLE
CLOUD-613 - Push xml report to S3 and add test aggregator job

### DIFF
--- a/cloud/jenkins/psmdb_operator_gke_version.groovy
+++ b/cloud/jenkins/psmdb_operator_gke_version.groovy
@@ -136,7 +136,7 @@ void runTest(String TEST_NAME, String CLUSTER_PREFIX) {
 
                     export KUBECONFIG=/tmp/$CLUSTER_NAME-${CLUSTER_PREFIX}
                     source $HOME/google-cloud-sdk/path.bash.inc
-                    # ./e2e-tests/$TEST_NAME/run
+                    ./e2e-tests/$TEST_NAME/run
                 fi
             """
             pushArtifactFile("${params.GIT_BRANCH}#${env.GIT_SHORT_COMMIT}#$TEST_NAME#${params.PLATFORM_VER}#$MDB_TAG")

--- a/cloud/jenkins/test-results-aggregator.yml
+++ b/cloud/jenkins/test-results-aggregator.yml
@@ -1,0 +1,34 @@
+- job:
+    name: test-results-aggregator
+    project-type: pipeline
+    description: |
+        Do not edit this job through the web!
+    concurrent: false
+    properties:
+    - build-discarder:
+        days-to-keep: -1
+        num-to-keep: 30
+        artifact-days-to-keep: -1
+        artifact-num-to-keep: 30
+    pipeline-scm:
+      scm:
+        - git:
+            url: https://github.com/Percona-Lab/jenkins-pipelines.git
+            branches:
+            - master
+            wipe-workspace: false
+      lightweight-checkout: true
+      script-path: cloud/jenkins/test_results_aggregator.groovy
+    parameters:
+    - choice:
+        name: PRODUCT
+        choices:
+          - PSMDB
+          - PXC
+          - PG
+        description: Product for which test results should be collected
+    - string:
+        name: GIT_COMMIT
+        default: xxxyyyzz 
+        description: Short git commit hash for which test results should be collected
+

--- a/cloud/jenkins/test_results_aggregator.groovy
+++ b/cloud/jenkins/test_results_aggregator.groovy
@@ -1,0 +1,60 @@
+pipeline {
+    environment {
+        CLOUDSDK_CORE_DISABLE_PROMPTS = 1
+    }
+    parameters {
+        choice(
+            choices: 'PSMDBO\nPXCO\nPGO',
+            description: 'Product for which test results should be collected',
+            name: 'PRODUCT')
+        string(
+            defaultValue: 'xxxyyyzz',
+            description: 'Short git commit hash for which test results should be collected',
+            name: 'GIT_COMMIT')
+    }
+    agent {
+        label 'docker'
+    }
+    options {
+        skipDefaultCheckout()
+        disableConcurrentBuilds()
+    }
+
+    stages {
+        stage('Collect test results') {
+            steps {
+                withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AMI/OVF', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
+                    sh """
+                        case "\${PRODUCT}" in
+                            PSMDBO)
+                                jobs=("psmdb-operator-gke-version" "psmdb-operator-gke-latest" "psmdb-operator-aws-openshift-latest" "psmdb-operator-aws-openshift-4" "psmdb-operator-eks" "psmdb-operator-minikube")
+                                ;;
+                            PXCO)
+                                jobs=("pxc-operator-gke-version" "pxc-operator-gke-latest" "pxc-operator-aws-openshift-latest" "pxc-operator-aws-openshift-4" "pxc-operator-eks" "pxc-operator-minikube")
+                                ;;
+                            PGO)
+                                jobs=("pgo-operator-gke-version" "pgo-operator-gke-latest" "pgo-operator-aws-openshift-latest" "pgo-operator-aws-openshift-4" "pgo-operator-eks" "pgo-operator-minikube")
+                                ;;
+                        esac
+
+                        for job in \${jobs[@]}; do
+                            echo "Downloading files from job: \$job"
+                            mkdir -p \$job/\$GIT_COMMIT
+                            pushd \$job/\$GIT_COMMIT >/dev/null
+                            aws s3 cp s3://percona-jenkins-artifactory/\$job/\$GIT_COMMIT . --recursive --exclude "*" --include "*.xml"
+                            find . -name "*.xml" -exec touch {} \\;
+                            echo "---"
+                            popd >/dev/null
+                        done
+                    """
+                }
+            }
+        }
+        stage('Publish and archive results') {
+            steps {
+                step([$class: 'JUnitResultArchiver', testResults: '**/*.xml', healthScaleFactor: 1.0])
+                archiveArtifacts '**/*.xml'
+            }
+        }
+    }
+}


### PR DESCRIPTION
The idea is to push junit xml report to S3 bucket for every run and then have one aggregator job which takes parameters `product` and `git_commit` and which copies the test results from all jobs and shows them in one place.
The benefit is that S3 bucket will include info on both passed, but also failed tests and when running tests for release we can collect the test results for different combinations of platform versions and database versions.

Also I have changed the format of filenames in S3 bucket from eg. "main-9de97343-version-service-1.21-main" to "main#9de97343#version-service#1.21#main" because git branches can contain dashes and underscores so this is safer for parsing.

Job example: https://cloud.cd.percona.com/job/test-results-aggregator/
Test results example: https://cloud.cd.percona.com/job/test-results-aggregator/lastCompletedBuild/testReport/(root)/

**=== When we agree about this I will make changes to other jobs (now only one PSMDB job is changed). ===**