### PR TITLE
Skipping some distributions in PS 5.6 to PS 5.7 upgrade job

### DIFF
--- a/ps/jenkins/package-testing-ps-build-5.7.groovy
+++ b/ps/jenkins/package-testing-ps-build-5.7.groovy
@@ -65,6 +65,9 @@ List all_nodes = node_setups.keySet().collect()
 List ps56_excluded_nodes = [
     "min-ol-8-x64",
     "min-focal-x64",
+    "min-jammy-x64",
+    "min-ol-9-x64",
+    "min-bullseye-x64"
 ]
 
 List all_actions = [


### PR DESCRIPTION
Skipping distributions as their packages are not available and they fail by throwing error that No matching packages are available.

Jammy 
Ol9
Bullseye