### PR TITLE
PXC-4132 CREATES A SYMLINK FOR PYTHON3

### DIFF
--- a/pxc/local/test-binary-pxc57
+++ b/pxc/local/test-binary-pxc57
@@ -40,7 +40,7 @@ if [ -f /usr/bin/yum ]; then
     fi
 elif [ -f /usr/bin/apt-get ]; then
     OS_NAME="$(lsb_release -sc)"
-    if [[ $(OS_NAME) == "jammy" ]] || [[ $(OS_NAME) == "bullseye" ]]; then
+    if [[ ${OS_NAME} == "jammy" ]] || [[ ${OS_NAME} == "bullseye" ]]; then
         sudo ln -sf /usr/bin/python3 /usr/bin/python
     fi
 fi


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-4132

Post-push fix to rectify the incorrect use of OS_NAME variable.