### PR TITLE
FIXED PXB-2638 - ASAN job ignores CMAKE_OPTIONS

### DIFF
--- a/pxb/v2/local/build-binary
+++ b/pxb/v2/local/build-binary
@@ -78,7 +78,7 @@ if [[ -n "$(which git)" ]] && [[ -d "${SOURCEDIR}/.git" ]]; then
 fi
 
 if [[ "${ASAN_SWITCH}" == "ON" ]]; then
-    CMAKE_OPTS=+" -DWITH_ASAN=ON"
+    CMAKE_OPTS+=" -DWITH_ASAN=ON"
     TAG+="-asan"
 fi
 


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2638

build-binary was incorrectly appending -DWITH_ASAN to CMAKE_OPTS
variable.