### PR TITLE
ENG-1159 PXB 2.4 jenkins job improvements

### DIFF
--- a/pxb/percona-xtrabackup-2.4-param.yml
+++ b/pxb/percona-xtrabackup-2.4-param.yml
@@ -15,11 +15,8 @@
         values:
         - min-centos-7-x64
         - min-centos-8-x64
-        - min-xenial-x64
-        - min-xenial-x32
         - min-bionic-x64
         - min-focal-x64
-        - min-stretch-x64
         - min-buster-x64
         - asan
     - axis:

--- a/pxb/percona-xtrabackup-2.4-template.yml
+++ b/pxb/percona-xtrabackup-2.4-template.yml
@@ -73,6 +73,10 @@
                 PKGLIST+=" devtoolset-2-valgrind devtoolset-2-valgrind-devel"
             fi
 
+            if [[ ${RHEL} -eq 7 ]]; then
+                PKGLIST+=" openssl11-libs cmake3"
+            fi
+
             until sudo -E yum -y install ${PKGLIST}; do
                 echo "waiting"
                 sleep 1
@@ -186,6 +190,14 @@
             THREADS=$(grep -c ^processor /proc/cpuinfo)
         else
             THREADS=1
+        fi
+
+        if [ -f /usr/bin/yum ]; then
+            RHEL=$(rpm --eval %rhel)
+            if [[ ${RHEL} -eq 7 ]]; then
+                sudo rm /bin/cmake
+                sudo ln -sf /bin/cmake3 /bin/cmake
+            fi
         fi
 
         if [ -d ${WORKSPACE}/xtrabackup ]


### PR DESCRIPTION
https://jira.percona.com/browse/ENG-1159

* Adds support to install openssl11-libs and cmake3 packages and use cmake3 for compilation on centos-7 platform.
* Removes xenial and stretch platfoms from the configuration matrix since they're EOL and no jenkins nodes exist for them.