### PR TITLE
Fix errors due to "+" in email address.

### DIFF
--- a/pmm/aws-staging-start.groovy
+++ b/pmm/aws-staging-start.groovy
@@ -166,7 +166,7 @@ pipeline {
                     sh """
                         echo "\${BUILD_USER_EMAIL}" > OWNER_EMAIL
                         echo "\${BUILD_USER_EMAIL}" | awk -F '@' '{print \$1}' > OWNER_FULL
-                        echo "pmm-\$(cat OWNER_FULL)-\$(date -u '+%Y%m%d%H%M%S')-${BUILD_NUMBER}" \
+                        echo "pmm-\$(cat OWNER_FULL | sed 's/[^a-zA-Z0-9_.-]//')-\$(date -u '+%Y%m%d%H%M%S')-${BUILD_NUMBER}" \
                             > VM_NAME
                     """
                 }


### PR DESCRIPTION
- Container names allow only `[a-zA-Z0-9][a-zA-Z0-9_.-]`
- This fixes an issue with email address containing "+"