### PR TITLE
CLOUD-730 Use AWS CSI driver

### DIFF
--- a/cloud/jenkins/pgo_operator_eks.groovy
+++ b/cloud/jenkins/pgo_operator_eks.groovy
@@ -308,6 +308,14 @@ metadata:
     region: eu-west-3
     version: '$KUBEVERSION'
 
+iam:
+  withOIDC: true
+
+addons:
+- name: aws-ebs-csi-driver
+  wellKnownPolicies:
+    ebsCSIController: true
+
 nodeGroups:
     - name: ng-1
       minSize: 3
@@ -372,6 +380,7 @@ EOF
                 withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'eks-cicd', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
                     unstash 'cluster_conf'
                     sh """
+                        eksctl delete addon --name aws-ebs-csi-driver --cluster eks-pgo-cluster --region eu-west-3
                         eksctl delete cluster -f cluster.yaml --wait --force
                     """
                 }

--- a/cloud/jenkins/ps_operator_eks.groovy
+++ b/cloud/jenkins/ps_operator_eks.groovy
@@ -265,6 +265,14 @@ metadata:
     region: eu-west-3
     version: "$PLATFORM_VER"
 
+iam:
+  withOIDC: true
+
+addons:
+- name: aws-ebs-csi-driver
+  wellKnownPolicies:
+    ebsCSIController: true
+
 nodeGroups:
     - name: ng-1
       minSize: 3
@@ -330,6 +338,7 @@ EOF
                 withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'eks-cicd', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
                     unstash 'cluster_conf'
                     sh """
+                        eksctl delete addon --name aws-ebs-csi-driver --cluster eks-psmo-cluster --region eu-west-3
                         eksctl delete cluster -f cluster.yaml --wait --force
                     """
                 }

--- a/cloud/jenkins/psmdb_operator_eks.groovy
+++ b/cloud/jenkins/psmdb_operator_eks.groovy
@@ -236,6 +236,14 @@ metadata:
     region: eu-west-3
     version: "$PLATFORM_VER"
 
+iam:
+  withOIDC: true
+
+addons:
+- name: aws-ebs-csi-driver
+  wellKnownPolicies:
+    ebsCSIController: true
+
 nodeGroups:
     - name: ng-1
       minSize: 3
@@ -263,6 +271,7 @@ EOF
                          export PATH=/home/ec2-user/.local/bin:$PATH
                          source $HOME/google-cloud-sdk/path.bash.inc
 
+                         eksctl delete addon --name aws-ebs-csi-driver --cluster eks-psmdb-cluster --region eu-west-3
                          eksctl create cluster -f cluster.yaml
                      """
                 }

--- a/cloud/jenkins/pxc_operator_eks.groovy
+++ b/cloud/jenkins/pxc_operator_eks.groovy
@@ -274,6 +274,13 @@ metadata:
     name: eks-pxc-cluster
     region: eu-west-3
     version: "$PLATFORM_VER"
+iam:
+  withOIDC: true
+
+addons:
+- name: aws-ebs-csi-driver
+  wellKnownPolicies:
+    ebsCSIController: true
 
 nodeGroups:
     - name: ng-1
@@ -404,6 +411,7 @@ EOF
                 withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'eks-cicd', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
                     unstash 'cluster_conf'
                     sh """
+                        eksctl delete addon --name aws-ebs-csi-driver --cluster eks-pxc-cluster --region eu-west-3
                         eksctl delete cluster -f cluster.yaml --wait --force
                     """
                 }


### PR DESCRIPTION
It seems like since 1.23 pvcs can't be created due to the lack of
default block storage manager. So we need to install it on cluster
startup