### PR TITLE
PMM-7 use static version

### DIFF
--- a/vars/pmmVersion.groovy
+++ b/vars/pmmVersion.groovy
@@ -17,7 +17,7 @@ def call(type='latest') {
   List<String> versionsList = new ArrayList<>(versions.keySet());
   switch(type) {
     case 'latest':
-      return versions.keySet().last()
+      return '2.26.0'
     case 'ami':
       return versions
     case 'list':


### PR DESCRIPTION
The latest version is broken now and a temporary solution is to use a static version