### PR TITLE
Add --force to eksctl delete in cloud pipelines

### DIFF
--- a/cloud/jenkins/pgo_operator_eks.groovy
+++ b/cloud/jenkins/pgo_operator_eks.groovy
@@ -346,7 +346,7 @@ EOF
                 withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'eks-cicd', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
                     unstash 'cluster_conf'
                     sh """
-                        eksctl delete cluster -f cluster.yaml --wait
+                        eksctl delete cluster -f cluster.yaml --wait --force
                     """
                 }
 

--- a/cloud/jenkins/psmdb_operator_eks.groovy
+++ b/cloud/jenkins/psmdb_operator_eks.groovy
@@ -309,7 +309,7 @@ EOF
                 withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'eks-cicd', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
                     unstash 'cluster_conf'
                     sh """
-                        eksctl delete cluster -f cluster.yaml --wait
+                        eksctl delete cluster -f cluster.yaml --wait --force
                     """
                 }
 

--- a/cloud/jenkins/pxc_operator_eks.groovy
+++ b/cloud/jenkins/pxc_operator_eks.groovy
@@ -378,7 +378,7 @@ EOF
                 withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'eks-cicd', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
                     unstash 'cluster_conf'
                     sh """
-                        eksctl delete cluster -f cluster.yaml --wait
+                        eksctl delete cluster -f cluster.yaml --wait --force
                     """
                 }
 


### PR DESCRIPTION
Deleting CloudFormation Stack fails if there are still existing pods, it tries to drain pods in the nodes and fails because of pod disruption budget.
So this should fix it and prevent manual cleanup of CloudFormation stacks.
There was a `--drain=false` option before, but it doesn't seem to exist any more.
Here's how it looks:
```
2021-12-20 14:15:39 [!]  ignoring DaemonSet-managed Pods: kube-system/aws-node-xh5ll, kube-system/kube-proxy-pc7mx
2021-12-20 14:15:39 [!]  pod eviction error ("error evicting pod: default-cr-10000/my-cluster-name-cfg-2: Cannot evict pod as it would violate the pod's disruption budget.") on node ip-192-168-35-185.eu-west-3.compute.internal
2021-12-20 14:15:44 [!]  ignoring DaemonSet-managed Pods: kube-system/aws-node-fkfcj, kube-system/kube-proxy-rr8xw
2021-12-20 14:15:44 [!]  pod eviction error ("error evicting pod: default-cr-10000/my-cluster-name-cfg-0: Cannot evict pod as it would violate the pod's disruption budget.") on node ip-192-168-79-46.eu-west-3.compute.internal
2021-12-20 14:15:49 [!]  ignoring DaemonSet-managed Pods: kube-system/aws-node-xh5ll, kube-system/kube-proxy-pc7mx
2021-12-20 14:15:49 [!]  pod eviction error ("error evicting pod: default-cr-10000/my-cluster-name-cfg-2: Cannot evict pod as it would violate the pod's disruption budget.") on node ip-192-168-35-185.eu-west-3.compute.internal
2021-12-20 14:15:55 [!]  ignoring DaemonSet-managed Pods: kube-system/aws-node-fkfcj, kube-system/kube-proxy-rr8xw
2021-12-20 14:15:55 [!]  pod eviction error ("error evicting pod: default-cr-10000/my-cluster-name-cfg-0: Cannot evict pod as it would violate the pod's disruption budget.") on node ip-192-168-79-46.eu-west-3.compute.internal
2021-12-20 14:16:00 [!]  ignoring DaemonSet-managed Pods: kube-system/aws-node-xh5ll, kube-system/kube-proxy-pc7mx
2021-12-20 14:16:00 [!]  pod eviction error ("error evicting pod: default-cr-10000/my-cluster-name-cfg-2: Cannot evict pod as it would violate the pod's disruption budget.") on node ip-192-168-35-185.eu-west-3.compute.internal
2021-12-20 14:16:05 [!]  ignoring DaemonSet-managed Pods: kube-system/aws-node-fkfcj, kube-system/kube-proxy-rr8xw
2021-12-20 14:16:05 [!]  pod eviction error ("error evicting pod: default-cr-10000/my-cluster-name-cfg-0: Cannot evict pod as it would violate the pod's disruption budget.") on node ip-192-168-79-46.eu-west-3.compute.internal
Error: Unauthorized
```