### PR TITLE
PMM-11658 prevent Jenkins from killing the process

### DIFF
--- a/pmm/aws-staging-start.groovy
+++ b/pmm/aws-staging-start.groovy
@@ -3,7 +3,7 @@ import hudson.slaves.*
 import jenkins.model.Jenkins
 import hudson.plugins.sshslaves.SSHLauncher
 
-library changelog: false, identifier: 'lib@master', retriever: modernSCM([
+library changelog: false, identifier: 'lib@PMM-11658-move-exporter-configs', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/Percona-Lab/jenkins-pipelines.git'
 ]) _

--- a/pmm/aws-staging-start.groovy
+++ b/pmm/aws-staging-start.groovy
@@ -3,7 +3,7 @@ import hudson.slaves.*
 import jenkins.model.Jenkins
 import hudson.plugins.sshslaves.SSHLauncher
 
-library changelog: false, identifier: 'lib@PMM-11658-move-exporter-configs', retriever: modernSCM([
+library changelog: false, identifier: 'lib@master', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/Percona-Lab/jenkins-pipelines.git'
 ]) _

--- a/vars/setupPMMClient.groovy
+++ b/vars/setupPMMClient.groovy
@@ -56,7 +56,8 @@ def call(String SERVER_IP, String CLIENT_VERSION, String PMM_VERSION, String ENA
                     wget -O pmm2-client.tar.gz --progress=dot:giga "https://www.percona.com/downloads/pmm2/${CLIENT_VERSION}/binary/tarball/pmm2-client-${CLIENT_VERSION}.tar.gz"
                 fi
 
-                export BUILD_ID=dont-kill-the-instance
+                export BUILD_ID=dont-kill-the-process
+                export ENKINS_NODE_COOKIE=dont-kill-the-process
                 tar -zxpf pmm2-client.tar.gz
                 rm -f pmm2-client.tar.gz
                 mv pmm2-client-* "$PMM_BINARY"

--- a/vars/setupPMMClient.groovy
+++ b/vars/setupPMMClient.groovy
@@ -57,7 +57,7 @@ def call(String SERVER_IP, String CLIENT_VERSION, String PMM_VERSION, String ENA
                 fi
 
                 export BUILD_ID=dont-kill-the-process
-                export ENKINS_NODE_COOKIE=dont-kill-the-process
+                export JENKINS_NODE_COOKIE=dont-kill-the-process
                 tar -zxpf pmm2-client.tar.gz
                 rm -f pmm2-client.tar.gz
                 mv pmm2-client-* "$PMM_BINARY"


### PR DESCRIPTION
We want to prevent Jenkins from killing the pmm-agent process when the pipeline terminates.

Ref: https://stackoverflow.com/questions/39169457/how-to-tell-jenkins-not-to-kill-processes-after-successful-execution-of-job-in-m