### PR TITLE
PMM-7 Update spot instance price for min-* agents.

### DIFF
--- a/IaC/pmm.cd/init.groovy.d/cloud.groovy
+++ b/IaC/pmm.cd/init.groovy.d/cloud.groovy
@@ -67,7 +67,7 @@ priceMap = [:]
 priceMap['t2.large']  = '0.045'
 priceMap['t3.xlarge'] = '0.065'
 priceMap['t3.large']  = '0.035'
-priceMap['m4.large']  = '0.040'
+priceMap['m4.large']  = '0.045'
 
 userMap = [:]
 userMap['min-rhel-7-x64']    = 'centos'


### PR DESCRIPTION
Now, we were getting following error:
_Apr 17, 2023 5:20:47 AM hudson.plugins.ec2.EC2Cloud
INFO: Node still not ready. Current status: Your Spot request price of 0.04 is lower than the minimum required Spot request fulfillment price of 0.0417._