### PR TITLE
ENG-7 spot-price-auto-updater: keep 1000 builds

### DIFF
--- a/IaC/spot-price-auto-updater.yml
+++ b/IaC/spot-price-auto-updater.yml
@@ -10,9 +10,9 @@
     properties:
     - build-discarder:
         days-to-keep: -1
-        num-to-keep: 10
+        num-to-keep: 1000
         artifact-days-to-keep: -1
-        artifact-num-to-keep: 10
+        artifact-num-to-keep: 1000
     triggers:
     - timed: 'H/15 * * * *'
     dsl: |


### PR DESCRIPTION
Increasing the number of build upto 1000, which is equal to 10 days and 20 hours.
1 build ~ 40KB, 1000 builds ~ 40MB of space.