### PR TITLE
PXC-4132 INSTALLS MYSQLCLIENT PACAGE FROM PIP3

### DIFF
--- a/pxc/docker/install-deps
+++ b/pxc/docker/install-deps
@@ -193,7 +193,7 @@ if [ -f /usr/bin/yum ]; then
         rm /anaconda-post.log
     fi
 #   Install mysql-connector for QA framework run
-    pip3 install mysql-connector
+    pip3 install mysql-connector mysqlclient
 fi
 
 if [ -f /usr/bin/apt-get ]; then


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-4132

Installs mysqlclient python package for to support the tests which make use of the 'MySQLdb' module.