### PR TITLE
DISTPG-567: Add ol-8 & ol-9 to ppg-testing. 

### DIFF
--- a/vars/ppgOperatingSystems.groovy
+++ b/vars/ppgOperatingSystems.groovy
@@ -1,5 +1,5 @@
 def call() {
   // centos8 - centos8.3
   // rhel8 - rhel 8.0
-  return ['centos-7', 'centos8', 'debian-10', 'debian-11', 'ubuntu-focal', 'ubuntu-bionic', 'ubuntu-jammy']
+  return ['centos-7', 'ol-8', 'ol-9', 'debian-10', 'debian-11', 'ubuntu-focal', 'ubuntu-bionic', 'ubuntu-jammy']
 }


### PR DESCRIPTION
DISTPG-567: Moved centos8 to ol-8, and added ol-9 in os list that is used for ppg testing.