### PR TITLE
PXB-2422 - Update pxb80 platform for 8.0.28

### DIFF
--- a/pxb/jenkins/pxb80-single-platform-run.yml
+++ b/pxb/jenkins/pxb80-single-platform-run.yml
@@ -117,6 +117,7 @@
               PKGLIST="${PKGLIST} libaio-devel perl-DBD-MySQL vim-common ncurses-devel readline-devel"
               PKGLIST="${PKGLIST} zlib-devel libgcrypt-devel bison perl-Digest-MD5"
               PKGLIST="${PKGLIST} socat numactl-libs numactl"
+              PKGLIST="${PKGLIST} libudev-devel"
 
               if [[ ${RHEL} != 8 ]]; then
                   PKGLIST+=" python-sphinx python-docutils"
@@ -168,6 +169,7 @@
               PKGLIST="${PKGLIST} cmake debhelper libaio-dev libncurses-dev libssl-dev libtool libz-dev"
               PKGLIST="${PKGLIST} libgcrypt-dev libev-dev lsb-release python-docutils"
               PKGLIST="${PKGLIST} build-essential rsync libdbd-mysql-perl libnuma1 socat librtmp-dev liblz4-tool liblz4-1 liblz4-dev libtinfo5"
+              PKGLIST="${PKGLIST} libudev-dev"
               if [[ "$DIST" == 'focal' ]]; then
                   PKGLIST="${PKGLIST} python3-sphinx"
               else


### PR DESCRIPTION
*Problem*:

Project pxb80-single-platform-run fails with:

```
CMake Warning at cmake/fido2.cmake:53 (MESSAGE):
  Cannot find development libraries.  You need to install the required
  packages:

    Debian/Ubuntu:              apt install libudev-dev
    RedHat/Fedora/Oracle Linux: yum install libudev-devel
    SuSE:                       zypper install libudev-devel

Call Stack (most recent call first):
  CMakeLists.txt:1856 (WARN_MISSING_SYSTEM_UDEV)

-- CMAKE_MODULE_LINKER_FLAGS_DEBUG  -Wl,-rpath,'$ORIGIN/../../private'
-- CMAKE_SHARED_LINKER_FLAGS_DEBUG  -Wl,-rpath,'$ORIGIN/../../private'
CMake Error at CMakeLists.txt:1880 (ADD_SUBDIRECTORY):
  The source directory

    /mnt/jenkins/workspace/pxb80-single-platform-run/CMAKE_BUILD_TYPE/RelWithDebInfo/jenkins-pipelines/pxb/sources/pxb80/extra/libkmip

  does not contain a CMakeLists.txt file.
```

8.0.28 introduces the FIDO libraries which are build if not installed.
For them to be build some dependencies are required.

*Fix*:

Install required library.
