### PR TITLE
PXB-2693 - Initialize PS submodules

### DIFF
--- a/pxb/jenkins/checkout
+++ b/pxb/jenkins/checkout
@@ -42,6 +42,9 @@ if [ "$SOURCE_NAME" == 'PXB80' -o "$SOURCE_NAME" == 'ALL' ]; then
         if [ -n "${PXB80_REPO}" -a -n "${PXB80_BRANCH}" ]; then
             git pull origin ${PXB80_BRANCH}
         fi
+
+        git submodule deinit -f . || true
+        git submodule update --init --recursive
      popd
 fi
 
@@ -69,5 +72,8 @@ if [ "$SOURCE_NAME" == 'PXB24' -o "$SOURCE_NAME" == 'ALL' ]; then
         if [ -n "${PXB24_REPO}" -a -n "${PXB24_BRANCH}" ]; then
             git pull origin ${PXB24_BRANCH}
         fi
+
+        git submodule deinit -f . || true
+        git submodule update --init --recursive
     popd
 fi


### PR DESCRIPTION
PS 8.0.28 introduces a submodule for the first time.

If submodules are not initialized the compilation fails with:

```
CMake Error at CMakeLists.txt:1880 (ADD_SUBDIRECTORY):
  The source directory

    /mnt/jenkins/workspace/pxb80-single-platform-run/CMAKE_BUILD_TYPE/RelWithDebInfo/jenkins-pipelines/pxb/sources/pxb80/extra/libkmip

  does not contain a CMakeLists.txt file.
```
