### PR TITLE
PXB-7 fix "unsafe repository" git issue

### DIFF
--- a/pxb/jenkins/pxb80-single-platform-run.yml
+++ b/pxb/jenkins/pxb80-single-platform-run.yml
@@ -95,7 +95,13 @@
               export XBCLOUD_CREDENTIALS="--storage=google --google-access-key=$XBCLOUD_ACCESS_KEY --google-secret-key=$XBCLOUD_SECRET_KEY  $XBCLOUD_EXTRA"
           fi
           rm -rf jenkins-pipelines || true
+          # get git version for debug purpose
+          git --version || true
+
           git clone https://github.com/Percona-Lab/jenkins-pipelines
+          sudo git config --global --unset-all safe.directory || true
+          sudo git config --global --add safe.directory "$(pwd)/jenkins-pipelines"
+
           cd jenkins-pipelines
           if [ -f /usr/bin/yum ]; then
               sudo -E yum -y erase percona-release || true


### PR DESCRIPTION
Newer git versions require "safe.directory" to be set in order to
perform any actions with repo on behalf any other user