### PR TITLE
Fix running of chaos mesh under GKE

### DIFF
--- a/cloud/jenkins/ps_operator_gke_version.groovy
+++ b/cloud/jenkins/ps_operator_gke_version.groovy
@@ -23,7 +23,10 @@ void runGKEcluster(String CLUSTER_SUFFIX) {
                 gcloud container clusters create --zone $GKERegion $CLUSTER_NAME-${CLUSTER_SUFFIX} --cluster-version $PLATFORM_VER --machine-type n1-standard-4 --preemptible --num-nodes=\$NODES_NUM --network=jenkins-ps-vpc --subnetwork=jenkins-ps-${CLUSTER_SUFFIX} --no-enable-autoupgrade && \
                 gcloud container clusters update --zone $GKERegion $CLUSTER_NAME-${CLUSTER_SUFFIX} --update-labels delete-cluster-after-hours=6 && \
                 kubectl create clusterrolebinding cluster-admin-binding --clusterrole cluster-admin --user jenkins@"$GCP_PROJECT".iam.gserviceaccount.com || ret_val=\$?
-                if [ \${ret_val} -eq 0 ]; then break; fi
+                if [ \${ret_val} -eq 0 ]; then
+                    curl https://raw.githubusercontent.com/Percona-QA/cloud-qa/main/chaos-mesh/chaos-mesh-gke-permissions.yml | sed "s/name: USER_ACCOUNT/name: jenkins@\"$GCP_PROJECT\"/" | kubectl apply -f -
+                    break
+                fi
                 ret_num=\$((ret_num + 1))
             done
             if [ \${ret_num} -eq 15 ]; then exit 1; fi
@@ -44,7 +47,10 @@ void runGKEclusterAlpha(String CLUSTER_SUFFIX) {
                 gcloud config set project $GCP_PROJECT && \
                 gcloud alpha container clusters create --release-channel rapid $CLUSTER_NAME-${CLUSTER_SUFFIX} --cluster-version $PLATFORM_VER --zone $GKERegion --project $GCP_PROJECT --preemptible --machine-type n1-standard-4 --num-nodes=4 --min-nodes=4 --max-nodes=6 --network=jenkins-ps-vpc --subnetwork=jenkins-ps-${CLUSTER_SUFFIX} && \
                 kubectl create clusterrolebinding cluster-admin-binding1 --clusterrole=cluster-admin --user=\$(gcloud config get-value core/account) || ret_val=\$?
-                if [ \${ret_val} -eq 0 ]; then break; fi
+                if [ \${ret_val} -eq 0 ]; then
+                    curl https://raw.githubusercontent.com/Percona-QA/cloud-qa/main/chaos-mesh/chaos-mesh-gke-permissions.yml | sed "s/name: USER_ACCOUNT/name: jenkins@\"$GCP_PROJECT\"/" | kubectl apply -f -
+                    break
+                fi
                 ret_num=\$((ret_num + 1))
             done
             if [ \${ret_num} -eq 15 ]; then exit 1; fi

--- a/cloud/jenkins/psmdb_operator_gke_version.groovy
+++ b/cloud/jenkins/psmdb_operator_gke_version.groovy
@@ -25,7 +25,10 @@ void runGKEcluster(String CLUSTER_PREFIX) {
                 gcloud container clusters create --zone $GKERegion $CLUSTER_NAME-${CLUSTER_PREFIX} --cluster-version $PLATFORM_VER --machine-type n1-standard-4 --preemptible --num-nodes=3 --network=jenkins-vpc --subnetwork=jenkins-${CLUSTER_PREFIX} --no-enable-autoupgrade && \
                 gcloud container clusters update --zone $GKERegion $CLUSTER_NAME-${CLUSTER_PREFIX} --update-labels delete-cluster-after-hours=6 && \
                 kubectl create clusterrolebinding cluster-admin-binding --clusterrole cluster-admin --user jenkins@"$GCP_PROJECT".iam.gserviceaccount.com || ret_val=\$?
-                if [ \${ret_val} -eq 0 ]; then break; fi
+                if [ \${ret_val} -eq 0 ]; then
+                    curl https://raw.githubusercontent.com/Percona-QA/cloud-qa/main/chaos-mesh/chaos-mesh-gke-permissions.yml | sed "s/name: USER_ACCOUNT/name: jenkins@\"$GCP_PROJECT\"/" | kubectl apply -f -
+                    break
+                fi
                 ret_num=\$((ret_num + 1))
             done
             if [ \${ret_num} -eq 15 ]; then exit 1; fi
@@ -46,7 +49,10 @@ void runGKEclusterAlpha(String CLUSTER_PREFIX) {
                 gcloud alpha container clusters create --release-channel rapid $CLUSTER_NAME-${CLUSTER_PREFIX} --zone $GKERegion --cluster-version $PLATFORM_VER --project $GCP_PROJECT --preemptible --machine-type n1-standard-4 --num-nodes=4 --min-nodes=4 --max-nodes=6 --network=jenkins-vpc --subnetwork=jenkins-${CLUSTER_PREFIX} && \
                 gcloud container clusters update --zone $GKERegion $CLUSTER_NAME-${CLUSTER_PREFIX} --update-labels delete-cluster-after-hours=6 && \
                 kubectl create clusterrolebinding cluster-admin-binding1 --clusterrole=cluster-admin --user=\$(gcloud config get-value core/account) || ret_val=\$?
-                if [ \${ret_val} -eq 0 ]; then break; fi
+                if [ \${ret_val} -eq 0 ]; then
+                    curl https://raw.githubusercontent.com/Percona-QA/cloud-qa/main/chaos-mesh/chaos-mesh-gke-permissions.yml | sed "s/name: USER_ACCOUNT/name: jenkins@\"$GCP_PROJECT\"/" | kubectl apply -f -
+                    break
+                fi
                 ret_num=\$((ret_num + 1))
             done
             if [ \${ret_num} -eq 15 ]; then exit 1; fi

--- a/cloud/jenkins/pxc_operator_gke_version.groovy
+++ b/cloud/jenkins/pxc_operator_gke_version.groovy
@@ -27,7 +27,10 @@ void runGKEcluster(String CLUSTER_PREFIX) {
                 gcloud container clusters create --zone $GKERegion $CLUSTER_NAME-${CLUSTER_PREFIX} --cluster-version $PLATFORM_VER --machine-type n1-standard-4 --preemptible --num-nodes=\$NODES_NUM --network=jenkins-vpc --subnetwork=jenkins-${CLUSTER_PREFIX} --no-enable-autoupgrade --cluster-ipv4-cidr=10.\$(( RANDOM % 250 )).\$(( RANDOM % 30 * 8 )).0/21 && \
                 gcloud container clusters update --zone $GKERegion $CLUSTER_NAME-${CLUSTER_PREFIX} --update-labels delete-cluster-after-hours=6 && \
                 kubectl create clusterrolebinding cluster-admin-binding --clusterrole cluster-admin --user jenkins@"$GCP_PROJECT".iam.gserviceaccount.com || ret_val=\$?
-                if [ \${ret_val} -eq 0 ]; then break; fi
+                if [ \${ret_val} -eq 0 ]; then
+                    curl https://raw.githubusercontent.com/Percona-QA/cloud-qa/main/chaos-mesh/chaos-mesh-gke-permissions.yml | sed "s/name: USER_ACCOUNT/name: jenkins@\"$GCP_PROJECT\"/" | kubectl apply -f -
+                    break
+                fi
                 ret_num=\$((ret_num + 1))
             done
             if [ \${ret_num} -eq 15 ]; then exit 1; fi
@@ -49,7 +52,10 @@ void runGKEclusterAlpha(String CLUSTER_PREFIX) {
                 gcloud alpha container clusters create --release-channel rapid $CLUSTER_NAME-${CLUSTER_PREFIX} --cluster-version $PLATFORM_VER --zone $GKERegion --project $GCP_PROJECT --preemptible --machine-type n1-standard-4 --num-nodes=4 --enable-autoscaling --min-nodes=4 --max-nodes=6 --network=jenkins-vpc --subnetwork=jenkins-${CLUSTER_PREFIX} --cluster-ipv4-cidr=10.\$(( RANDOM % 250 )).\$(( RANDOM % 30 * 8 )).0/21 && \
                 gcloud alpha container clusters update --zone $GKERegion $CLUSTER_NAME-${CLUSTER_PREFIX} --update-labels delete-cluster-after-hours=6 && \
                 kubectl create clusterrolebinding cluster-admin-binding1 --clusterrole=cluster-admin --user=\$(gcloud config get-value core/account) || ret_val=\$?
-                if [ \${ret_val} -eq 0 ]; then break; fi
+                if [ \${ret_val} -eq 0 ]; then
+                    curl https://raw.githubusercontent.com/Percona-QA/cloud-qa/main/chaos-mesh/chaos-mesh-gke-permissions.yml | sed "s/name: USER_ACCOUNT/name: jenkins@\"$GCP_PROJECT\"/" | kubectl apply -f -
+                    break
+                fi
                 ret_num=\$((ret_num + 1))
             done
             if [ \${ret_num} -eq 15 ]; then exit 1; fi


### PR DESCRIPTION
Was bumping into issue:
```
Error from server (alpha-svc-acct@cloud-dev-112233.iam.gserviceaccount.com is forbidden on namespace self-healing-advanced-chaos-26310): error when creating "STDIN": admission webhook "vauth.kb.io" denied the request: alpha-svc-acct@cloud-dev-112233.iam.gserviceaccount.com is forbidden on namespace self-healing-advanced-chaos-26310
```
This seems to be the fix: https://chaos-mesh.org/docs/faqs/#q-the-default-administrator-google-cloud-user-account-is-forbidden-to-create-chaos-experiments-how-to-fix-it