### PR TITLE
Remove unsupported distros and add OL8 for ps57 package-testing

### DIFF
--- a/ps/jenkins/package-testing-ps-5.7.groovy
+++ b/ps/jenkins/package-testing-ps-5.7.groovy
@@ -4,13 +4,9 @@ library changelog: false, identifier: 'lib@master', retriever: modernSCM([
 ]) _
 
 List all_nodes = [
-    "min-stretch-x64",
     "min-buster-x64",
-    "min-bullseye-x64",
-    "min-centos-6-x64",
     "min-centos-7-x64",
-    "min-centos-8-x64",
-    "min-xenial-x64",
+    "min-ol-8-x64",
     "min-bionic-x64",
     "min-focal-x64",
     "min-amazon-2-x64",
@@ -80,18 +76,6 @@ pipeline {
 
         stage("Run parallel") {
             parallel {
-                stage("Debian Stretch") {
-                    when {
-                        expression {
-                            nodes_to_test.contains("min-stretch-x64")
-                        }
-                    }
-
-                    steps {
-                        runNodeBuild("min-stretch-x64")
-                    }
-                }
-
                 stage("Debian Buster") {
                     when {
                         expression {
@@ -101,30 +85,6 @@ pipeline {
 
                     steps {
                         runNodeBuild("min-buster-x64")
-                    }
-                }
-
-                stage("Debian Bullseye") {
-                    when {
-                        expression {
-                            nodes_to_test.contains("min-bullseye-x64")
-                        }
-                    }
-
-                    steps {
-                        runNodeBuild("min-bullseye-x64")
-                    }
-                }
-
-                stage("Centos 6") {
-                    when {
-                        expression {
-                            nodes_to_test.contains("min-centos-6-x64")
-                        }
-                    }
-
-                    steps {
-                        runNodeBuild("min-centos-6-x64")
                     }
                 }
 
@@ -140,27 +100,15 @@ pipeline {
                     }
                 }
 
-                stage("Centos 8") {
+                stage("Oracle Linux 8") {
                     when {
                         expression {
-                            nodes_to_test.contains("min-centos-8-x64")
+                            nodes_to_test.contains("min-ol-8-x64")
                         }
                     }
 
                     steps {
-                        runNodeBuild("min-centos-8-x64")
-                    }
-                }
-
-                stage("Ubuntu Xenial") {
-                    when {
-                        expression {
-                            nodes_to_test.contains("min-xenial-x64")
-                        }
-                    }
-
-                    steps {
-                        runNodeBuild("min-xenial-x64")
+                        runNodeBuild("min-ol-8-x64")
                     }
                 }
 

--- a/ps/jenkins/package-testing-ps-5.7.yml
+++ b/ps/jenkins/package-testing-ps-5.7.yml
@@ -36,13 +36,9 @@
             name: node_to_test
             choices:
                 - "all"
-                - "min-stretch-x64"
                 - "min-buster-x64"
-                - "min-bullseye-x64"
-                - "min-centos-6-x64"
                 - "min-centos-7-x64"
-                - "min-centos-8-x64"
-                - "min-xenial-x64"
+                - "min-ol-8-x64"
                 - "min-bionic-x64"
                 - "min-focal-x64"
                 - "min-amazon-2-x64"

--- a/ps/jenkins/package-testing-ps-build-5.7.groovy
+++ b/ps/jenkins/package-testing-ps-build-5.7.groovy
@@ -11,22 +11,20 @@ setup_rhel_package_tests = { ->
     '''
 }
 
-setup_amazon_package_tests = { ->
+//Use Fedora epel-release for OL8 till PS-8268 is fixed
+setup_rhel_8_package_tests = { ->
     sh '''
-        sudo amazon-linux-extras install epel
+        sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
         sudo yum -y update
         sudo yum install -y ansible git wget
     '''
 }
 
-setup_stretch_package_tests = { ->
+setup_amazon_package_tests = { ->
     sh '''
-        sudo apt-get update
-        sudo apt-get install -y dirmngr gnupg2
-        echo "deb http://ppa.launchpad.net/ansible/ansible/ubuntu trusty main" | sudo tee -a /etc/apt/sources.list > /dev/null
-        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367
-        sudo apt-get update
-        sudo apt-get install -y ansible git wget
+        sudo amazon-linux-extras install epel
+        sudo yum -y update
+        sudo yum install -y ansible git wget
     '''
 }
 
@@ -47,13 +45,9 @@ setup_ubuntu_package_tests = { ->
 }
 
 node_setups = [
-    "min-stretch-x64": setup_stretch_package_tests,
     "min-buster-x64": setup_debian_package_tests,
-    "min-bullseye-x64": setup_debian_package_tests,
-    "min-centos-6-x64": setup_rhel_package_tests,
     "min-centos-7-x64": setup_rhel_package_tests,
-    "min-centos-8-x64": setup_rhel_package_tests,
-    "min-xenial-x64": setup_ubuntu_package_tests,
+    "min-ol-8-x64": setup_rhel_8_package_tests,
     "min-bionic-x64": setup_ubuntu_package_tests,
     "min-focal-x64": setup_ubuntu_package_tests,
     "min-amazon-2-x64": setup_amazon_package_tests,
@@ -66,8 +60,7 @@ void setup_package_tests() {
 List all_nodes = node_setups.keySet().collect()
 
 List ps56_excluded_nodes = [
-    "min-bullseye-x64",
-    "min-centos-8-x64",
+    "min-ol-8-x64",
     "min-focal-x64",
 ]
 

--- a/ps/jenkins/package-testing-ps-build-5.7.yml
+++ b/ps/jenkins/package-testing-ps-build-5.7.yml
@@ -37,13 +37,9 @@
         - choice:
             name: node_to_test
             choices:
-                - "min-stretch-x64"
                 - "min-buster-x64"
-                - "min-bullseye-x64"
-                - "min-centos-6-x64"
                 - "min-centos-7-x64"
-                - "min-centos-8-x64"
-                - "min-xenial-x64"
+                - "min-ol-8-x64"
                 - "min-bionic-x64"
                 - "min-focal-x64"
                 - "min-amazon-2-x64"


### PR DESCRIPTION
Remove unsupported for PS5.7 distros from test:
- bullseye;
- stretch;
- centos6;
- xenial.
Replace Centos8 with Oracle Linux8 . 
Successful test runs:
https://ps57.cd.percona.com/job/package-testing-ps57-eleonora/5/ (note: failed major update is expected due to percona-mysql-shell issue PS-8256).
Fedora epel-repo is used for Oracle Linux8 due to PS-8268.
