### PR TITLE
PMM-7-remove-psmdb-op-apply-as-default

### DIFF
--- a/pmm/kubernetes-cluster-staging.groovy
+++ b/pmm/kubernetes-cluster-staging.groovy
@@ -28,11 +28,11 @@ pipeline {
             description: 'Select Kubernetes version',
             name: 'KUBE_VERSION')
         choice(
-            choices: ['none', 'v1.8.0', 'v1.9.0', 'v1.10.0'],
+            choices: ['none', 'v1.10.0', 'v1.9.0', 'v1.8.0'],
             description: 'Select version of PXC operator',
             name: 'PXC_OPERATOR_VERSION')
         choice(
-            choices: ['v1.11.0', 'none', 'v1.8.0', 'v1.9.0', 'v1.10.0', 'v1.12.0'], //set v1.11.0 as default temporarily until PMM-10012 is fixed
+            choices: ['none', 'v1.12.0', 'v1.11.0', 'v1.10.0', 'v1.9.0', 'v1.8.0'],
             description: 'Select version of PSMDB operator',
             name: 'PSMDB_OPERATOR_VERSION')                    
         string(


### PR DESCRIPTION
Operators installation is handled by OLM now. No need to apply operators via script anymore.