### PR TITLE
Devtoolset 12 adjustments

### DIFF
--- a/pxc/docker/install-deps
+++ b/pxc/docker/install-deps
@@ -118,6 +118,7 @@ if [ -f /usr/bin/yum ]; then
         PKGLIST_DEVTOOLSET12+=" gcc-toolset-12-libatomic-devel"
         PKGLIST_DEVTOOLSET12+=" gcc-toolset-12-libasan-devel gcc-toolset-12-libubsan-devel"
         PKGLIST_DEVTOOLSET12+=" valgrind valgrind-devel"
+        PKGLIST_DEVTOOLSET12+=" gcc-toolset-12-annobin-annocheck gcc-toolset-12-annobin-plugin-gcc"        
     fi
 
     # KH: why?

--- a/pxc/local/build-binary-pxc-parallel-mtr
+++ b/pxc/local/build-binary-pxc-parallel-mtr
@@ -173,6 +173,7 @@ pushd ${WORKDIR}
         -DFORCE_INSOURCE_BUILD=1 \
         -DWITH_INNODB_MEMCACHED=ON \
         -DDOWNLOAD_BOOST=1 \
+        -DWITH_PACKAGE_FLAGS=OFF \
         -DWITH_BOOST=${DOWNLOAD_DIR} \
         -DCMAKE_INSTALL_PREFIX=/usr/local/${PRODUCT_FULL} \
         -DMYSQL_DATADIR=/usr/local/${PRODUCT_FULL}/data \


### PR DESCRIPTION
1. Added missing gcc-12 toolset missing packages
2. Added WITH_PACKAGE_FLAGS=OFF compilation flag (unified with PS) It disables LTO (Link Time Optimization) and suppresses ODR (One Definition Rule) violations