### PR TITLE
PMM-7 add mysql status and restart check

### DIFF
--- a/pmm/pmm2-ui-tests-nightly.groovy
+++ b/pmm/pmm2-ui-tests-nightly.groovy
@@ -94,6 +94,20 @@ void checkClientNodesAgentStatus(String VM_CLIENT_IP) {
     }
 }
 
+void checkAndRestartMySQL(String VM_CLIENT_IP) {
+    withCredentials([sshUserPrivateKey(credentialsId: 'aws-jenkins', keyFileVariable: 'KEY_PATH', passphraseVariable: '', usernameVariable: 'USER')]) {
+        sh """
+            ssh -i "${KEY_PATH}" -o ConnectTimeout=1 -o StrictHostKeyChecking=no "${USER}@${VM_CLIENT_IP}" '
+                set -o errexit
+                set -o xtrace
+                echo "Checking MySQL Status on Client Nodes"
+                sudo chmod 755 /srv/pmm-qa/pmm-tests/check_and_restart_mysql.sh
+                bash -xe /srv/pmm-qa/pmm-tests/check_and_restart_mysql.sh
+            '
+        """
+    }
+}
+
 void destroyStaging(IP) {
     build job: 'aws-staging-stop', parameters: [
         string(name: 'VM', value: IP),
@@ -271,7 +285,7 @@ pipeline {
                 runStagingServer(DOCKER_VERSION, CLIENT_VERSION, '--addclient=haproxy,1 --setup-alertmanager --setup-external-service', CLIENT_INSTANCE, '127.0.0.1', ADMIN_PASSWORD)
             }
         }
-        stage('Setup PMM Client and Kubernetes Cluster') {
+        stage('Setup PMM Clients') {
             parallel {
                 stage('Start Client Instance - ps-replication') {
                     steps {
@@ -312,6 +326,12 @@ pipeline {
                     sudo npx playwright install-deps
                     envsubst < env.list > env.generated.list
                 """
+            }
+        }
+        stage('MySQL status check') {
+            steps {
+                checkAndRestartMySQL(env.VM_CLIENT_IP_MYSQL)
+                checkAndRestartMySQL(env.VM_CLIENT_IP_PXC)
             }
         }
         stage('Sleep') {


### PR DESCRIPTION
--addclient=ms,1 and --setup-replication-ps-pmm2 --group setups are not stable (services go down sometimes which causes mysql dashboard tests failures). This stage checks the services and restarts a service if the address/port is down.

Test run https://pmm.cd.percona.com/blue/organizations/jenkins/pmm2-ui-test-nightly-beata-temp/detail/pmm2-ui-test-nightly-beata-temp/26/pipeline/73 