### PR TITLE
ENG-7 downgrade pshinx for OL9

### DIFF
--- a/pxc/docker/install-deps
+++ b/pxc/docker/install-deps
@@ -361,7 +361,7 @@ if [ -f /usr/bin/yum ]; then
         ln -s /opt/rh/rh-python36/root/usr/bin/sphinx-apidoc /usr/local/bin/sphinx-apidoc
     else
         if [[ ${RHVER} -eq 9 ]]; then
-            pip3 install --upgrade sphinx==6.1.3
+            pip3 install --upgrade sphinx==5.3.0
         else
             pip3 install --upgrade sphinx==1.6.7
             if [[ ${RHVER} -eq 7 ]]; then


### PR DESCRIPTION
Downgrade sphinx for OL9 to 5.3.0 due to
https://github.com/sphinx-doc/sphinx/issues/11094