### PR TITLE
CLOUD-777 - Increase resources used for running minikube tests

### DIFF
--- a/cloud/jenkins/ps_operator_minikube.groovy
+++ b/cloud/jenkins/ps_operator_minikube.groovy
@@ -276,7 +276,7 @@ pipeline {
 
                         sudo curl -Lo /usr/local/bin/minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
                         sudo chmod +x /usr/local/bin/minikube
-                        /usr/local/bin/minikube start --kubernetes-version ${PLATFORM_VER}
+                        /usr/local/bin/minikube start --kubernetes-version ${PLATFORM_VER} --cpus=6 --memory=28G
                     '''
 
                     unstash "sourceFILES"

--- a/cloud/jenkins/psmdb_operator_minikube.groovy
+++ b/cloud/jenkins/psmdb_operator_minikube.groovy
@@ -254,7 +254,7 @@ pipeline {
                         sudo curl -Lo /usr/local/bin/minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
                         sudo chmod +x /usr/local/bin/minikube
                         export CHANGE_MINIKUBE_NONE_USER=true
-                        /usr/local/bin/minikube start --kubernetes-version ${PLATFORM_VER}
+                        /usr/local/bin/minikube start --kubernetes-version ${PLATFORM_VER} --cpus=6 --memory=28G
 
                         sudo sh -c "curl -s -L https://github.com/mikefarah/yq/releases/download/v4.27.2/yq_linux_amd64 > /usr/local/bin/yq"
                         sudo chmod +x /usr/local/bin/yq

--- a/cloud/jenkins/pxc_operator_minikube.groovy
+++ b/cloud/jenkins/pxc_operator_minikube.groovy
@@ -279,7 +279,7 @@ pipeline {
                         sudo chmod +x /usr/local/bin/yq
                         sudo curl -Lo /usr/local/bin/minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
                         sudo chmod +x /usr/local/bin/minikube
-                        /usr/local/bin/minikube start --kubernetes-version ${PLATFORM_VER}
+                        /usr/local/bin/minikube start --kubernetes-version ${PLATFORM_VER} --cpus=6 --memory=28G
                     '''
 
                     unstash "sourceFILES"


### PR DESCRIPTION
This WILL NOT speed up the tests, it will just allow to run tests which ask for more reasources.
Eg. we will probably be able to remove this: https://github.com/percona/percona-server-mysql-operator/blob/main/e2e-tests/functions#L137

Also I didn't go with maximum numbers for the current instance type 8cpu 32GB, but left some buffer, not sure if makes sense or not.