### PR TITLE
PMM-7 Hint on how to launch PMM with RC

### DIFF
--- a/pmm/aws-staging-start.groovy
+++ b/pmm/aws-staging-start.groovy
@@ -35,7 +35,7 @@ pipeline {
             name: 'DOCKER_VERSION')
         string(
             defaultValue: 'dev-latest',
-            description: 'PMM Client version ("dev-latest" for main branch, "latest" or "X.X.X" for released version, "http://..." for feature build)',
+            description: 'PMM Client version ("dev-latest" for main branch, "latest" or "X.X.X" for released version, "pmm2-rc" for Release Candidate, "http://..." for feature build)',
             name: 'CLIENT_VERSION')
         string(
             defaultValue: '',


### PR DESCRIPTION
It is not clear for most folks how to launch a staging instance of PMM with the Release Candidate version of PMM Client. This PR provides a hint for the `CLIENT_VERSION` input parameter.