### PR TITLE
bump gcc to version 10 on Centos8

### DIFF
--- a/pxb/v2/local/build-binary
+++ b/pxb/v2/local/build-binary
@@ -89,10 +89,15 @@ else
     export BUILD_TYPE=" -DBUILD_CONFIG=xtrabackup_release"
 fi
 
-# Enable devtoolset if XB_MAJOR_VERSION is 8 and for  CentOS 7 or 8
-if [[ "${DOCKER_OS}" = "centos-7" ]] || [[ "${DOCKER_OS}" = "centos-8" ]] || [[ "${DOCKER_OS}" = "asan" ]]; then
+# Enable devtoolset if XB_MAJOR_VERSION is 8 and for  CentOS 7
+if [[ "${DOCKER_OS}" = "centos-7" ]] || [[ "${DOCKER_OS}" = "asan" ]]; then
   if [[ ${XB_VERSION_MAJOR} -eq 8 ]] && [[ -f /opt/rh/devtoolset-10/enable ]]; then
     source /opt/rh/devtoolset-10/enable
+  fi
+fi
+if [[ "${DOCKER_OS}" = "centos-8" ]]; then
+  if [[ ${XB_VERSION_MAJOR} -eq 8 ]] && [[ -f /opt/rh/gcc-toolset-10/enable ]]; then
+    source /opt/rh/gcc-toolset-10/enable
   fi
 fi
 


### PR DESCRIPTION
centos-8 uses gcc-toolset instead of devtoolset