### PR TITLE
PMM-7 reduce time to instance

### DIFF
--- a/pmm/pmm2-ovf.groovy
+++ b/pmm/pmm2-ovf.groovy
@@ -26,7 +26,7 @@ pipeline {
         stage('Prepare') {
             steps {
                 script {
-                    env.PMM_VERSION = 'dev-latest-el9'
+                    env.PMM_VERSION = 'dev-latest'
                     if (params.RELEASE_CANDIDATE == 'yes') {
                         // release branch should be in the format: pmm-2.x.y
                         env.PMM_VERSION = PMM_BRANCH.split('-')[1] 
@@ -86,7 +86,7 @@ pipeline {
                                 """
                             }
                         }
-                        sh 'ls */*/*.ova | cut -d "/" -f 2 > IMAGE_EL7'
+                        sh 'ls */*/PMM2-Server-EL7*.ova | cut -d "/" -f 2 > IMAGE_EL7'
                         stash includes: 'IMAGE_EL7', name: 'IMAGE_EL7'
                         archiveArtifacts 'IMAGE_EL7'
                     }
@@ -100,7 +100,7 @@ pipeline {
                                 '''
                             }
                         }
-                        sh 'ls */*/*.ova | cut -d "/" -f 2 > IMAGE'
+                        sh 'ls */*/PMM2-Server-EL9*.ova | cut -d "/" -f 2 > IMAGE'
                     }
                 }
             }
@@ -124,7 +124,7 @@ pipeline {
                                 """
                             }
                         }
-                        sh 'ls */*/*.ova | cut -d "/" -f 2 > IMAGE_EL7'
+                        sh 'ls */*/PMM2-Server-EL7*.ova | cut -d "/" -f 2 > IMAGE_EL7'
                         stash includes: 'IMAGE_EL7', name: 'IMAGE_EL7'
                         archiveArtifacts 'IMAGE_EL7'
                     }
@@ -138,7 +138,7 @@ pipeline {
                                 '''
                             }
                         }
-                        sh 'ls */*/*.ova | cut -d "/" -f 2 > IMAGE'
+                        sh 'ls */*/PMM2-Server-EL9*.ova | cut -d "/" -f 2 > IMAGE'
                     }
                 }
             }
@@ -225,7 +225,7 @@ pipeline {
                             """
                         }
                         script {
-                            env.PMM2_SERVER_EL7_OVA_S3 = "https://percona-vm.s3.amazonaws.com/PMM2-Server-dev-latest.el7.ova"
+                            env.PMM2_SERVER_EL7_OVA_S3 = "http://percona-vm.s3-website-us-east-1.amazonaws.com/PMM2-Server-dev-latest.el7.ova"
                         }
                     }
                 }
@@ -243,7 +243,6 @@ pipeline {
 
                                 # This will redirect to the image above
                                 echo /${NAME} > PMM2-Server-dev-latest.ova
-
                                 aws s3 cp \
                                     --only-show-errors \
                                     --website-redirect /${NAME} \
@@ -252,7 +251,7 @@ pipeline {
                             '''
                         }
                         script {
-                            env.PMM2_SERVER_OVA_S3 = "https://percona-vm.s3.amazonaws.com/PMM2-Server-dev-latest.ova"
+                            env.PMM2_SERVER_OVA_S3 = "http://percona-vm.s3-website-us-east-1.amazonaws.com/PMM2-Server-dev-latest.ova"
                         }
                     }
                 }
@@ -265,12 +264,12 @@ pipeline {
             script {
                 if (params.RELEASE_CANDIDATE == "yes")
                 {
-                    currentBuild.description = "RC Build, EL9 Image: " + env.PMM2_SERVER_OVA_S3 + "EL7 Image: " + env.PMM2_SERVER_EL7_OVA_S3
-                    slackSend botUser: true, channel: '#pmm-qa', color: '#00FF00', message: "[${JOB_NAME}]: ${BUILD_URL} RC build finished, EL9 Image: " + env.PMM2_SERVER_OVA_S3 + "EL7 Image: " + env.PMM2_SERVER_EL7_OVA_S3
+                    currentBuild.description = "RC Build, EL9 Image: " + env.PMM2_SERVER_OVA_S3 + " EL7 Image: " + env.PMM2_SERVER_EL7_OVA_S3
+                    slackSend botUser: true, channel: '#pmm-qa', color: '#00FF00', message: "[${JOB_NAME}]: ${BUILD_URL} RC build finished, EL9 Image: " + env.PMM2_SERVER_OVA_S3 + " EL7 Image: " + env.PMM2_SERVER_EL7_OVA_S3
                 }
                 else
                 {
-                    slackSend botUser: true, channel: '#pmm-ci', color: '#00FF00', message: "[${JOB_NAME}]: build finished, EL9 Image: " + env.PMM2_SERVER_OVA_S3 + "EL7 Image: " + env.PMM2_SERVER_EL7_OVA_S3
+                    slackSend botUser: true, channel: '#pmm-ci', color: '#00FF00', message: "[${JOB_NAME}]: build finished, EL9 Image: " + env.PMM2_SERVER_OVA_S3 + " EL7 Image: " + env.PMM2_SERVER_EL7_OVA_S3
                 }
             }
         }

--- a/vars/launchSpotInstance.groovy
+++ b/vars/launchSpotInstance.groovy
@@ -110,7 +110,7 @@ def call(String INSTANCE_TYPE, String SPOT_PRICE, VOLUME) {
                         --query SpotInstanceRequests[].SpotInstanceRequestId
                 )
                 echo \$REQUEST_ID > REQUEST_ID
-                ATTEMPS=2
+                ATTEMPTS=2
                 until [ -s IP ]; do
                     sleep 5
                     aws ec2 describe-instances \
@@ -119,8 +119,8 @@ def call(String INSTANCE_TYPE, String SPOT_PRICE, VOLUME) {
                         --output text \
                         --region us-east-2 \
                         | tee IP
-                    ATTEMPS=\$((ATTEMPS-1))
-                    if [ \$ATTEMPS -eq 0 ]; then
+                    ATTEMPTS=\$((ATTEMPTS-1))
+                    if [ \$ATTEMPTS -eq 0 ]; then
                         break
                     fi
                 done

--- a/vars/launchSpotInstance.groovy
+++ b/vars/launchSpotInstance.groovy
@@ -110,7 +110,7 @@ def call(String INSTANCE_TYPE, String SPOT_PRICE, VOLUME) {
                         --query SpotInstanceRequests[].SpotInstanceRequestId
                 )
                 echo \$REQUEST_ID > REQUEST_ID
-                ATTEMPS=10
+                ATTEMPS=2
                 until [ -s IP ]; do
                     sleep 5
                     aws ec2 describe-instances \


### PR DESCRIPTION
Currently, the aws-staging-start pipeline makes 10 loops with 5s waiting time between the loops before it realizes that there are no AWS instances available at that price. Then it increases the bid price by 15% and tries again. The process loops until AWS can offer an instance at that price. This contributes oftentimes (when the spots are in high demand) to long waiting times to acquire an instance. Example: https://pmm.cd.percona.com/job/aws-staging-start/68442

Our observation is that 2 loops are more than sufficient for that. AWS API is reliable enough, so the first two negative answers should be sufficient to proceed to the another cycle. Anything above 4 mins waiting time is too long (see the second column on the screenshot).

<img width="1302" alt="Screenshot 2023-06-14 at 10 56 17" src="https://github.com/Percona-Lab/jenkins-pipelines/assets/81549/d21c6c94-a03f-43f6-abdb-403384c44cce">



This PR will reduce the time-to-instance, which the team will greatly benefit from.