### PR TITLE
K8SPS-123 - Make FILE_NAME variable local to fix conflict when running tests in parallel

### DIFF
--- a/cloud/jenkins/ps_operator_aws_openshift-4.groovy
+++ b/cloud/jenkins/ps_operator_aws_openshift-4.groovy
@@ -38,7 +38,7 @@ void runTest(String TEST_NAME) {
             echo "The $TEST_NAME test was started!"
             testsReportMap[TEST_NAME] = 'failure'
 
-            FILE_NAME = "${env.GIT_BRANCH}-${env.GIT_SHORT_COMMIT}-$TEST_NAME-eks-${env.PLATFORM_VER}"
+            def FILE_NAME = "${env.GIT_BRANCH}-${env.GIT_SHORT_COMMIT}-$TEST_NAME-eks-${env.PLATFORM_VER}"
             popArtifactFile("$FILE_NAME")
 
             timeout(time: 90, unit: 'MINUTES') {

--- a/cloud/jenkins/ps_operator_eks.groovy
+++ b/cloud/jenkins/ps_operator_eks.groovy
@@ -38,7 +38,7 @@ void runTest(String TEST_NAME) {
             echo "The $TEST_NAME test was started!"
             testsReportMap[TEST_NAME] = 'failure'
 
-            FILE_NAME = "${env.GIT_BRANCH}-${env.GIT_SHORT_COMMIT}-$TEST_NAME-eks-${env.PLATFORM_VER}"
+            def FILE_NAME = "${env.GIT_BRANCH}-${env.GIT_SHORT_COMMIT}-$TEST_NAME-eks-${env.PLATFORM_VER}"
             popArtifactFile("$FILE_NAME")
 
             timeout(time: 90, unit: 'MINUTES') {

--- a/cloud/jenkins/ps_operator_gke_version.groovy
+++ b/cloud/jenkins/ps_operator_gke_version.groovy
@@ -143,7 +143,7 @@ void runTest(String TEST_NAME, String CLUSTER_SUFFIX) {
             echo "The $TEST_NAME test was started!"
             testsReportMap[TEST_NAME] = 'failure'
 
-            FILE_NAME = "$VERSION-$TEST_NAME-gke-${env.PLATFORM_VER}"
+            def FILE_NAME = "$VERSION-$TEST_NAME-gke-${env.PLATFORM_VER}"
             popArtifactFile("$FILE_NAME")
 
             timeout(time: 90, unit: 'MINUTES') {

--- a/cloud/jenkins/ps_operator_minikube.groovy
+++ b/cloud/jenkins/ps_operator_minikube.groovy
@@ -38,7 +38,7 @@ void runTest(String TEST_NAME) {
             GIT_SHORT_COMMIT = sh(script: 'git -C source rev-parse --short HEAD', , returnStdout: true).trim()
             PS_TAG = sh(script: "if [ -n \"\${IMAGE_MYSQL}\" ] ; then echo ${IMAGE_MYSQL} | awk -F':' '{print \$2}'; else echo 'main'; fi", , returnStdout: true).trim()
             VERSION = "${env.GIT_BRANCH}-$GIT_SHORT_COMMIT"
-            FILE_NAME = "$VERSION-$TEST_NAME-minikube-${env.PLATFORM_VER}-$PS_TAG"
+            def FILE_NAME = "$VERSION-$TEST_NAME-minikube-${env.PLATFORM_VER}-$PS_TAG"
             testsReportMap[TEST_NAME] = 'failure'
 
             popArtifactFile("$FILE_NAME", "$GIT_SHORT_COMMIT")

--- a/cloud/jenkins/psmdb_operator_minikube.groovy
+++ b/cloud/jenkins/psmdb_operator_minikube.groovy
@@ -43,7 +43,7 @@ void runTest(String TEST_NAME) {
 
             GIT_SHORT_COMMIT = sh(script: 'git -C source rev-parse --short HEAD', , returnStdout: true).trim()
             VERSION = "${env.GIT_BRANCH}-$GIT_SHORT_COMMIT"
-            FILE_NAME = "$VERSION-$TEST_NAME-minikube-${env.PLATFORM_VER}"
+            def FILE_NAME = "$VERSION-$TEST_NAME-minikube-${env.PLATFORM_VER}"
             MDB_TAG = sh(script: "if [ -n \"\${IMAGE_MONGOD}\" ] ; then echo ${IMAGE_MONGOD} | awk -F':' '{print \$2}'; else echo 'main'; fi", , returnStdout: true).trim()
             testsReportMap[TEST_NAME] = 'failure'
 

--- a/cloud/jenkins/pxc_operator_minikube.groovy
+++ b/cloud/jenkins/pxc_operator_minikube.groovy
@@ -44,7 +44,7 @@ void runTest(String TEST_NAME) {
             GIT_SHORT_COMMIT = sh(script: 'git -C source rev-parse --short HEAD', , returnStdout: true).trim()
             PXC_TAG = sh(script: "if [ -n \"\${IMAGE_PXC}\" ] ; then echo ${IMAGE_PXC} | awk -F':' '{print \$2}'; else echo 'main'; fi", , returnStdout: true).trim()
             VERSION = "${env.GIT_BRANCH}-$GIT_SHORT_COMMIT"
-            FILE_NAME = "$VERSION-$TEST_NAME-minikube-${env.PLATFORM_VER}-$PXC_TAG-CW_${params.CLUSTER_WIDE}"
+            def FILE_NAME = "$VERSION-$TEST_NAME-minikube-${env.PLATFORM_VER}-$PXC_TAG-CW_${params.CLUSTER_WIDE}"
             testsReportMap[TEST_NAME] = 'failure'
 
             popArtifactFile("$FILE_NAME", "$GIT_SHORT_COMMIT")


### PR DESCRIPTION
`FILE_NAME` variable should always be local in `runTest` function in case we are running tests in parallel.