### PR TITLE
remove outdated auto-refresh option

### DIFF
--- a/cloud/jenkins/pg_containers_docker_build.groovy
+++ b/cloud/jenkins/pg_containers_docker_build.groovy
@@ -18,10 +18,10 @@ void checkImageForDocker(String IMAGE_POSTFIX){
                     TrityHightLog="$WORKSPACE/trivy-hight-\$IMAGE_NAME-ppg\${PG_VER}-${IMAGE_POSTFIX}.log"
                     TrityCriticaltLog="$WORKSPACE/trivy-critical-\$IMAGE_NAME-ppg\${PG_VER}-${IMAGE_POSTFIX}.log"
                     /usr/local/bin/trivy -o \$TrityHightLog --ignore-unfixed --exit-code 0 --severity HIGH --quiet \
-                        --auto-refresh perconalab/\$IMAGE_NAME:${GIT_PD_BRANCH}-ppg\${PG_VER}-${IMAGE_POSTFIX}
+                        perconalab/\$IMAGE_NAME:${GIT_PD_BRANCH}-ppg\${PG_VER}-${IMAGE_POSTFIX}
 
                     /usr/local/bin/trivy -o \$TrityCriticaltLog --ignore-unfixed --exit-code 0 --severity CRITICAL --quiet \
-                        --auto-refresh perconalab/\$IMAGE_NAME:${GIT_PD_BRANCH}-ppg\${PG_VER}-${IMAGE_POSTFIX}
+                        perconalab/\$IMAGE_NAME:${GIT_PD_BRANCH}-ppg\${PG_VER}-${IMAGE_POSTFIX}
 
                     if [ ! -s \$TrityHightLog ]; then
                         rm -rf \$TrityHightLog

--- a/cloud/jenkins/ps_containers_docker_build.groovy
+++ b/cloud/jenkins/ps_containers_docker_build.groovy
@@ -15,10 +15,10 @@ void checkImageForDocker(String IMAGE_POSTFIX){
                 TrityHightLog="$WORKSPACE/trivy-hight-percona-server-mysql-operator-${IMAGE_POSTFIX}.log"
                 TrityCriticaltLog="$WORKSPACE/trivy-critical-percona-server-mysql-operator-${IMAGE_POSTFIX}.log"
                 /usr/local/bin/trivy -o \$TrityHightLog --ignore-unfixed --exit-code 0 --severity HIGH --quiet \
-                    --auto-refresh perconalab/percona-server-mysql-operator:${GIT_PD_BRANCH}-${IMAGE_POSTFIX}
+                    perconalab/percona-server-mysql-operator:${GIT_PD_BRANCH}-${IMAGE_POSTFIX}
 
                 /usr/local/bin/trivy -o \$TrityCriticaltLog --ignore-unfixed --exit-code 0 --severity CRITICAL --quiet \
-                    --auto-refresh perconalab/percona-server-mysql-operator:${GIT_PD_BRANCH}-${IMAGE_POSTFIX}
+                    perconalab/percona-server-mysql-operator:${GIT_PD_BRANCH}-${IMAGE_POSTFIX}
 
                 if [ ! -s \$TrityHightLog ]; then
                     rm -rf \$TrityHightLog

--- a/cloud/jenkins/pxc_containers_docker_build.groovy
+++ b/cloud/jenkins/pxc_containers_docker_build.groovy
@@ -30,8 +30,8 @@ void checkImageForDocker(String IMAGE_PREFIX){
 
             sg docker -c "
                 docker login -u '${USER}' -p '${PASS}'
-                /usr/local/bin/trivy -o \$TrityHightLog --ignore-unfixed --exit-code 0 --severity HIGH --quiet --auto-refresh perconalab/\$IMAGE_NAME:main-${IMAGE_PREFIX}
-                /usr/local/bin/trivy -o \$TrityCriticaltLog --ignore-unfixed --exit-code 0 --severity CRITICAL --quiet --auto-refresh perconalab/\$IMAGE_NAME:main-${IMAGE_PREFIX}
+                /usr/local/bin/trivy -o \$TrityHightLog --ignore-unfixed --exit-code 0 --severity HIGH --quiet perconalab/\$IMAGE_NAME:main-${IMAGE_PREFIX}
+                /usr/local/bin/trivy -o \$TrityCriticaltLog --ignore-unfixed --exit-code 0 --severity CRITICAL --quiet perconalab/\$IMAGE_NAME:main-${IMAGE_PREFIX}
             "
 
             if [ ! -s \$TrityHightLog ]; then


### PR DESCRIPTION
the issue on Jenkins
```
USAGE:
   trivy [global options] command [command options] target

VERSION:
   0.20.2

2021-10-26T10:04:50.130Z	[31mFATAL[0m	flag provided but not defined: -auto-refresh
Incorrect Usage. flag provided but not defined: -auto-refresh
```