### PR TITLE
K8SPXC-895 - default-cr test cannot run on minikube

### DIFF
--- a/cloud/jenkins/pxc_operator_minikube.groovy
+++ b/cloud/jenkins/pxc_operator_minikube.groovy
@@ -274,7 +274,6 @@ pipeline {
                     }
 
                     installRpms()
-                    conditionalRunTest('default-cr')
                     runTest('affinity')
                     runTest('auto-tuning')
                     runTest('limits')


### PR DESCRIPTION
because of anti-affinity rules