### PR TITLE
Fix PXB-3188: Use boost from image

### DIFF
--- a/pxb/v2/local/build-binary
+++ b/pxb/v2/local/build-binary
@@ -43,7 +43,7 @@ wget_loop() {
 }
 
 BOOST_VERSION=$(grep 'SET(BOOST_PACKAGE_NAME' ${SOURCEDIR}/cmake/boost.cmake | sed -re 's/.*([0-9]+_[0-9]+_[0-9]+).*/\1/')
-wget_loop "boost_${BOOST_VERSION}.tar.gz" "http://downloads.sourceforge.net/boost/boost/${BOOST_VERSION//_/.}/boost_${BOOST_VERSION}.tar.gz"
+wget_loop "boost_${BOOST_VERSION}.tar.bz2" "http://downloads.sourceforge.net/boost/boost/${BOOST_VERSION//_/.}/boost_${BOOST_VERSION}.tar.bz2"
 
 # ------------------------------------------------------------------------------
 # Set OS/Arch flags


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-3188

Adjust boost logic to look for tar.bz2 boost file instead of tar.gz. Our images already have a tar.bz2 available.