### PR TITLE
Ps 8342 add debian 11 support for ps 5.7

### DIFF
--- a/ps/jenkins/package-testing-ps-5.7.groovy
+++ b/ps/jenkins/package-testing-ps-5.7.groovy
@@ -13,12 +13,25 @@ List all_nodes = [
     "min-amazon-2-x64",
 ]
 
+List all_nodes_except_bullseye = [
+    "min-buster-x64",
+    "min-centos-7-x64",
+    "min-ol-8-x64",
+    "min-bionic-x64",
+    "min-focal-x64",
+    "min-amazon-2-x64",
+]
+
 product_to_test = params.product_to_test
 
 List nodes_to_test = []
 if (params.node_to_test == "all") {
     nodes_to_test = all_nodes
-} else {
+} 
+else if (params.node_to_test == "all_nodes_except_bullseye") {
+    nodes_to_test = all_nodes_except_bullseye
+}
+else {
     nodes_to_test = [params.node_to_test]
 }
 
@@ -54,7 +67,7 @@ pipeline {
 
         choice(
             name: "node_to_test",
-            choices: ["all"] + all_nodes,
+            choices: ["all","all_nodes_except_bullseye"] + all_nodes,
             description: "Node in which to test the product"
         )
 

--- a/ps/jenkins/package-testing-ps-5.7.groovy
+++ b/ps/jenkins/package-testing-ps-5.7.groovy
@@ -4,6 +4,7 @@ library changelog: false, identifier: 'lib@master', retriever: modernSCM([
 ]) _
 
 List all_nodes = [
+    "min-bullseye-x64",
     "min-buster-x64",
     "min-centos-7-x64",
     "min-ol-8-x64",
@@ -76,6 +77,18 @@ pipeline {
 
         stage("Run parallel") {
             parallel {
+                stage("Debian Bullseye") {
+                    when {
+                        expression {
+                            nodes_to_test.contains("min-bullseye-x64")
+                        }
+                    }
+
+                    steps {
+                        runNodeBuild("min-bullseye-x64")
+                    }
+                }
+
                 stage("Debian Buster") {
                     when {
                         expression {

--- a/ps/jenkins/package-testing-ps-5.7.yml
+++ b/ps/jenkins/package-testing-ps-5.7.yml
@@ -36,6 +36,7 @@
             name: node_to_test
             choices:
                 - "all"
+                - "all_nodes_except_bullseye"
                 - "min-bullseye-x64"
                 - "min-buster-x64"
                 - "min-centos-7-x64"

--- a/ps/jenkins/package-testing-ps-5.7.yml
+++ b/ps/jenkins/package-testing-ps-5.7.yml
@@ -36,6 +36,7 @@
             name: node_to_test
             choices:
                 - "all"
+                - "min-bullseye-x64"
                 - "min-buster-x64"
                 - "min-centos-7-x64"
                 - "min-ol-8-x64"

--- a/ps/jenkins/package-testing-ps-build-5.7.groovy
+++ b/ps/jenkins/package-testing-ps-build-5.7.groovy
@@ -45,6 +45,7 @@ setup_ubuntu_package_tests = { ->
 }
 
 node_setups = [
+    "min-bullseye-x64": setup_debian_package_tests,
     "min-buster-x64": setup_debian_package_tests,
     "min-centos-7-x64": setup_rhel_package_tests,
     "min-ol-8-x64": setup_rhel_8_package_tests,

--- a/ps/jenkins/package-testing-ps-build-5.7.yml
+++ b/ps/jenkins/package-testing-ps-build-5.7.yml
@@ -37,6 +37,7 @@
         - choice:
             name: node_to_test
             choices:
+                - "min-bullseye-x64"            
                 - "min-buster-x64"
                 - "min-centos-7-x64"
                 - "min-ol-8-x64"


### PR DESCRIPTION
Modify package-testing-ps-5.7 and package-testing-ps-build-5.7 jenkins jobs .groovy and .yml for adding Debian 11 Bullseye support.