### PR TITLE
K8SPG-358 - Create version-service:main-latest image for testing

### DIFF
--- a/cloud/jenkins/version_service_docker_build.groovy
+++ b/cloud/jenkins/version_service_docker_build.groovy
@@ -101,6 +101,11 @@ pipeline {
                             fi
                             docker login -u '${USER}' -p '${PASS}'
                             docker push \$IMG
+                            if [[ "\$IMG" == *"perconalab/version-service:main-"* ]]; then
+                                export IMG_LATEST="perconalab/version-service:main-latest"
+                                docker tag \$IMG \\$IMG_LATEST
+                                docker push \\$IMG_LATEST
+                            fi
                             docker logout
                         "
                     '''


### PR DESCRIPTION
This is needed so we can use latest image from the main branch in our tests.