### PR TITLE
PMM-7 Fix Oracle Linux 8 agents.

### DIFF
--- a/IaC/pmm.cd/init.groovy.d/cloud.groovy
+++ b/IaC/pmm.cd/init.groovy.d/cloud.groovy
@@ -121,7 +121,7 @@ initMap['rpmMap'] = '''
     elif [[ $SYSREL -eq 7 ]]; then
         PKGLIST="tar coreutils java-11-openjdk"
     elif [[ $SYSREL -ge 8 ]]; then
-        PKGLIST="tar coreutils java-11-openjdk"
+        PKGLIST="tar coreutils java-11-openjdk tzdata-java"
     fi
 
     until sudo yum makecache; do


### PR DESCRIPTION
We were unable to launch **_min-ol-8-x64_** agent:
**_Exception in thread "main" java.lang.Error: java.io.FileNotFoundException: /usr/lib/jvm/java-11-openjdk-11.0.20.0.8-2.0.1.el8.x86_64/lib/tzdb.dat (No such file or directory)_**

We fix this by installing **_tzdata-java_** package
