### PR TITLE
Update epel repo and remove unsupported distros for ps package-testing

### DIFF
--- a/ps/jenkins/package-testing-ps-5.7.groovy
+++ b/ps/jenkins/package-testing-ps-5.7.groovy
@@ -4,13 +4,9 @@ library changelog: false, identifier: 'lib@master', retriever: modernSCM([
 ]) _
 
 List all_nodes = [
-    "min-stretch-x64",
     "min-buster-x64",
-    "min-bullseye-x64",
-    "min-centos-6-x64",
     "min-centos-7-x64",
     "min-centos-8-x64",
-    "min-xenial-x64",
     "min-bionic-x64",
     "min-focal-x64",
     "min-amazon-2-x64",
@@ -80,18 +76,6 @@ pipeline {
 
         stage("Run parallel") {
             parallel {
-                stage("Debian Stretch") {
-                    when {
-                        expression {
-                            nodes_to_test.contains("min-stretch-x64")
-                        }
-                    }
-
-                    steps {
-                        runNodeBuild("min-stretch-x64")
-                    }
-                }
-
                 stage("Debian Buster") {
                     when {
                         expression {
@@ -101,30 +85,6 @@ pipeline {
 
                     steps {
                         runNodeBuild("min-buster-x64")
-                    }
-                }
-
-                stage("Debian Bullseye") {
-                    when {
-                        expression {
-                            nodes_to_test.contains("min-bullseye-x64")
-                        }
-                    }
-
-                    steps {
-                        runNodeBuild("min-bullseye-x64")
-                    }
-                }
-
-                stage("Centos 6") {
-                    when {
-                        expression {
-                            nodes_to_test.contains("min-centos-6-x64")
-                        }
-                    }
-
-                    steps {
-                        runNodeBuild("min-centos-6-x64")
                     }
                 }
 
@@ -149,18 +109,6 @@ pipeline {
 
                     steps {
                         runNodeBuild("min-centos-8-x64")
-                    }
-                }
-
-                stage("Ubuntu Xenial") {
-                    when {
-                        expression {
-                            nodes_to_test.contains("min-xenial-x64")
-                        }
-                    }
-
-                    steps {
-                        runNodeBuild("min-xenial-x64")
                     }
                 }
 

--- a/ps/jenkins/package-testing-ps-5.7.groovy
+++ b/ps/jenkins/package-testing-ps-5.7.groovy
@@ -7,6 +7,7 @@ List all_nodes = [
     "min-buster-x64",
     "min-centos-7-x64",
     "min-centos-8-x64",
+    "min-ol-8-x64",
     "min-bionic-x64",
     "min-focal-x64",
     "min-amazon-2-x64",
@@ -109,6 +110,18 @@ pipeline {
 
                     steps {
                         runNodeBuild("min-centos-8-x64")
+                    }
+                }
+
+                stage("Oracle Linux 8") {
+                    when {
+                        expression {
+                            nodes_to_test.contains("min-ol-8-x64")
+                        }
+                    }
+
+                    steps {
+                        runNodeBuild("min-ol-8-x64")
                     }
                 }
 

--- a/ps/jenkins/package-testing-ps-5.7.yml
+++ b/ps/jenkins/package-testing-ps-5.7.yml
@@ -39,6 +39,7 @@
                 - "min-buster-x64"
                 - "min-centos-7-x64"
                 - "min-centos-8-x64"
+                - "min-ol-8-x64"
                 - "min-bionic-x64"
                 - "min-focal-x64"
                 - "min-amazon-2-x64"

--- a/ps/jenkins/package-testing-ps-5.7.yml
+++ b/ps/jenkins/package-testing-ps-5.7.yml
@@ -36,13 +36,9 @@
             name: node_to_test
             choices:
                 - "all"
-                - "min-stretch-x64"
                 - "min-buster-x64"
-                - "min-bullseye-x64"
-                - "min-centos-6-x64"
                 - "min-centos-7-x64"
                 - "min-centos-8-x64"
-                - "min-xenial-x64"
                 - "min-bionic-x64"
                 - "min-focal-x64"
                 - "min-amazon-2-x64"

--- a/ps/jenkins/package-testing-ps-build-5.7.groovy
+++ b/ps/jenkins/package-testing-ps-build-5.7.groovy
@@ -39,6 +39,7 @@ node_setups = [
     "min-buster-x64": setup_debian_package_tests,
     "min-centos-7-x64": setup_rhel_package_tests,
     "min-centos-8-x64": setup_rhel_package_tests,
+    "min-ol-8-x64": setup_rhel_package_tests,
     "min-bionic-x64": setup_ubuntu_package_tests,
     "min-focal-x64": setup_ubuntu_package_tests,
     "min-amazon-2-x64": setup_amazon_package_tests,
@@ -52,6 +53,7 @@ List all_nodes = node_setups.keySet().collect()
 
 List ps56_excluded_nodes = [
     "min-centos-8-x64",
+    "min-ol-8-x64",
     "min-focal-x64",
 ]
 

--- a/ps/jenkins/package-testing-ps-build-5.7.groovy
+++ b/ps/jenkins/package-testing-ps-build-5.7.groovy
@@ -19,17 +19,6 @@ setup_amazon_package_tests = { ->
     '''
 }
 
-setup_stretch_package_tests = { ->
-    sh '''
-        sudo apt-get update
-        sudo apt-get install -y dirmngr gnupg2
-        echo "deb http://ppa.launchpad.net/ansible/ansible/ubuntu trusty main" | sudo tee -a /etc/apt/sources.list > /dev/null
-        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367
-        sudo apt-get update
-        sudo apt-get install -y ansible git wget
-    '''
-}
-
 setup_debian_package_tests = { ->
     sh '''
         sudo apt-get update
@@ -47,13 +36,9 @@ setup_ubuntu_package_tests = { ->
 }
 
 node_setups = [
-    "min-stretch-x64": setup_stretch_package_tests,
     "min-buster-x64": setup_debian_package_tests,
-    "min-bullseye-x64": setup_debian_package_tests,
-    "min-centos-6-x64": setup_rhel_package_tests,
     "min-centos-7-x64": setup_rhel_package_tests,
     "min-centos-8-x64": setup_rhel_package_tests,
-    "min-xenial-x64": setup_ubuntu_package_tests,
     "min-bionic-x64": setup_ubuntu_package_tests,
     "min-focal-x64": setup_ubuntu_package_tests,
     "min-amazon-2-x64": setup_amazon_package_tests,
@@ -66,7 +51,6 @@ void setup_package_tests() {
 List all_nodes = node_setups.keySet().collect()
 
 List ps56_excluded_nodes = [
-    "min-bullseye-x64",
     "min-centos-8-x64",
     "min-focal-x64",
 ]

--- a/ps/jenkins/package-testing-ps-build-5.7.yml
+++ b/ps/jenkins/package-testing-ps-build-5.7.yml
@@ -40,6 +40,7 @@
                 - "min-buster-x64"
                 - "min-centos-7-x64"
                 - "min-centos-8-x64"
+                - "min-ol-8-x64"
                 - "min-bionic-x64"
                 - "min-focal-x64"
                 - "min-amazon-2-x64"

--- a/ps/jenkins/package-testing-ps-build-5.7.yml
+++ b/ps/jenkins/package-testing-ps-build-5.7.yml
@@ -37,13 +37,9 @@
         - choice:
             name: node_to_test
             choices:
-                - "min-stretch-x64"
                 - "min-buster-x64"
-                - "min-bullseye-x64"
-                - "min-centos-6-x64"
                 - "min-centos-7-x64"
                 - "min-centos-8-x64"
-                - "min-xenial-x64"
                 - "min-bionic-x64"
                 - "min-focal-x64"
                 - "min-amazon-2-x64"


### PR DESCRIPTION
Centos package-test fails because sshpass package for ansible is not found (https://ps57.cd.percona.com/job/package-testing-ps57-build/294/execution/node/41/log/). Based on https://bugzilla.redhat.com/show_bug.cgi?id=2020679 sshpass was removed from epel repo and included to RHEL8.6. To install ansible for the test an EPEL archive will be used to install sshpass.

Additionally the unsupported releases are removed from the tests.