### PR TITLE
Fix trivy timeout for PSMDB 5.0

### DIFF
--- a/cloud/jenkins/psmdb_docker_build.groovy
+++ b/cloud/jenkins/psmdb_docker_build.groovy
@@ -24,8 +24,8 @@ void checkImageForDocker(String IMAGE_SUFFIX){
 
             sg docker -c "
                 docker login -u '${USER}' -p '${PASS}'
-                /usr/local/bin/trivy -q --cache-dir /mnt/jenkins/trivy-${JOB_NAME}/ image -o \$TrityHightLog --timeout 10m0s --ignore-unfixed --exit-code 0 --severity HIGH perconalab/\$IMAGE_NAME:\${IMAGE_SUFFIX}
-                /usr/local/bin/trivy -q --cache-dir /mnt/jenkins/trivy-${JOB_NAME}/ image -o \$TrityCriticaltLog --timeout 10m0s --ignore-unfixed --exit-code 0 --severity CRITICAL perconalab/\$IMAGE_NAME:\${IMAGE_SUFFIX}
+                /usr/local/bin/trivy -q --cache-dir /mnt/jenkins/trivy-${JOB_NAME}/ image -o \$TrityHightLog --timeout 15m0s --ignore-unfixed --exit-code 0 --severity HIGH perconalab/\$IMAGE_NAME:\${IMAGE_SUFFIX}
+                /usr/local/bin/trivy -q --cache-dir /mnt/jenkins/trivy-${JOB_NAME}/ image -o \$TrityCriticaltLog --timeout 15m0s --ignore-unfixed --exit-code 0 --severity CRITICAL perconalab/\$IMAGE_NAME:\${IMAGE_SUFFIX}
             "
 
             if [ ! -s \$TrityHightLog ]; then


### PR DESCRIPTION
Following issue is seen with PSMDB 5.0:
```
+ sg docker -c '
                docker login -u '\'****\'' -p '\'****\''
                /usr/local/bin/trivy -q --cache-dir /mnt/jenkins/trivy-psmdb-docker-build/ image -o /mnt/jenkins/workspace/psmdb-docker-build/trivy-hight-percona-server-mongodb-operator-main-mongod5.0-debug.log --timeout 10m0s --ignore-unfixed --exit-code 0 --severity HIGH perconalab/percona-server-mongodb-operator:main-mongod5.0-debug
                /usr/local/bin/trivy -q --cache-dir /mnt/jenkins/trivy-psmdb-docker-build/ image -o /mnt/jenkins/workspace/psmdb-docker-build/trivy-critical-percona-server-mongodb-operator-main-mongod5.0-debug.log --timeout 10m0s --ignore-unfixed --exit-code 0 --severity CRITICAL perconalab/percona-server-mongodb-operator:main-mongod5.0-debug
            '
WARNING! Using --password via the CLI is insecure. Use --password-stdin.
WARNING! Your password will be stored unencrypted in /home/ec2-user/.docker/config.json.
Configure a credential helper to remove this warning. See
https://docs.docker.com/engine/reference/commandline/login/#credentials-store

Login Succeeded
2022-03-08T19:51:01.333Z	[31mFATAL[0m	scan error: image scan failed: failed analysis: analyze error: timeout: context deadline exceeded
2022-03-08T20:01:02.385Z	[31mFATAL[0m	scan error: image scan failed: failed analysis: analyze error: timeout: context deadline exceeded
```