### PR TITLE
PMM-7 reduce the number of code owners on some paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,8 +3,8 @@
 
 /cloud/gcp-functions/ @egegunes @inelpandzic
 /cloud/ @hors @tplavcic @nmarukovich @cap1984 
-/pmm/ @talhabinrizwan @atymchuk @puneet0191 @Percona-Lab/build-engineers
-/IaC/pmm.cd/ @talhabinrizwan @atymchuk @Percona-Lab/build-engineers
+/pmm/ @talhabinrizwan @atymchuk @puneet0191
+/IaC/pmm.cd/ @talhabinrizwan @atymchuk
 /pxb/ @mchawla16 @eleo007 @mohitj1988 @kaushikpuneet07 @panchal-yash @hrvojem @Percona-Lab/build-engineers
 /pxc/ @mchawla16 @eleo007 @mohitj1988 @kaushikpuneet07 @panchal-yash @hrvojem @Percona-Lab/build-engineers
 /ps/jenkins/ @mchawla16 @eleo007 @mohitj1988 @kaushikpuneet07 @panchal-yash @hrvojem @Percona-Lab/build-engineers


### PR DESCRIPTION
This PR is supposed to reduce the number of code owners on some paths where the number of code owners was already sufficient before the most recent change.  This will allow to reduce the time it takes to review and commit changes to our code.