### PR TITLE
PXC-3730: PXC8 jenkins jobs should use latest PXB 2.4/8.0 version by …

### DIFF
--- a/pxc/local/checkout
+++ b/pxc/local/checkout
@@ -160,6 +160,10 @@ if [ "$SOURCE_NAME" == 'PXB24' -o "$SOURCE_NAME" == 'ALL' ]; then
         git reset --hard
         git clean -xdf
 
+        if [[ ${PXB24_LATEST} == "true" ]]; then
+            git checkout 2.4
+            unset PXB24_BRANCH && PXB24_BRANCH="$(git describe --tags --abbrev=0)"
+        fi
         if [ -n "${PXB24_BRANCH}" ]; then
             git checkout "${PXB24_BRANCH}" -b "tag-${PXB24_BRANCH}"
         fi


### PR DESCRIPTION
…default

https://jira.percona.com/browse/PXC-3730

It seems PR https://github.com/Percona-Lab/jenkins-pipelines/pull/1404
misses this modification. As the result PXB24 latest is not used.
Instead, the version specified in PXB24_BRANCH is used.