### PR TITLE
ENG-1164 Removes support for centos:6 and use cmake3 for centos:7

### DIFF
--- a/pxb/jenkins/build-binary-pxb24
+++ b/pxb/jenkins/build-binary-pxb24
@@ -75,6 +75,16 @@ if [[ "$COMPILER" != "default" ]]; then
     export CXX=$(echo ${COMPILER} | sed -e 's/gcc/g++/; s/clang/clang++/')
 fi
 
+# CentOS 7
+RHVER=0
+if [[ -f /etc/redhat-release ]]; then
+    RHVER="$(rpm --eval %rhel)"
+fi
+
+if [[ ${RHVER} -eq 7 ]]; then
+    JOB_CMAKE='cmake3'
+fi
+
 # ------------------------------------------------------------------------------
 # set version
 # ------------------------------------------------------------------------------

--- a/pxb/jenkins/pxb24-single-platform-run.groovy
+++ b/pxb/jenkins/pxb24-single-platform-run.groovy
@@ -13,7 +13,7 @@ pipeline {
             name: 'PXB24_BRANCH',
             trim: true)
         choice(
-            choices: 'centos:6\ncentos:7\ncentos:8\nubuntu:xenial\nubuntu:bionic\nubuntu:focal\ndebian:stretch\ndebian:buster',
+            choices: 'centos:7\ncentos:8\nubuntu:xenial\nubuntu:bionic\nubuntu:focal\ndebian:stretch\ndebian:buster',
             description: 'OS version for compilation',
             name: 'DOCKER_OS')
         choice(

--- a/pxc/jenkins/param57.yml
+++ b/pxc/jenkins/param57.yml
@@ -99,7 +99,6 @@
          type: user-defined
          name: DOCKER_OS
          values:
-          - centos:6
           - centos:7
           - centos:8
           - ubuntu:bionic

--- a/pxc/jenkins/prepare-pxc-build-docker.yml
+++ b/pxc/jenkins/prepare-pxc-build-docker.yml
@@ -51,7 +51,6 @@
                 stage('Build') {
                     steps {
                         parallel(
-                            "centos:6":       { build('centos:6') },
                             "centos:7":       { build('centos:7') },
                             "centos:8":       { build('centos:8') },
                             "ubuntu:xenial":  { build('ubuntu:xenial') },

--- a/pxc/jenkins/pxc57-pipeline.groovy
+++ b/pxc/jenkins/pxc57-pipeline.groovy
@@ -27,7 +27,7 @@ pipeline {
             name: 'PXB24_BRANCH',
             trim: true)
         choice(
-            choices: 'centos:6\ncentos:7\ncentos:8\nubuntu:bionic\nubuntu:focal\ndebian:buster',
+            choices: 'centos:7\ncentos:8\nubuntu:bionic\nubuntu:focal\ndebian:buster',
             description: 'OS version for compilation',
             name: 'DOCKER_OS')
         choice(

--- a/pxc/jenkins/pxc57-pipeline.yml
+++ b/pxc/jenkins/pxc57-pipeline.yml
@@ -96,7 +96,6 @@
          type: user-defined
          name: DOCKER_OS
          values:
-          - centos:6
           - centos:7
           - centos:8
           - ubuntu:bionic

--- a/pxc/jenkins/qa-param57.yml
+++ b/pxc/jenkins/qa-param57.yml
@@ -67,7 +67,6 @@
          type: user-defined
          name: DOCKER_OS
          values:
-          - centos:6
           - centos:7
           - centos:8
           - ubuntu:bionic

--- a/pxc/jenkins/qa-pxc57-pipeline.groovy
+++ b/pxc/jenkins/qa-pxc57-pipeline.groovy
@@ -33,7 +33,7 @@ pipeline {
             name: 'PXB24_BRANCH',
             trim: true)
         choice(
-            choices: 'centos:6\ncentos:7\ncentos:8\nubuntu:bionic\nubuntu:focal\ndebian:buster',
+            choices: 'centos:7\ncentos:8\nubuntu:bionic\nubuntu:focal\ndebian:buster',
             description: 'OS version for compilation',
             name: 'DOCKER_OS')
         choice(

--- a/pxc/local/build-binary-pxb24
+++ b/pxc/local/build-binary-pxb24
@@ -90,6 +90,16 @@ if [[ "$COMPILER" != "default" ]]; then
     export CXX=$(echo ${COMPILER} | sed -e 's/gcc/g++/; s/clang/clang++/')
 fi
 
+# CentOS 7
+RHVER=0
+if [[ -f /etc/redhat-release ]]; then
+    RHVER="$(rpm --eval %rhel)"
+fi
+
+if [[ ${RHVER} -eq 7 ]]; then
+    JOB_CMAKE='cmake3'
+fi
+
 # ------------------------------------------------------------------------------
 # set version
 # ------------------------------------------------------------------------------

--- a/pxc/local/checkout
+++ b/pxc/local/checkout
@@ -131,7 +131,8 @@ if [ "$SOURCE_NAME" == 'PXB80' -o "$SOURCE_NAME" == 'ALL' ]; then
             unset PXB80_BRANCH && PXB80_BRANCH="$(git describe --tags --abbrev=0)"
         fi
         if [ -n "${PXB80_BRANCH}" ]; then
-            git checkout "${PXB80_BRANCH}" -b "tag-${PXB80_BRANCH}"
+            git checkout "${PXB80_BRANCH}"
+            git checkout -b "tag-${PXB80_BRANCH}"
         fi
         if [ -n "${PXB80_REPO}" -a -n "${PXB80_BRANCH}" ]; then
             git pull origin ${PXB80_BRANCH}
@@ -165,7 +166,8 @@ if [ "$SOURCE_NAME" == 'PXB24' -o "$SOURCE_NAME" == 'ALL' ]; then
             unset PXB24_BRANCH && PXB24_BRANCH="$(git describe --tags --abbrev=0)"
         fi
         if [ -n "${PXB24_BRANCH}" ]; then
-            git checkout "${PXB24_BRANCH}" -b "tag-${PXB24_BRANCH}"
+            git checkout "${PXB24_BRANCH}"
+            git checkout -b "tag-${PXB24_BRANCH}"
         fi
         if [ -n "${PXB24_REPO}" -a -n "${PXB24_BRANCH}" ]; then
             git pull origin ${PXB24_BRANCH}

--- a/pxc/local/checkout56
+++ b/pxc/local/checkout56
@@ -84,7 +84,8 @@ if [ "$SOURCE_NAME" == 'PXB23' -o "$SOURCE_NAME" == 'ALL' ]; then
         git clean -xdf
 
         if [ -n "${PXB23_BRANCH}" ]; then
-            git checkout "${PXB23_BRANCH}" -b "tag-${PXB23_BRANCH}"
+            git checkout "${PXB23_BRANCH}"
+            git checkout -b "tag-${PXB23_BRANCH}"
         fi
         if [ -n "${PXB23_REPO}" -a -n "${PXB23_BRANCH}" ]; then
             git pull origin ${PXB23_BRANCH}
@@ -112,7 +113,8 @@ if [ "$SOURCE_NAME" == 'GALERA3' -o "$SOURCE_NAME" == 'ALL' ]; then
         git clean -xdf
 
         if [ -n "${GALERA3_BRANCH}" ]; then
-            git checkout "origin/${GALERA3_BRANCH}" -b "tag-${GALERA3_BRANCH}"
+            git checkout "origin/${GALERA3_BRANCH}"
+            git checkout -b "tag-${GALERA3_BRANCH}"
         fi
         if [ -n "${GALERA3_REPO}" -a -n "${GALERA3_BRANCH}" ]; then
             git pull origin ${GALERA3_BRANCH}

--- a/pxc/local/checkout57
+++ b/pxc/local/checkout57
@@ -88,7 +88,8 @@ if [ "$SOURCE_NAME" == 'PXB24' -o "$SOURCE_NAME" == 'ALL' ]; then
         git clean -xdf
 
         if [ -n "${PXB24_BRANCH}" ]; then
-            git checkout "${PXB24_BRANCH}" -b "tag-${PXB24_BRANCH}"
+            git checkout "${PXB24_BRANCH}"
+            git checkout -b "tag-${PXB24_BRANCH}"
         fi
         if [ -n "${PXB24_REPO}" -a -n "${PXB24_BRANCH}" ]; then
             git pull origin ${PXB24_BRANCH}

--- a/pxc/percona-xtrabackup-2.4-binaries.yml
+++ b/pxc/percona-xtrabackup-2.4-binaries.yml
@@ -4,8 +4,6 @@
         name: Host
         type: label-expression
         values:
-        - min-centos-6-x32
-        - min-centos-6-x64
         - min-centos-7-x64
         - min-jessie-x64
         - min-stretch-x64
@@ -19,7 +17,7 @@
         if [ -f /usr/bin/yum ]; then
             sudo yum clean all
             sudo -E yum -y install epel-release
-            sudo -E yum -y install gcc gcc-c++ check-devel openssl-devel cmake bison boost-devel curl-devel curl wget vim-common
+            sudo -E yum -y install gcc gcc-c++ check-devel openssl-devel cmake cmake3 bison boost-devel curl-devel curl wget vim-common
             sudo -E yum -y install libev-devel libgcrypt-devel zlib-devel ncurses-devel python-docutils libgcrypt-devel bison
             sudo -E yum -y install asio-devel libaio-devel ncurses-devel readline-devel pam-devel socat python-docutils
 
@@ -56,7 +54,7 @@
             sleep 5
             sudo -E DEBIAN_FRONTEND=noninteractive apt-get -y install make gcc g++ bison libasio-dev libssl-dev libtool libc-dev libgpg-error-dev python-sphinx
             sudo -E DEBIAN_FRONTEND=noninteractive apt-get -y install libaio-dev libncurses-dev zlib1g-dev libz-dev check python-sphinx libgcrypt-dev python-docutils
-            sudo -E DEBIAN_FRONTEND=noninteractive apt-get -y install openssl cmake libboost-all-dev libreadline-dev libpam-dev socat libev-dev libcurl4-openssl-dev
+            sudo -E DEBIAN_FRONTEND=noninteractive apt-get -y install openssl cmake cmake3 libboost-all-dev libreadline-dev libpam-dev socat libev-dev libcurl4-openssl-dev
             sudo -E DEBIAN_FRONTEND=noninteractive apt-get -y install lsb-release python3-pip
 
             # TODO REMOVE AFTER image fix

--- a/pxc/percona-xtrabackup-8.0-binary-tarball_for_pxc.yml
+++ b/pxc/percona-xtrabackup-8.0-binary-tarball_for_pxc.yml
@@ -4,7 +4,6 @@
         name: Host
         type: label-expression
         values:
-        - min-centos-6-x64
         - min-centos-7-x64
         - min-stretch-x64
         - min-xenial-x64


### PR DESCRIPTION
https://jira.percona.com/browse/ENG-1164

* Disables some necessary PXC and PXB jobs from running tests on centos:6 since it is already EOL.
* Makes sure that cmake3 is being used to compile PXB in centos:7 images.