### PR TITLE
PMM-7 pass pmm client version as env var

### DIFF
--- a/pmm/pmm2-dbaas-e2e-tests.groovy
+++ b/pmm/pmm2-dbaas-e2e-tests.groovy
@@ -8,7 +8,7 @@ void runStagingServer(String DOCKER_VERSION, CLIENT_VERSION, CLIENT_INSTANCE, SE
         string(name: 'DOCKER_VERSION', value: DOCKER_VERSION),
         string(name: 'CLIENT_VERSION', value: CLIENT_VERSION),
         string(name: 'CLIENT_INSTANCE', value: CLIENT_INSTANCE),
-        string(name: 'DOCKER_ENV_VARIABLE', value: '-e PMM_DEBUG=1 -e ENABLE_DBAAS=1 -e PERCONA_TEST_VERSION_SERVICE_URL=https://check-dev.percona.com/versions/v1'),
+        string(name: 'DOCKER_ENV_VARIABLE', value: DOCKER_ENV_VARIABLE),
         string(name: 'SERVER_IP', value: SERVER_IP),
         string(name: 'NOTIFY', value: 'false'),
         string(name: 'DAYS', value: '1')
@@ -65,6 +65,10 @@ pipeline {
             defaultValue: 'dev-latest',
             description: 'PMM Client version',
             name: 'CLIENT_VERSION')
+        string(
+            defaultValue: '-e PMM_DEBUG=1 -e ENABLE_DBAAS=1 -e PERCONA_TEST_VERSION_SERVICE_URL=https://check-dev.percona.com/versions/v1 -e PERCONA_TEST_DBAAS_PMM_CLIENT=perconalab/pmm-client:dev-latest',
+            description: 'Envirnomental variables',
+            name: 'DOCKER_ENV_VARIABLE')    
         string(
             defaultValue: "'@dbaas'",
             description: 'Pass test tags ex. @dbaas',


### PR DESCRIPTION
We need to pass PERCONA_TEST_DBAAS_PMM_CLIENT=perconalab/pmm-client:dev-latest as default due to bug https://jira.percona.com/browse/PMM-10361 to make dbaas tests fail less

Before: https://pmm.cd.percona.com/blue/organizations/jenkins/pmm2-dbaas-e2e-tests/detail/pmm2-dbaas-e2e-tests/1336/tests
After: https://pmm.cd.percona.com/blue/organizations/jenkins/pmm2-dbaas-e2e-tests-beata-temp/detail/pmm2-dbaas-e2e-tests-beata-temp/4/tests