### PR TITLE
PXC-4132 CREATES A SYMLINK FOR PYTHON3

### DIFF
--- a/pxc/local/test-binary-pxc57
+++ b/pxc/local/test-binary-pxc57
@@ -33,6 +33,18 @@ if [[ -f /opt/rh/devtoolset-7/enable ]]; then
     source /opt/rh/devtoolset-7/enable
 fi
 
+if [ -f /usr/bin/yum ]; then
+    RHEL=$(rpm --eval %rhel)
+    if [[ ${RHEL} -eq 9 ]]; then
+        sudo ln -sf /bin/python3 /bin/python
+    fi
+elif [ -f /usr/bin/apt-get ]; then
+    OS_NAME="$(lsb_release -sc)"
+    if [[ $(OS_NAME) == "jammy" ]] || [[ $(OS_NAME) == "bullseye" ]]; then
+        sudo ln -sf /usr/bin/python3 /usr/bin/python
+    fi
+fi
+
 sudo cp ${WORKDIR_ABS}/PXB/bin/* /usr/bin/
 
 JEMALLOC=$(find /lib* /usr/lib* /usr/local/lib* -type f -name 'libjemalloc.so*' | head -n1)


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-4132

Some tests which require python3 are failing in Jenkins looking for python only to find python2 installed in bullseye and python3 in OEL9. So, a symlink is created to so that the tests can be consistent.