### PR TITLE
[ENG-1082] fix: CentOS 6 CA certificates are too old

### DIFF
--- a/IaC/pmm.cd/init.groovy.d/cloud.groovy
+++ b/IaC/pmm.cd/init.groovy.d/cloud.groovy
@@ -81,6 +81,7 @@ initMap = [:]
 initMap['rpmMap'] = '''
     set -o xtrace
     RHVER=$(rpm --eval %rhel)
+    ARCH=$(uname -m)
     SYSREL=$(cat /etc/system-release | tr -dc '0-9.'|awk -F'.' {'print $1'})
 
     if ! mountpoint -q /mnt; then
@@ -96,7 +97,11 @@ initMap['rpmMap'] = '''
         fi
     fi
     if [[ ${RHVER} -eq 6 ]]; then
-        sudo curl https://jenkins.percona.com/downloads/cent6/centos6-eol.repo --output /etc/yum.repos.d/CentOS-Base.repo
+        if [[ ${ARCH} == "x86_64" ]]; then
+            sudo curl https://jenkins.percona.com/downloads/cent6/centos6-eol.repo --output /etc/yum.repos.d/CentOS-Base.repo
+        else
+            sudo curl -k https://jenkins.percona.com/downloads/cent6/centos6-eol-s3.repo --output /etc/yum.repos.d/CentOS-Base.repo
+        fi
         until sudo yum makecache; do
             sleep 1
             echo try again


### PR DESCRIPTION
This PR is related to #1358, split due to different code owners  