### PR TITLE
DISTMYSQL-178: add option to preserve test environment

### DIFF
--- a/pdps/orchestrator.groovy
+++ b/pdps/orchestrator.groovy
@@ -5,14 +5,14 @@ library changelog: false, identifier: "lib@master", retriever: modernSCM([
 
 
 pipeline {
-  agent {
-  label 'min-centos-7-x64'
-  }
-  environment {
-      PATH = '/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/home/ec2-user/.local/bin';
-      MOLECULE_DIR = "molecule/pdmysql/orchestrator";
-  }
-  parameters {
+    agent {
+    label 'min-centos-7-x64'
+    }
+    environment {
+        PATH = '/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/home/ec2-user/.local/bin';
+        MOLECULE_DIR = "molecule/pdmysql/orchestrator";
+    }
+    parameters {
         choice(
             name: 'REPO',
             description: 'PDMYSQL will be installed from this repo',
@@ -26,69 +26,71 @@ pipeline {
             defaultValue: '8.0.27',
             description: 'PDMYSQL version for test',
             name: 'VERSION'
-         )
+        )
         string(
             defaultValue: 'master',
             description: 'Branch for package-testing repository',
-            name: 'TESTING_BRANCH')
+            name: 'TESTING_BRANCH'
+        )
         string(
             defaultValue: 'master',
             description: 'Tests will be run from branch of  https://github.com/percona/orchestrator',
-            name: 'ORCHESTRATOR_TESTS_VERSION')
-  }
-  options {
-          withCredentials(moleculePdpsJenkinsCreds())
-          disableConcurrentBuilds()
-  }
-  stages {
-    stage('Checkout') {
-      steps {
-            deleteDir()
-            git poll: false, branch: TESTING_BRANCH, url: 'https://github.com/Percona-QA/package-testing.git'
-        }
+            name: 'ORCHESTRATOR_TESTS_VERSION'
+        )
     }
-    stage ('Prepare') {
-      steps {
-          script {
-              installMolecule()
+    options {
+        withCredentials(moleculePdpsJenkinsCreds())
+        disableConcurrentBuilds()
+    }
+    stages {
+        stage('Checkout') {
+            steps {
+                deleteDir()
+                git poll: false, branch: TESTING_BRANCH, url: 'https://github.com/Percona-QA/package-testing.git'
+            }
+        }
+        stage ('Prepare') {
+            steps {
+                script {
+                    installMolecule()
+                }
+            }
+        }
+        stage ('Create virtual machines') {
+            steps {
+                script{
+                    moleculeExecuteActionWithScenario(env.MOLECULE_DIR, "create", "ubuntu-bionic")
+                }
+            }
+        }
+        stage ('Run playbook for test') {
+            steps {
+                script{
+                    moleculeExecuteActionWithScenario(env.MOLECULE_DIR, "converge", "ubuntu-bionic")
+                }
+            }
+        }
+        stage ('Start testinfra tests') {
+            steps {
+                script{
+                    moleculeExecuteActionWithScenario(env.MOLECULE_DIR, "verify", "ubuntu-bionic")
+                }
+            }
+        }
+        stage ('Start Cleanup ') {
+            steps {
+                script {
+                    moleculeExecuteActionWithScenario(env.MOLECULE_DIR, "cleanup", "ubuntu-bionic")
+                }
             }
         }
     }
-    stage ('Create virtual machines') {
-      steps {
-          script{
-              moleculeExecuteActionWithScenario(env.MOLECULE_DIR, "create", "ubuntu-bionic")
+    post {
+        always {
+            script {
+                moleculeExecuteActionWithScenario(env.MOLECULE_DIR, "destroy", "ubuntu-bionic")
+                junit "${MOLECULE_DIR}/report.xml"
             }
         }
     }
-    stage ('Run playbook for test') {
-      steps {
-          script{
-              moleculeExecuteActionWithScenario(env.MOLECULE_DIR, "converge", "ubuntu-bionic")
-            }
-        }
-    }
-    stage ('Start testinfra tests') {
-      steps {
-            script{
-              moleculeExecuteActionWithScenario(env.MOLECULE_DIR, "verify", "ubuntu-bionic")
-            }
-        }
-    }
-    stage ('Start Cleanup ') {
-      steps {
-          script {
-              moleculeExecuteActionWithScenario(env.MOLECULE_DIR, "cleanup", "ubuntu-bionic")
-            }
-        }
-    }
-  }
-  post {
-    always {
-          script {
-             moleculeExecuteActionWithScenario(env.MOLECULE_DIR, "destroy", "ubuntu-bionic")
-             junit "${MOLECULE_DIR}/report.xml"
-        }
-    }
-  }
 }

--- a/pdps/orchestrator.groovy
+++ b/pdps/orchestrator.groovy
@@ -37,6 +37,14 @@ pipeline {
             description: 'Tests will be run from branch of  https://github.com/percona/orchestrator',
             name: 'ORCHESTRATOR_TESTS_VERSION'
         )
+        choice(
+            name: 'DESTROY_ENV',
+            description: 'Destroy VM after tests',
+            choices: [
+                'yes',
+                'no'
+            ]
+        )
     }
     options {
         withCredentials(moleculePdpsJenkinsCreds())
@@ -88,8 +96,10 @@ pipeline {
     post {
         always {
             script {
-                moleculeExecuteActionWithScenario(env.MOLECULE_DIR, "destroy", "ubuntu-bionic")
-                junit "${MOLECULE_DIR}/report.xml"
+                if (env.DESTROY_ENV == "yes") {
+                    moleculeExecuteActionWithScenario(env.MOLECULE_DIR, "destroy", "ubuntu-bionic")
+                    junit "${MOLECULE_DIR}/report.xml"
+                }
             }
         }
     }

--- a/pdps/pdps-upgrade.groovy
+++ b/pdps/pdps-upgrade.groovy
@@ -70,6 +70,14 @@ pipeline {
             description: 'Updated Percona Orchestrator version',
             name: 'ORCHESTRATOR_VERSION'
         )
+        choice(
+            name: 'DESTROY_ENV',
+            description: 'Destroy VM after tests',
+            choices: [
+                'yes',
+                'no'
+            ]
+        )
     }
     options {
         withCredentials(moleculePdpsJenkinsCreds())
@@ -86,7 +94,7 @@ pipeline {
         stage('Checkout') {
             steps {
                 deleteDir()
-            git poll: false, branch: TESTING_BRANCH, url: 'https://github.com/Percona-QA/package-testing.git'
+                git poll: false, branch: TESTING_BRANCH, url: 'https://github.com/Percona-QA/package-testing.git'
             }
         }
         stage ('Prepare') {
@@ -128,8 +136,10 @@ pipeline {
     post {
         always {
             script {
-                moleculeExecuteActionWithScenario(env.MOLECULE_DIR, "destroy", env.PLATFORM)
-                junit "${MOLECULE_DIR}/report.xml"
+                if (env.DESTROY_ENV == "yes") {
+                    moleculeExecuteActionWithScenario(env.MOLECULE_DIR, "destroy", env.PLATFORM)
+                    junit "${MOLECULE_DIR}/report.xml"
+                }
             }
         }
     }

--- a/pdps/pdps-upgrade.groovy
+++ b/pdps/pdps-upgrade.groovy
@@ -4,14 +4,14 @@ library changelog: false, identifier: "lib@master", retriever: modernSCM([
 ])
 
 pipeline {
-  agent {
-  label 'min-centos-7-x64'
-  }
-  environment {
-      PATH = '/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/home/ec2-user/.local/bin';
-      MOLECULE_DIR = "molecule/pdmysql/pdps-minor-upgrade";
-  }
-  parameters {
+    agent {
+    label 'min-centos-7-x64'
+    }
+    environment {
+        PATH = '/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/home/ec2-user/.local/bin';
+        MOLECULE_DIR = "molecule/pdmysql/pdps-minor-upgrade";
+    }
+    parameters {
         choice(
             name: 'PLATFORM',
             description: 'For what platform (OS) need to test',
@@ -38,7 +38,8 @@ pipeline {
         string(
             defaultValue: '8.0.28',
             description: 'Percona Server will be upgraded from this version',
-            name: 'FROM_VERSION')
+            name: 'FROM_VERSION'
+        )
         string(
             defaultValue: '8.0.29',
             description: 'Percona Server will be upgraded to this version',
@@ -47,88 +48,89 @@ pipeline {
         string(
             defaultValue: 'master',
             description: 'Branch for testing repository',
-            name: 'TESTING_BRANCH')
+            name: 'TESTING_BRANCH'
+        )
         string(
             defaultValue: '2.3.2',
             description: 'Updated Proxysql version',
             name: 'PROXYSQL_VERSION'
-         )
+        )
         string(
             defaultValue: '8.0.28',
             description: 'Updated PXB version',
             name: 'PXB_VERSION'
-         )
+        )
         string(
             defaultValue: '3.3.1',
             description: 'Updated Percona Toolkit version',
             name: 'PT_VERSION'
-         )
+        )
         string(
             defaultValue: '3.2.6',
             description: 'Updated Percona Orchestrator version',
             name: 'ORCHESTRATOR_VERSION'
-         )
-  }
-  options {
-          withCredentials(moleculePdpsJenkinsCreds())
-          disableConcurrentBuilds()
-  }
-  stages {
-    stage('Set build name'){
-      steps {
+        )
+    }
+    options {
+        withCredentials(moleculePdpsJenkinsCreds())
+        disableConcurrentBuilds()
+    }
+    stages {
+        stage('Set build name'){
+            steps {
                 script {
                     currentBuild.displayName = "${env.BUILD_NUMBER}-${env.PLATFORM}-${env.MOLECULE_DIR}"
                 }
             }
         }
-    stage('Checkout') {
-      steps {
-            deleteDir()
+        stage('Checkout') {
+            steps {
+                deleteDir()
             git poll: false, branch: TESTING_BRANCH, url: 'https://github.com/Percona-QA/package-testing.git'
+            }
         }
-    }
-    stage ('Prepare') {
-      steps {
-          script {
-              installMolecule()
+        stage ('Prepare') {
+            steps {
+                script {
+                    installMolecule()
+                }
+            }
+        }
+        stage ('Create virtual machines') {
+            steps {
+                script{
+                    moleculeExecuteActionWithScenario(env.MOLECULE_DIR, "create", env.PLATFORM)
+                }
+            }
+        }
+        stage ('Run playbook for test') {
+            steps {
+                script{
+                    moleculeExecuteActionWithScenario(env.MOLECULE_DIR, "converge", env.PLATFORM)
+                }
+            }
+        }
+        stage ('Start testinfra tests') {
+            steps {
+                script{
+                    moleculeExecuteActionWithScenario(env.MOLECULE_DIR, "verify", env.PLATFORM)
+                }
+            }
+        }
+        stage ('Start Cleanup ') {
+            steps {
+                script {
+                    moleculeExecuteActionWithScenario(env.MOLECULE_DIR, "cleanup", env.PLATFORM)
+                }
             }
         }
     }
-    stage ('Create virtual machines') {
-      steps {
-          script{
-              moleculeExecuteActionWithScenario(env.MOLECULE_DIR, "create", env.PLATFORM)
+    post {
+        always {
+            script {
+                moleculeExecuteActionWithScenario(env.MOLECULE_DIR, "destroy", env.PLATFORM)
+                junit "${MOLECULE_DIR}/report.xml"
             }
         }
     }
-    stage ('Run playbook for test') {
-      steps {
-          script{
-              moleculeExecuteActionWithScenario(env.MOLECULE_DIR, "converge", env.PLATFORM)
-            }
-        }
-    }
-    stage ('Start testinfra tests') {
-      steps {
-            script{
-              moleculeExecuteActionWithScenario(env.MOLECULE_DIR, "verify", env.PLATFORM)
-            }
-        }
-    }
-    stage ('Start Cleanup ') {
-      steps {
-          script {
-              moleculeExecuteActionWithScenario(env.MOLECULE_DIR, "cleanup", env.PLATFORM)
-            }
-        }
-    }
-  }
-  post {
-    always {
-          script {
-             moleculeExecuteActionWithScenario(env.MOLECULE_DIR, "destroy", env.PLATFORM)
-             junit "${MOLECULE_DIR}/report.xml"
-        }
-    }
-  }
 }

--- a/pdps/pdps.groovy
+++ b/pdps/pdps.groovy
@@ -67,6 +67,14 @@ pipeline {
             description: 'Tests will be run from branch of  https://github.com/percona/orchestrator',
             name: 'ORCHESTRATOR_TESTS_VERSION'
         )
+        choice(
+            name: 'DESTROY_ENV',
+            description: 'Destroy VM after tests',
+            choices: [
+                'yes',
+                'no'
+            ]
+        )
     }
     options {
           withCredentials(moleculePdpsJenkinsCreds())
@@ -125,8 +133,10 @@ pipeline {
     post {
         always {
             script {
-                moleculeExecuteActionWithScenario(env.MOLECULE_DIR, "destroy", env.PLATFORM)
-                junit "${MOLECULE_DIR}/report.xml"
+                if (env.DESTROY_ENV == "yes") {
+                    moleculeExecuteActionWithScenario(env.MOLECULE_DIR, "destroy", env.PLATFORM)
+                    junit "${MOLECULE_DIR}/report.xml"
+                }
             }
         }
     }

--- a/pdps/pdps.groovy
+++ b/pdps/pdps.groovy
@@ -5,14 +5,14 @@ library changelog: false, identifier: "lib@master", retriever: modernSCM([
 
 
 pipeline {
-  agent {
-  label 'min-centos-7-x64'
-  }
-  environment {
+    agent {
+    label 'min-centos-7-x64'
+    }
+    environment {
       PATH = '/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/home/ec2-user/.local/bin';
       MOLECULE_DIR = "molecule/pdmysql/${SCENARIO}";
-  }
-  parameters {
+    }
+    parameters {
         choice(
             name: 'PLATFORM',
             description: 'For what platform (OS) need to test',
@@ -31,27 +31,27 @@ pipeline {
             defaultValue: '8.0.23',
             description: 'Percona Server version for test',
             name: 'VERSION'
-         )
+        )
         string(
             defaultValue: '2.0.18',
             description: 'Proxysql version for test',
             name: 'PROXYSQL_VERSION'
-         )
+        )
         string(
             defaultValue: '8.0.23',
             description: 'PXB version for test',
             name: 'PXB_VERSION'
-         )
+        )
         string(
             defaultValue: '3.3.1',
             description: 'Percona toolkit version for test',
             name: 'PT_VERSION'
-         )
+        )
         string(
             defaultValue: '3.1.4',
             description: 'Percona Orchestrator version for test',
             name: 'ORCHESTRATOR_VERSION'
-         )
+        )
         choice(
             name: 'SCENARIO',
             description: 'Scenario for test',
@@ -60,72 +60,74 @@ pipeline {
         string(
             defaultValue: 'master',
             description: 'Branch for package-testing repository',
-            name: 'TESTING_BRANCH')
+            name: 'TESTING_BRANCH'
+        )
         string(
             defaultValue: 'master',
             description: 'Tests will be run from branch of  https://github.com/percona/orchestrator',
-            name: 'ORCHESTRATOR_TESTS_VERSION')
-  }
-  options {
+            name: 'ORCHESTRATOR_TESTS_VERSION'
+        )
+    }
+    options {
           withCredentials(moleculePdpsJenkinsCreds())
           disableConcurrentBuilds()
-  }
-  stages {
-    stage('Set build name'){
-      steps {
+    }
+    stages {
+        stage('Set build name'){
+            steps {
                 script {
                     currentBuild.displayName = "${env.BUILD_NUMBER}-${env.PLATFORM}-${env.SCENARIO}"
                 }
             }
         }
-    stage('Checkout') {
-      steps {
-            deleteDir()
-            git poll: false, branch: TESTING_BRANCH, url: 'https://github.com/Percona-QA/package-testing.git'
+        stage('Checkout') {
+            steps {
+                deleteDir()
+                git poll: false, branch: TESTING_BRANCH, url: 'https://github.com/Percona-QA/package-testing.git'
+            }
         }
-    }
-    stage ('Prepare') {
-      steps {
-          script {
-              installMolecule()
+        stage ('Prepare') {
+            steps {
+                script {
+                    installMolecule()
+                }
+            }
+        }
+        stage ('Create virtual machines') {
+            steps {
+                script{
+                    moleculeExecuteActionWithScenario(env.MOLECULE_DIR, "create", env.PLATFORM)
+                }
+            }
+        }
+        stage ('Run playbook for test') {
+            steps {
+                script{
+                    moleculeExecuteActionWithScenario(env.MOLECULE_DIR, "converge", env.PLATFORM)
+                }
+            }
+        }
+        stage ('Start testinfra tests') {
+            steps {
+                script{
+                    moleculeExecuteActionWithScenario(env.MOLECULE_DIR, "verify", env.PLATFORM)
+                }
+            }
+        }
+        stage ('Start Cleanup ') {
+            steps {
+                script {
+                    moleculeExecuteActionWithScenario(env.MOLECULE_DIR, "cleanup", env.PLATFORM)
+                }
             }
         }
     }
-    stage ('Create virtual machines') {
-      steps {
-          script{
-              moleculeExecuteActionWithScenario(env.MOLECULE_DIR, "create", env.PLATFORM)
+    post {
+        always {
+            script {
+                moleculeExecuteActionWithScenario(env.MOLECULE_DIR, "destroy", env.PLATFORM)
+                junit "${MOLECULE_DIR}/report.xml"
             }
         }
     }
-    stage ('Run playbook for test') {
-      steps {
-          script{
-              moleculeExecuteActionWithScenario(env.MOLECULE_DIR, "converge", env.PLATFORM)
-            }
-        }
-    }
-    stage ('Start testinfra tests') {
-      steps {
-            script{
-              moleculeExecuteActionWithScenario(env.MOLECULE_DIR, "verify", env.PLATFORM)
-            }
-        }
-    }
-    stage ('Start Cleanup ') {
-      steps {
-          script {
-              moleculeExecuteActionWithScenario(env.MOLECULE_DIR, "cleanup", env.PLATFORM)
-            }
-        }
-    }
-  }
-  post {
-    always {
-          script {
-             moleculeExecuteActionWithScenario(env.MOLECULE_DIR, "destroy", env.PLATFORM)
-             junit "${MOLECULE_DIR}/report.xml"
-        }
-    }
-  }
 }


### PR DESCRIPTION
A new choice parameter DESTROY_ENV was added for pdps, pdps-upgrade and orchestrator jobs. By default it is set to 'yes'. If set to 'no', the shh key will be uploaded to test env (this part is in package-testing commit) and test env will be preserved on aws.

Tests were run on copied jenkins tasks:
https://ps80.cd.percona.com/job/pdps-upgrade-eleonora/
https://ps80.cd.percona.com/job/orchestrator-eleonora/
https://ps80.cd.percona.com/job/pdps-eleonora/