### PR TITLE
ENG-1203 - Fix python urllib3 library version for azure cli

### DIFF
--- a/cloud/jenkins/psmdb_operator_aks_latest.groovy
+++ b/cloud/jenkins/psmdb_operator_aks_latest.groovy
@@ -313,7 +313,8 @@ EOF
 
                     if ! command -v az &>/dev/null; then
                         curl -L https://azurecliprod.blob.core.windows.net/install.py -o install.py
-                        printf "/usr/azure-cli\\n/usr/bin" | sudo  python3 install.py
+                        printf "/usr/azure-cli\\n/usr/bin" | sudo python3 install.py
+                        sudo /usr/azure-cli/bin/python -m pip install "urllib3<2.0.0"
                     fi
                 """
 

--- a/cloud/jenkins/psmdb_operator_aks_version.groovy
+++ b/cloud/jenkins/psmdb_operator_aks_version.groovy
@@ -313,7 +313,8 @@ EOF
 
                     if ! command -v az &>/dev/null; then
                         curl -L https://azurecliprod.blob.core.windows.net/install.py -o install.py
-                        printf "/usr/azure-cli\\n/usr/bin" | sudo  python3 install.py
+                        printf "/usr/azure-cli\\n/usr/bin" | sudo python3 install.py
+                        sudo /usr/azure-cli/bin/python -m pip install "urllib3<2.0.0"
                     fi
                 """
 

--- a/cloud/jenkins/pxc_operator_aks_latest.groovy
+++ b/cloud/jenkins/pxc_operator_aks_latest.groovy
@@ -335,7 +335,8 @@ EOF
                     
                     if ! command -v az &>/dev/null; then
                         curl -L https://azurecliprod.blob.core.windows.net/install.py -o install.py
-                        printf "/usr/azure-cli\\n/usr/bin" | sudo  python3 install.py
+                        printf "/usr/azure-cli\\n/usr/bin" | sudo python3 install.py
+                        sudo /usr/azure-cli/bin/python -m pip install "urllib3<2.0.0"
                     fi
                 """
                 withCredentials([file(credentialsId: 'cloud-secret-file', variable: 'CLOUD_SECRET_FILE')]) {

--- a/cloud/jenkins/pxc_operator_aks_version.groovy
+++ b/cloud/jenkins/pxc_operator_aks_version.groovy
@@ -335,7 +335,8 @@ EOF
                     
                     if ! command -v az &>/dev/null; then
                         curl -L https://azurecliprod.blob.core.windows.net/install.py -o install.py
-                        printf "/usr/azure-cli\\n/usr/bin" | sudo  python3 install.py
+                        printf "/usr/azure-cli\\n/usr/bin" | sudo python3 install.py
+                        sudo /usr/azure-cli/bin/python -m pip install "urllib3<2.0.0"
                     fi
                 """
                 withCredentials([file(credentialsId: 'cloud-secret-file', variable: 'CLOUD_SECRET_FILE')]) {


### PR DESCRIPTION
Failure:
```
11:40:54  + az login --service-principal -u **** -p **** -t **** --allow-no-subscriptions
11:40:54  urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'OpenSSL 1.0.2k-fips  26 Jan 2017'. See: https://github.com/urllib3/urllib3/issues/2168
11:40:54  ERROR: Error loading command module 'acr': urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'OpenSSL 1.0.2k-fips  26 Jan 2017'. See: https://github.com/urllib3/urllib3/issues/2168
11:40:54  ERROR: Error loading command module 'appservice': urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'OpenSSL 1.0.2k-fips  26 Jan 2017'. See: https://github.com/urllib3/urllib3/issues/2168
11:40:54  ERROR: Error loading command module 'aro': urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'OpenSSL 1.0.2k-fips  26 Jan 2017'. See: https://github.com/urllib3/urllib3/issues/2168
11:40:54  ERROR: Error loading command module 'batch': urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'OpenSSL 1.0.2k-fips  26 Jan 2017'. See: https://github.com/urllib3/urllib3/issues/2168
11:40:54  ERROR: Error loading command module 'container': urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'OpenSSL 1.0.2k-fips  26 Jan 2017'. See: https://github.com/urllib3/urllib3/issues/2168
11:40:54  ERROR: Error loading command module 'eventhubs': urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'OpenSSL 1.0.2k-fips  26 Jan 2017'. See: https://github.com/urllib3/urllib3/issues/2168
11:40:54  ERROR: Error loading command module 'hdinsight': urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'OpenSSL 1.0.2k-fips  26 Jan 2017'. See: https://github.com/urllib3/urllib3/issues/2168
11:40:55  ERROR: Error loading command module 'iot': urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'OpenSSL 1.0.2k-fips  26 Jan 2017'. See: https://github.com/urllib3/urllib3/issues/2168
11:40:55  ERROR: Error loading command module 'monitor': urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'OpenSSL 1.0.2k-fips  26 Jan 2017'. See: https://github.com/urllib3/urllib3/issues/2168
11:40:55  ERROR: Error loading command module 'netappfiles': urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'OpenSSL 1.0.2k-fips  26 Jan 2017'. See: https://github.com/urllib3/urllib3/issues/2168
11:40:55  ERROR: Error loading command module 'network': urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'OpenSSL 1.0.2k-fips  26 Jan 2017'. See: https://github.com/urllib3/urllib3/issues/2168
11:40:55  ERROR: Error loading command module 'policyinsights': urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'OpenSSL 1.0.2k-fips  26 Jan 2017'. See: https://github.com/urllib3/urllib3/issues/2168
11:40:55  ERROR: Error loading command module 'rdbms': urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'OpenSSL 1.0.2k-fips  26 Jan 2017'. See: https://github.com/urllib3/urllib3/issues/2168
11:40:55  ERROR: Error loading command module 'servicebus': urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'OpenSSL 1.0.2k-fips  26 Jan 2017'. See: https://github.com/urllib3/urllib3/issues/2168
11:40:55  ERROR: Error loading command module 'serviceconnector': urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'OpenSSL 1.0.2k-fips  26 Jan 2017'. See: https://github.com/urllib3/urllib3/issues/2168
11:40:55  ERROR: Error loading command module 'servicefabric': urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'OpenSSL 1.0.2k-fips  26 Jan 2017'. See: https://github.com/urllib3/urllib3/issues/2168
11:40:55  ERROR: Error loading command module 'sql': urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'OpenSSL 1.0.2k-fips  26 Jan 2017'. See: https://github.com/urllib3/urllib3/issues/2168
11:40:55  ERROR: Error loading command module 'sqlvm': urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'OpenSSL 1.0.2k-fips  26 Jan 2017'. See: https://github.com/urllib3/urllib3/issues/2168
11:40:55  ERROR: Error loading command module 'vm': urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'OpenSSL 1.0.2k-fips  26 Jan 2017'. See: https://github.com/urllib3/urllib3/issues/2168
11:40:55  Traceback (most recent call last):
11:40:55    File "/usr/azure-cli/lib/python3.7/site-packages/knack/cli.py", line 233, in invoke
11:40:55      cmd_result = self.invocation.execute(args)
11:40:55    File "/usr/azure-cli/lib/python3.7/site-packages/azure/cli/core/commands/__init__.py", line 663, in execute
11:40:55      raise ex
11:40:55    File "/usr/azure-cli/lib/python3.7/site-packages/azure/cli/core/commands/__init__.py", line 726, in _run_jobs_serially
11:40:55      results.append(self._run_job(expanded_arg, cmd_copy))
11:40:55    File "/usr/azure-cli/lib/python3.7/site-packages/azure/cli/core/commands/__init__.py", line 697, in _run_job
11:40:55      result = cmd_copy(params)
11:40:55    File "/usr/azure-cli/lib/python3.7/site-packages/azure/cli/core/commands/__init__.py", line 333, in __call__
11:40:55      return self.handler(*args, **kwargs)
11:40:55    File "/usr/azure-cli/lib/python3.7/site-packages/azure/cli/core/commands/command_operation.py", line 121, in handler
11:40:55      return op(**command_args)
11:40:55    File "/usr/azure-cli/lib/python3.7/site-packages/azure/cli/command_modules/profile/custom.py", line 148, in login
11:40:55      use_cert_sn_issuer=use_cert_sn_issuer)
11:40:55    File "/usr/azure-cli/lib/python3.7/site-packages/azure/cli/core/_profile.py", line 159, in login
11:40:55      identity.login_with_service_principal(username, password, scopes=scopes)
11:40:55    File "/usr/azure-cli/lib/python3.7/site-packages/azure/cli/core/auth/identity.py", line 182, in login_with_service_principal
11:40:55      cred = ServicePrincipalCredential(sp_auth, **self._msal_app_kwargs)
11:40:55    File "/usr/azure-cli/lib/python3.7/site-packages/azure/cli/core/auth/msal_authentication.py", line 132, in __init__
11:40:55      super().__init__(service_principal_auth.client_id, client_credential=client_credential, **kwargs)
11:40:55    File "/usr/azure-cli/lib/python3.7/site-packages/msal/application.py", line 507, in __init__
11:40:55      import requests  # Lazy load
11:40:55    File "/usr/azure-cli/lib/python3.7/site-packages/requests/__init__.py", line 43, in <module>
11:40:55      import urllib3
11:40:55    File "/usr/azure-cli/lib/python3.7/site-packages/urllib3/__init__.py", line 42, in <module>
11:40:55      "urllib3 v2.0 only supports OpenSSL 1.1.1+, currently "
11:40:55  ImportError: urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'OpenSSL 1.0.2k-fips  26 Jan 2017'. See: https://github.com/urllib3/urllib3/issues/2168
11:40:55  
11:40:55  During handling of the above exception, another exception occurred:
11:40:55  
11:40:55  Traceback (most recent call last):
11:40:55    File "/usr/lib64/python3.7/runpy.py", line 193, in _run_module_as_main
11:40:55      "__main__", mod_spec)
11:40:55    File "/usr/lib64/python3.7/runpy.py", line 85, in _run_code
11:40:55      exec(code, run_globals)
11:40:55    File "/usr/azure-cli/lib/python3.7/site-packages/azure/cli/__main__.py", line 50, in <module>
11:40:55      exit_code = cli_main(az_cli, sys.argv[1:])
11:40:55    File "/usr/azure-cli/lib/python3.7/site-packages/azure/cli/__main__.py", line 36, in cli_main
11:40:55      return cli.invoke(args)
11:40:55    File "/usr/azure-cli/lib/python3.7/site-packages/knack/cli.py", line 245, in invoke
11:40:55      exit_code = self.exception_handler(ex)
11:40:55    File "/usr/azure-cli/lib/python3.7/site-packages/azure/cli/core/__init__.py", line 127, in exception_handler
11:40:55      return handle_exception(ex)
11:40:55    File "/usr/azure-cli/lib/python3.7/site-packages/azure/cli/core/util.py", line 59, in handle_exception
11:40:55      from msrestazure.azure_exceptions import CloudError
11:40:55    File "/usr/azure-cli/lib/python3.7/site-packages/msrestazure/__init__.py", line 28, in <module>
11:40:55      from .azure_configuration import AzureConfiguration
11:40:55    File "/usr/azure-cli/lib/python3.7/site-packages/msrestazure/azure_configuration.py", line 34, in <module>
11:40:55      from msrest import Configuration
11:40:55    File "/usr/azure-cli/lib/python3.7/site-packages/msrest/__init__.py", line 28, in <module>
11:40:55      from .configuration import Configuration
11:40:55    File "/usr/azure-cli/lib/python3.7/site-packages/msrest/configuration.py", line 37, in <module>
11:40:55      from .pipeline import Pipeline
11:40:55    File "/usr/azure-cli/lib/python3.7/site-packages/msrest/pipeline/__init__.py", line 52, in <module>
11:40:55      from requests.structures import CaseInsensitiveDict
11:40:55    File "/usr/azure-cli/lib/python3.7/site-packages/requests/__init__.py", line 43, in <module>
11:40:55      import urllib3
11:40:55    File "/usr/azure-cli/lib/python3.7/site-packages/urllib3/__init__.py", line 42, in <module>
11:40:55      "urllib3 v2.0 only supports OpenSSL 1.1.1+, currently "
11:40:55  ImportError: urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'OpenSSL 1.0.2k-fips  26 Jan 2017'. See: https://github.com/urllib3/urllib3/issues/2168
```