### PR TITLE
PMM-7 add pg 15.1 to staging-start

### DIFF
--- a/pmm/aws-staging-start.groovy
+++ b/pmm/aws-staging-start.groovy
@@ -82,7 +82,7 @@ pipeline {
             description: "Which version of PostgreSQL",
             name: 'PGSQL_VERSION')
         choice(
-            choices: ['15.0','14.4','14.3','14.2', '14.1', '14.0', '13.7', '13.6', '13.4', '13.2', '13.1', '12.11', '12.10', '12.8', '11.16', '11.15', '11.13'],
+            choices: ['15.1','15.0','14.4','14.3','14.2', '14.1', '14.0', '13.7', '13.6', '13.4', '13.2', '13.1', '12.11', '12.10', '12.8', '11.16', '11.15', '11.13'],
             description: 'Percona Distribution for PostgreSQL',
             name: 'PDPGSQL_VERSION')
         choice(


### PR DESCRIPTION
pmm2-ui-test-nightly fails:

[2023-01-09T00:16:47.013Z] Scheduling project: aws-staging-start

Value for choice parameter 'PDPGSQL_VERSION' is '15.1', but valid choices are [15.0, 14.4, 14.3, 14.2, 14.1, 14.0, 13.7, 13.6, 13.4, 13.2, 13.1, 12.11, 12.10, 12.8, 11.16, 11.15, 11.13]