### PR TITLE
Post-fix: Enable keyring and xbcloud tests by default

### DIFF
--- a/pxb/v2/jenkins/percona-xtrabackup-8.0-test-param.yml
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.0-test-param.yml
@@ -37,15 +37,15 @@
         description: "Starts Microsoft Azurite emulator and tests xbcloud against it"
     - bool:
         name: WITH_XBCLOUD_TESTS
-        default: false
+        default: true
         description: "Run xbcloud tests"
     - bool:
         name: WITH_VAULT_TESTS
-        default: false
+        default: true
         description: "Run vault tests"
     - bool:
         name: WITH_KMIP_TESTS
-        default: false
+        default: true
         description: "Run kmip tests"
     - choice:
         name: LABEL

--- a/pxb/v2/jenkins/percona-xtrabackup-8.0-test-pipeline.groovy
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.0-test-pipeline.groovy
@@ -34,15 +34,15 @@ pipeline {
             name: 'WITH_AZURITE')
         booleanParam(
             name: 'WITH_XBCLOUD_TESTS',
-            defaultValue: false,
+            defaultValue: true,
             description: 'Run xbcloud tests')
         booleanParam(
             name: 'WITH_VAULT_TESTS',
-            defaultValue: false,
+            defaultValue: true,
             description: 'Run vault tests')
         booleanParam(
             name: 'WITH_KMIP_TESTS',
-            defaultValue: false,
+            defaultValue: true,
             description: 'Run kmip tests')
         choice(
             choices: 'docker-32gb\ndocker',

--- a/pxb/v2/jenkins/percona-xtrabackup-8.0-test-pipeline.yml
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.0-test-pipeline.yml
@@ -61,15 +61,15 @@
         description: "Starts Microsoft Azurite emulator and tests xbcloud against it"
     - bool:
         name: WITH_XBCLOUD_TESTS
-        default: false
+        default: true
         description: "Run xbcloud tests"
     - bool:
         name: WITH_VAULT_TESTS
-        default: false
+        default: true
         description: "Run vault tests"
     - bool:
         name: WITH_KMIP_TESTS
-        default: false
+        default: true
         description: "Run kmip tests"
     - choice:
         name: LABEL

--- a/pxb/v2/jenkins/percona-xtrabackup-8.1-test-param.yml
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.1-test-param.yml
@@ -41,15 +41,15 @@
         description: "Starts Microsoft Azurite emulator and tests xbcloud against it"
     - bool:
         name: WITH_XBCLOUD_TESTS
-        default: false
+        default: true
         description: "Run xbcloud tests"
     - bool:
         name: WITH_VAULT_TESTS
-        default: false
+        default: true
         description: "Run vault tests"
     - bool:
         name: WITH_KMIP_TESTS
-        default: false
+        default: true
         description: "Run kmip tests"
     - choice:
         name: LABEL

--- a/pxb/v2/jenkins/percona-xtrabackup-8.1-test-pipeline.groovy
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.1-test-pipeline.groovy
@@ -34,15 +34,15 @@ pipeline {
             name: 'WITH_AZURITE')
         booleanParam(
             name: 'WITH_XBCLOUD_TESTS',
-            defaultValue: false,
+            defaultValue: true,
             description: 'Run xbcloud tests')
         booleanParam(
             name: 'WITH_VAULT_TESTS',
-            defaultValue: false,
+            defaultValue: true,
             description: 'Run vault tests')
         booleanParam(
             name: 'WITH_KMIP_TESTS',
-            defaultValue: false,
+            defaultValue: true,
             description: 'Run kmip tests')
         choice(
             choices: 'docker-32gb\ndocker',

--- a/pxb/v2/jenkins/percona-xtrabackup-8.1-test-pipeline.yml
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.1-test-pipeline.yml
@@ -62,15 +62,15 @@
         description: "Starts Microsoft Azurite emulator and tests xbcloud against it"
     - bool:
         name: WITH_XBCLOUD_TESTS
-        default: false
+        default: true
         description: "Run xbcloud tests"
     - bool:
         name: WITH_VAULT_TESTS
-        default: false
+        default: true
         description: "Run vault tests"
     - bool:
         name: WITH_KMIP_TESTS
-        default: false
+        default: true
         description: "Run kmip tests"
     - choice:
         name: LABEL


### PR DESCRIPTION
Enable keyring tests and xbcloud by default on test pipeline used by trunk jobs. Default from multijob is still disabled.