### PR TITLE
DISTMYSQL-221: rename pd(pxc|ps)-minor-upgrade to pd(pxc|ps)_minor_upgrade to move tests

### DIFF
--- a/pdps/pdps-multi-parallel.groovy
+++ b/pdps/pdps-multi-parallel.groovy
@@ -152,7 +152,7 @@ pipeline {
                         string(name: 'TO_REPO', value: "${env.TO_REPO}"),
                         string(name: 'VERSION', value: "${env.VERSION}"),
                         string(name: 'TESTING_BRANCH', value: "${env.TESTING_BRANCH}"),
-                        string(name: 'SCENARIO', value: "pdps-minor-upgrade"),
+                        string(name: 'SCENARIO', value: "pdps_minor_upgrade"),
                         string(name: 'PROXYSQL_VERSION', value: "${env.PROXYSQL_VERSION}"),
                         string(name: 'PXB_VERSION', value: "${env.PXB_VERSION}"),
                         string(name: 'PT_VERSION', value: "${env.PT_VERSION}"),

--- a/pdps/pdps-multi.groovy
+++ b/pdps/pdps-multi.groovy
@@ -168,7 +168,7 @@ pipeline {
                         string(name: 'TO_REPO', value: "${env.TO_REPO}"),
                         string(name: 'VERSION', value: "${env.VERSION}"),
                         string(name: 'TESTING_BRANCH', value: "${env.TESTING_BRANCH}"),
-                        string(name: 'SCENARIO', value: "pdps-minor-upgrade"),
+                        string(name: 'SCENARIO', value: "pdps_minor_upgrade"),
                         string(name: 'PROXYSQL_VERSION', value: "${env.PROXYSQL_VERSION}"),
                         string(name: 'PXB_VERSION', value: "${env.PXB_VERSION}"),
                         string(name: 'PT_VERSION', value: "${env.PT_VERSION}"),

--- a/pdps/pdps-upgrade-parallel.groovy
+++ b/pdps/pdps-upgrade-parallel.groovy
@@ -10,7 +10,7 @@ pipeline {
   }
   environment {
       PATH = '/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/home/ec2-user/.local/bin';
-      MOLECULE_DIR = "molecule/pdmysql/pdps-minor-upgrade";
+      MOLECULE_DIR = "molecule/pdmysql/pdps_minor_upgrade";
   }
   parameters {
         choice(

--- a/pdps/pdps-upgrade.groovy
+++ b/pdps/pdps-upgrade.groovy
@@ -46,7 +46,7 @@ pipeline {
             name: 'VERSION'
         )
         string(
-            defaultValue: 'DISTMYSQL-221_distro_tests',
+            defaultValue: 'master',
             description: 'Branch for testing repository',
             name: 'TESTING_BRANCH'
         )
@@ -94,7 +94,7 @@ pipeline {
         stage('Checkout') {
             steps {
                 deleteDir()
-                git poll: false, branch: TESTING_BRANCH, url: 'https://github.com/eleo007/package-testing.git'
+                git poll: false, branch: TESTING_BRANCH, url: 'https://github.com/Percona-QA/package-testing.git'
             }
         }
         stage ('Prepare') {

--- a/pdps/pdps-upgrade.groovy
+++ b/pdps/pdps-upgrade.groovy
@@ -9,7 +9,7 @@ pipeline {
     }
     environment {
         PATH = '/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/home/ec2-user/.local/bin';
-        MOLECULE_DIR = "molecule/pdmysql/pdps-minor-upgrade";
+        MOLECULE_DIR = "molecule/pdmysql/pdps_minor_upgrade";
     }
     parameters {
         choice(
@@ -46,7 +46,7 @@ pipeline {
             name: 'VERSION'
         )
         string(
-            defaultValue: 'master',
+            defaultValue: 'DISTMYSQL-221_distro_tests',
             description: 'Branch for testing repository',
             name: 'TESTING_BRANCH'
         )
@@ -94,7 +94,7 @@ pipeline {
         stage('Checkout') {
             steps {
                 deleteDir()
-                git poll: false, branch: TESTING_BRANCH, url: 'https://github.com/Percona-QA/package-testing.git'
+                git poll: false, branch: TESTING_BRANCH, url: 'https://github.com/eleo007/package-testing.git'
             }
         }
         stage ('Prepare') {

--- a/pdpxc/pdpxc-multi-parallel.groovy
+++ b/pdpxc/pdpxc-multi-parallel.groovy
@@ -152,7 +152,6 @@ pipeline {
                         string(name: 'TO_REPO', value: "${env.TO_REPO}"),
                         string(name: 'VERSION', value: "${env.VERSION}"),
                         string(name: 'TESTING_BRANCH', value: "${env.TESTING_BRANCH}"),
-                        string(name: 'SCENARIO', value: "pdpxc-minor-upgrade"),
                         string(name: 'PROXYSQL_VERSION', value: "${env.PROXYSQL_VERSION}"),
                         string(name: 'PXB_VERSION', value: "${env.PXB_VERSION}"),
                         string(name: 'PT_VERSION', value: "${env.PT_VERSION}"),

--- a/pdpxc/pdpxc-multi.groovy
+++ b/pdpxc/pdpxc-multi.groovy
@@ -168,7 +168,6 @@ pipeline {
                         string(name: 'TO_REPO', value: "${env.TO_REPO}"),
                         string(name: 'VERSION', value: "${env.VERSION}"),
                         string(name: 'TESTING_BRANCH', value: "${env.TESTING_BRANCH}"),
-                        string(name: 'SCENARIO', value: "pdpxc-minor-upgrade"),
                         string(name: 'PROXYSQL_VERSION', value: "${env.PROXYSQL_VERSION}"),
                         string(name: 'PXB_VERSION', value: "${env.PXB_VERSION}"),
                         string(name: 'PT_VERSION', value: "${env.PT_VERSION}"),

--- a/pdpxc/pdpxc-upgrade-parallel.groovy
+++ b/pdpxc/pdpxc-upgrade-parallel.groovy
@@ -10,7 +10,7 @@ pipeline {
   }
   environment {
       PATH = '/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/home/ec2-user/.local/bin';
-      MOLECULE_DIR = "molecule/pdmysql/pdpxc-minor-upgrade";
+      MOLECULE_DIR = "molecule/pdmysql/pdpxc_minor_upgrade";
   }
   parameters {
         choice(

--- a/pdpxc/pdpxc-upgrade.groovy
+++ b/pdpxc/pdpxc-upgrade.groovy
@@ -9,7 +9,7 @@ pipeline {
   }
   environment {
       PATH = '/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/home/ec2-user/.local/bin';
-      MOLECULE_DIR = "molecule/pdmysql/pdpxc-minor-upgrade";
+      MOLECULE_DIR = "molecule/pdmysql/pdpxc_minor_upgrade";
   }
   parameters {
         choice(


### PR DESCRIPTION
For changes in https://github.com/Percona-QA/package-testing/pull/311 we need to rename pd(pxc|ps)-minor-upgrade to pd(pxc|ps)_minor_upgrade and use corresponding names in tests