### PR TITLE
Temporary Fix for PXB-3192

### DIFF
--- a/pxb/v2/local/build-binary
+++ b/pxb/v2/local/build-binary
@@ -97,6 +97,8 @@ if [[ "${DOCKER_OS}" = "centos-7" ]] || [[ "${DOCKER_OS}" = "asan" ]]; then
 fi
 if [[ "${DOCKER_OS}" = "centos-8" ]]; then
   if [[ ${XB_VERSION_MAJOR} -eq 8 ]] && [[ -f /opt/rh/gcc-toolset-10/enable ]]; then
+    # Temporary patch for PXB-3192
+    sudo yum install -y gcc-toolset-10-annobin
     source /opt/rh/gcc-toolset-10/enable
   fi
 fi


### PR DESCRIPTION
Centos-8 is missing annobin library:

10:20:00 CMake Error at configure.cmake:337 (MESSAGE): 10:20:00 No mysys timer support detected!
10:20:00 Call Stack (most recent call first):
10:20:00 CMakeLists.txt:1621 (INCLUDE)

This is a temporary fix until the lib is installed on the base image.