### PR TITLE
ENG-7 fix OL9 docker build for ECR

### DIFF
--- a/pxc/docker/install-deps
+++ b/pxc/docker/install-deps
@@ -39,7 +39,7 @@ if [ -f /usr/bin/yum ]; then
   fi
 
   yum install -y https://repo.percona.com/yum/percona-release-latest.noarch.rpm
-  percona-release enable tools testing
+  percona-release enable-only tools testing
 
   until yum -y update; do
     yum clean all
@@ -210,7 +210,7 @@ if [ -f /usr/bin/apt-get ]; then
     done
 
     curl https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb --output /tmp/prel.deb && dpkg -i /tmp/prel.deb && rm /tmp/prel.deb
-    percona-release enable tools testing
+    percona-release enable-only tools testing
 
     DIST=$(lsb_release -sc)
     if [[ ${DIST} != 'focal' && ${DIST} != 'bullseye' && ${DIST} != 'jammy' ]]; then


### PR DESCRIPTION
While building OL9 image for pxc builds when we install the "mysql-devel" package, it requires as a dependency "mysql-libs" -> "mysql-common" -> "dependency: /etc/my.cnf"

"/etc/my.cnf" provided either by mariadb-connector-c-config or by Percona-Server-server-57(since original recona repo is enabled by default).

In scope of PXC-3363 tools testing repo was enabled only for installing patchelf tool, so we can safely use "enable-only" option while enabling our "tools testing" repo.
In this case Percona-Server-server-57 won't be selected as a candidate for installation.