### PR TITLE
PXC-4093 ADD DEBIAN-11, ORACLE LINUX-9, UBUNTU-22.04 TO PXC 5.7

### DIFF
--- a/pxb/v2/jenkins/percona-xtrabackup-8.0-compile-param.yml
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.0-compile-param.yml
@@ -50,9 +50,12 @@
          values:
          - centos:7
          - centos:8
+         - oraclelinux:9
          - ubuntu:bionic
          - ubuntu:focal
+         - ubuntu:jammy
          - debian:buster
+         - debian:bullseye
          - asan
     builders:
     - trigger-builds:

--- a/pxb/v2/jenkins/percona-xtrabackup-8.0-compile-pipeline.groovy
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.0-compile-pipeline.groovy
@@ -1,5 +1,3 @@
-pipeline_timeout = 10
-
 pipeline {
     parameters {
         string(
@@ -13,7 +11,7 @@ pipeline {
             name: 'BRANCH',
             trim: true)
         choice(
-            choices: 'centos:7\ncentos:8\nubuntu:bionic\nubuntu:focal\ndebian:buster\nasan',
+            choices: 'centos:7\ncentos:8\noraclelinux:9\nubuntu:bionic\nubuntu:focal\nubuntu:jammy\ndebian:buster\ndebian:bullseye\nasan',
             description: 'OS version for compilation',
             name: 'DOCKER_OS')
         choice(

--- a/pxb/v2/jenkins/percona-xtrabackup-8.0-compile-pipeline.yml
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.0-compile-pipeline.yml
@@ -27,9 +27,12 @@
         choices:
         - centos:7
         - centos:8
+        - oraclelinux:9
         - ubuntu:bionic
         - ubuntu:focal
+        - ubuntu:jammy
         - debian:buster
+        - debian:bullseye
         - asan
         description: OS version for compilation
     - choice:

--- a/pxb/v2/jenkins/percona-xtrabackup-8.0-test-param.yml
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.0-test-param.yml
@@ -56,9 +56,12 @@
         values:
         - centos:7
         - centos:8
+        - oraclelinux:9
         - ubuntu:bionic
         - ubuntu:focal
+        - ubuntu:jammy
         - debian:buster
+        - debian:bullseye
         - asan
     - axis:
         name: XTRABACKUP_TARGET

--- a/pxb/v2/jenkins/percona-xtrabackup-8.0-test-pipeline.groovy
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.0-test-pipeline.groovy
@@ -1,9 +1,7 @@
-pipeline_timeout = 10
-
 pipeline {
     parameters {
         choice(
-            choices: 'centos:7\ncentos:8\nubuntu:bionic\nubuntu:focal\ndebian:buster\nasan',
+            choices: 'centos:7\ncentos:8\noraclelinux:9\nubuntu:bionic\nubuntu:focal\nubuntu:jammy\ndebian:buster\ndebian:bullseye\nasan',
             description: 'OS version for compilation',
             name: 'DOCKER_OS')
         choice(

--- a/pxb/v2/jenkins/percona-xtrabackup-8.0-test-pipeline.yml
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.0-test-pipeline.yml
@@ -19,9 +19,12 @@
         choices:
           - centos:7
           - centos:8
+          - oraclelinux:9
           - ubuntu:bionic
           - ubuntu:focal
+          - ubuntu:jammy
           - debian:buster
+          - debian:bullseye
           - asan
         description: OS version for compilation
     - choice:

--- a/pxc/jenkins/param57.yml
+++ b/pxc/jenkins/param57.yml
@@ -35,7 +35,7 @@
         description: URL to PXB24 repository
     - string:
         name: PXB24_BRANCH
-        default: percona-xtrabackup-2.4.20
+        default: percona-xtrabackup-2.4.27
         description: Tag/Branch for PXC repository
     - choice:
         name: JOB_CMAKE
@@ -101,9 +101,12 @@
          values:
           - centos:7
           - centos:8
+          - oraclelinux:9
           - ubuntu:bionic
           - ubuntu:focal
+          - ubuntu:jammy
           - debian:buster
+          - debian:bullseye
     builders:
     - trigger-builds:
       - project: pxc-5.7-pipeline

--- a/pxc/jenkins/pxc57-pipeline.groovy
+++ b/pxc/jenkins/pxc57-pipeline.groovy
@@ -1,4 +1,5 @@
-pipeline_timeout = 10
+def JENKINS_SCRIPTS_BRANCH = 'master'
+def JENKINS_SCRIPTS_REPO = 'https://github.com/Percona-Lab/jenkins-pipelines'
 
 pipeline {
     parameters {
@@ -22,12 +23,12 @@ pipeline {
             name: 'PXB24_REPO',
             trim: true)
         string(
-            defaultValue: 'percona-xtrabackup-2.4.20',
+            defaultValue: 'percona-xtrabackup-2.4.27',
             description: 'Tag/Branch for PXC repository',
             name: 'PXB24_BRANCH',
             trim: true)
         choice(
-            choices: 'centos:7\ncentos:8\nubuntu:bionic\nubuntu:focal\ndebian:buster',
+            choices: 'centos:7\ncentos:8\noraclelinux:9\nubuntu:bionic\nubuntu:focal\nubuntu:jammy\ndebian:buster\ndebian:bullseye',
             description: 'OS version for compilation',
             name: 'DOCKER_OS')
         choice(
@@ -135,7 +136,7 @@ pipeline {
                 stage('Build PXB24') {
                     agent { label 'docker' }
                     steps {
-                        git branch: 'master', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
+                        git branch: JENKINS_SCRIPTS_BRANCH, url: JENKINS_SCRIPTS_REPO
                         echo 'Checkout PXB24 sources'
                         sh '''
                             # sudo is needed for better node recovery after compilation failure
@@ -173,7 +174,7 @@ pipeline {
         stage('Build PXC57') {
                 agent { label 'docker-32gb' }
                 steps {
-                    git branch: 'master', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
+                    git branch: JENKINS_SCRIPTS_BRANCH, url: JENKINS_SCRIPTS_REPO
                     echo 'Checkout PXC57 sources'
                     sh '''
                         # sudo is needed for better node recovery after compilation failure
@@ -210,7 +211,7 @@ pipeline {
         stage('Test PXC57') {
                 agent { label 'docker-32gb' }
                 steps {
-                    git branch: 'master', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
+                    git branch: JENKINS_SCRIPTS_BRANCH, url: JENKINS_SCRIPTS_REPO
                     echo 'Test PXC57'
                     withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'c42456e5-c28d-4962-b32c-b75d161bff27', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
                         sh '''

--- a/pxc/jenkins/pxc57-pipeline.yml
+++ b/pxc/jenkins/pxc57-pipeline.yml
@@ -32,7 +32,7 @@
         description: URL to PXB24 repository
     - string:
         name: PXB24_BRANCH
-        default: percona-xtrabackup-2.4.20
+        default: percona-xtrabackup-2.4.27
         description: Tag/Branch for PXC repository
     - choice:
         name: JOB_CMAKE
@@ -98,6 +98,9 @@
          values:
           - centos:7
           - centos:8
+          - oraclelinux:9
           - ubuntu:bionic
           - ubuntu:focal
+          - ubuntu:jammy
           - debian:buster
+          - debian:bullseye


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-4093

Adds debian:bullseye, oraclelinux:9 and ubuntu:jammy to the configuration matrix of PXC 5.7 pipeline along with some minor refactoring.