### PR TITLE
Fix trivy invocation

### DIFF
--- a/cloud/jenkins/pg_containers_docker_build.groovy
+++ b/cloud/jenkins/pg_containers_docker_build.groovy
@@ -17,10 +17,10 @@ void checkImageForDocker(String IMAGE_POSTFIX){
                 for PG_VER in 14 13 12; do
                     TrityHightLog="$WORKSPACE/trivy-hight-\$IMAGE_NAME-ppg\${PG_VER}-${IMAGE_POSTFIX}.log"
                     TrityCriticaltLog="$WORKSPACE/trivy-critical-\$IMAGE_NAME-ppg\${PG_VER}-${IMAGE_POSTFIX}.log"
-                    /usr/local/bin/trivy -o \$TrityHightLog --ignore-unfixed --exit-code 0 --severity HIGH --quiet \
+                    /usr/local/bin/trivy -q --cache-dir /mnt/jenkins/trivy-${JOB_NAME}/ image -o \$TrityHightLog --ignore-unfixed --exit-code 0 --severity HIGH \
                         perconalab/\$IMAGE_NAME:${GIT_PD_BRANCH}-ppg\${PG_VER}-${IMAGE_POSTFIX}
 
-                    /usr/local/bin/trivy -o \$TrityCriticaltLog --ignore-unfixed --exit-code 0 --severity CRITICAL --quiet \
+                    /usr/local/bin/trivy -q --cache-dir /mnt/jenkins/trivy-${JOB_NAME}/ image -o \$TrityCriticaltLog --ignore-unfixed --exit-code 0 --severity CRITICAL \
                         perconalab/\$IMAGE_NAME:${GIT_PD_BRANCH}-ppg\${PG_VER}-${IMAGE_POSTFIX}
 
                     if [ ! -s \$TrityHightLog ]; then

--- a/cloud/jenkins/ps_containers_docker_build.groovy
+++ b/cloud/jenkins/ps_containers_docker_build.groovy
@@ -14,10 +14,10 @@ void checkImageForDocker(String IMAGE_POSTFIX){
 
                 TrityHightLog="$WORKSPACE/trivy-hight-percona-server-mysql-operator-${IMAGE_POSTFIX}.log"
                 TrityCriticaltLog="$WORKSPACE/trivy-critical-percona-server-mysql-operator-${IMAGE_POSTFIX}.log"
-                /usr/local/bin/trivy -o \$TrityHightLog --ignore-unfixed --exit-code 0 --severity HIGH --quiet \
+                /usr/local/bin/trivy -q --cache-dir /mnt/jenkins/trivy-${JOB_NAME}/ image -o \$TrityHightLog --ignore-unfixed --exit-code 0 --severity HIGH \
                     perconalab/percona-server-mysql-operator:${GIT_PD_BRANCH}-${IMAGE_POSTFIX}
 
-                /usr/local/bin/trivy -o \$TrityCriticaltLog --ignore-unfixed --exit-code 0 --severity CRITICAL --quiet \
+                /usr/local/bin/trivy -q --cache-dir /mnt/jenkins/trivy-${JOB_NAME}/ image -o \$TrityCriticaltLog --ignore-unfixed --exit-code 0 --severity CRITICAL \
                     perconalab/percona-server-mysql-operator:${GIT_PD_BRANCH}-${IMAGE_POSTFIX}
 
                 if [ ! -s \$TrityHightLog ]; then

--- a/cloud/jenkins/pxc_containers_docker_build.groovy
+++ b/cloud/jenkins/pxc_containers_docker_build.groovy
@@ -30,8 +30,8 @@ void checkImageForDocker(String IMAGE_PREFIX){
 
             sg docker -c "
                 docker login -u '${USER}' -p '${PASS}'
-                /usr/local/bin/trivy -o \$TrityHightLog --ignore-unfixed --exit-code 0 --severity HIGH --quiet perconalab/\$IMAGE_NAME:main-${IMAGE_PREFIX}
-                /usr/local/bin/trivy -o \$TrityCriticaltLog --ignore-unfixed --exit-code 0 --severity CRITICAL --quiet perconalab/\$IMAGE_NAME:main-${IMAGE_PREFIX}
+                /usr/local/bin/trivy -q --cache-dir /mnt/jenkins/trivy-${JOB_NAME}/ image -o \$TrityHightLog --ignore-unfixed --exit-code 0 --severity HIGH perconalab/\$IMAGE_NAME:main-${IMAGE_PREFIX}
+                /usr/local/bin/trivy -q --cache-dir /mnt/jenkins/trivy-${JOB_NAME}/ image -o \$TrityCriticaltLog --ignore-unfixed --exit-code 0 --severity CRITICAL perconalab/\$IMAGE_NAME:main-${IMAGE_PREFIX}
             "
 
             if [ ! -s \$TrityHightLog ]; then


### PR DESCRIPTION
Following issue was visible in some jenkins jobs:
```
+ sg docker -c '
                IMAGE_NAME=percona-postgresql-operator
                docker login -u **** -p ****
                for PG_VER in 14 13 12; do
                    TrityHightLog="/mnt/jenkins/workspace/pg-containers-docker-build/trivy-hight-$IMAGE_NAME-ppg${PG_VER}-pgbackrest-repo.log"
                    TrityCriticaltLog="/mnt/jenkins/workspace/pg-containers-docker-build/trivy-critical-$IMAGE_NAME-ppg${PG_VER}-pgbackrest-repo.log"
                    /usr/local/bin/trivy -o $TrityHightLog --ignore-unfixed --exit-code 0 --severity HIGH --quiet                         perconalab/$IMAGE_NAME:main-ppg${PG_VER}-pgbackrest-repo

                    /usr/local/bin/trivy -o $TrityCriticaltLog --ignore-unfixed --exit-code 0 --severity CRITICAL --quiet                         perconalab/$IMAGE_NAME:main-ppg${PG_VER}-pgbackrest-repo

                    if [ ! -s $TrityHightLog ]; then
                        rm -rf $TrityHightLog
                    fi

                    if [ ! -s $TrityCriticaltLog ]; then
                        rm -rf $TrityCriticaltLog
                    fi
                done
            '
WARNING! Using --password via the CLI is insecure. Use --password-stdin.
WARNING! Your password will be stored unencrypted in /home/ec2-user/.docker/config.json.
Configure a credential helper to remove this warning. See
https://docs.docker.com/engine/reference/commandline/login/#credentials-store

Login Succeeded
Incorrect Usage. flag provided but not defined: -o
```