### PR TITLE
PMM-12645 pmm.cd: fix debian buster init script

### DIFF
--- a/IaC/pmm.cd/init.groovy.d/cloud.groovy
+++ b/IaC/pmm.cd/init.groovy.d/cloud.groovy
@@ -196,11 +196,12 @@ initMap['debMap'] = '''
         JDK_PACKAGE=openjdk-11-jdk
     fi
 
-    if [[ ${DEB_VERSION} == "bookworm" ]]; then
+    if [[ ${DEB_VERSION} == "bookworm" ]] || [[ ${DEB_VERSION} == "buster" ]]; then
         sudo DEBIAN_FRONTEND=noninteractive sudo apt-get -y install ${JDK_PACKAGE} git
         sudo mv /etc/ssl /etc/ssl_old
         sudo DEBIAN_FRONTEND=noninteractive sudo apt-get -y install ${JDK_PACKAGE}
         sudo cp -r /etc/ssl_old /etc/ssl
+        sudo DEBIAN_FRONTEND=noninteractive sudo apt-get -y install ${JDK_PACKAGE}
     else
         sudo DEBIAN_FRONTEND=noninteractive sudo apt-get -y install ${JDK_PACKAGE} git
     fi


### PR DESCRIPTION
Hack for proper openjdk-11-jre-headless installation for the ami images that already contain ca-certificates preinstalled.
`dpkg: error processing package ca-certificates-java (--configure):
 installed ca-certificates-java package post-installation script subprocess returned error exit status 1
dpkg: dependency problems prevent configuration of openjdk-11-jre-headless:amd64:
 openjdk-11-jre-headless:amd64 depends on ca-certificates-java (>= 20190405~); however:
  Package ca-certificates-java is not configured yet.
`