### PR TITLE
K8SPG-358 - Fix OpenShift pipeline to not fail on unzip if re-run

### DIFF
--- a/cloud/jenkins/pgo_operator_aws_openshift-4.groovy
+++ b/cloud/jenkins/pgo_operator_aws_openshift-4.groovy
@@ -24,7 +24,7 @@ void prepareNode() {
         sudo yum install -y percona-xtrabackup-80 | true
 
         wget https://releases.hashicorp.com/terraform/0.11.14/terraform_0.11.14_linux_amd64.zip
-        unzip terraform_0.11.14_linux_amd64.zip
+        unzip -o terraform_0.11.14_linux_amd64.zip
         sudo mv terraform /usr/local/bin/ && rm terraform_0.11.14_linux_amd64.zip
 
         curl -fsSL https://github.com/kubernetes-sigs/krew/releases/latest/download/krew-linux_amd64.tar.gz | tar -xzf -

--- a/cloud/jenkins/pgo_operator_aws_openshift_latest.groovy
+++ b/cloud/jenkins/pgo_operator_aws_openshift_latest.groovy
@@ -24,7 +24,7 @@ void prepareNode() {
         sudo yum install -y percona-xtrabackup-80 | true
 
         wget https://releases.hashicorp.com/terraform/0.11.14/terraform_0.11.14_linux_amd64.zip
-        unzip terraform_0.11.14_linux_amd64.zip
+        unzip -o terraform_0.11.14_linux_amd64.zip
         sudo mv terraform /usr/local/bin/ && rm terraform_0.11.14_linux_amd64.zip
 
         curl -fsSL https://github.com/kubernetes-sigs/krew/releases/latest/download/krew-linux_amd64.tar.gz | tar -xzf -

--- a/cloud/jenkins/pgo_v1_operator_aws_openshift-4.groovy
+++ b/cloud/jenkins/pgo_v1_operator_aws_openshift-4.groovy
@@ -338,7 +338,7 @@ pipeline {
                         sudo yum install -y percona-xtrabackup-80 | true
 
                         wget https://releases.hashicorp.com/terraform/0.11.14/terraform_0.11.14_linux_amd64.zip
-                        unzip terraform_0.11.14_linux_amd64.zip
+                        unzip -o terraform_0.11.14_linux_amd64.zip
                         sudo mv terraform /usr/local/bin/ && rm terraform_0.11.14_linux_amd64.zip
 
                         sudo tee /etc/yum.repos.d/google-cloud-sdk.repo << EOF

--- a/cloud/jenkins/pgo_v1_pg12_operator_aws_openshift-4.groovy
+++ b/cloud/jenkins/pgo_v1_pg12_operator_aws_openshift-4.groovy
@@ -334,7 +334,7 @@ pipeline {
                         sudo yum install -y percona-xtrabackup-80 | true
 
                         wget https://releases.hashicorp.com/terraform/0.11.14/terraform_0.11.14_linux_amd64.zip
-                        unzip terraform_0.11.14_linux_amd64.zip
+                        unzip -o terraform_0.11.14_linux_amd64.zip
                         sudo mv terraform /usr/local/bin/ && rm terraform_0.11.14_linux_amd64.zip
                     """
                 }

--- a/cloud/jenkins/pgo_v1_pg13_operator_aws_openshift-4.groovy
+++ b/cloud/jenkins/pgo_v1_pg13_operator_aws_openshift-4.groovy
@@ -334,7 +334,7 @@ pipeline {
                         sudo yum install -y percona-xtrabackup-80 | true
 
                         wget https://releases.hashicorp.com/terraform/0.11.14/terraform_0.11.14_linux_amd64.zip
-                        unzip terraform_0.11.14_linux_amd64.zip
+                        unzip -o terraform_0.11.14_linux_amd64.zip
                         sudo mv terraform /usr/local/bin/ && rm terraform_0.11.14_linux_amd64.zip
                     """
                 }

--- a/cloud/jenkins/ps_operator_aws_openshift-4.groovy
+++ b/cloud/jenkins/ps_operator_aws_openshift-4.groovy
@@ -169,7 +169,7 @@ pipeline {
             steps {
                 sh """
                     wget https://releases.hashicorp.com/terraform/0.11.14/terraform_0.11.14_linux_amd64.zip
-                    unzip terraform_0.11.14_linux_amd64.zip
+                    unzip -o terraform_0.11.14_linux_amd64.zip
                     sudo mv terraform /usr/local/bin/ && rm terraform_0.11.14_linux_amd64.zip
                 """
                 installRpms()

--- a/cloud/jenkins/psmdb_operator_aws_openshift-4.groovy
+++ b/cloud/jenkins/psmdb_operator_aws_openshift-4.groovy
@@ -341,7 +341,7 @@ pipeline {
 
                 sh """
                     wget https://releases.hashicorp.com/terraform/0.11.14/terraform_0.11.14_linux_amd64.zip
-                    unzip terraform_0.11.14_linux_amd64.zip
+                    unzip -o terraform_0.11.14_linux_amd64.zip
                     sudo mv terraform /usr/local/bin/ && rm terraform_0.11.14_linux_amd64.zip
                 """
                 sh '''

--- a/cloud/jenkins/pxc_operator_aws_openshift_latest.groovy
+++ b/cloud/jenkins/pxc_operator_aws_openshift_latest.groovy
@@ -24,7 +24,7 @@ void prepareNode() {
         sudo yum install -y percona-xtrabackup-80 | true
 
         wget https://releases.hashicorp.com/terraform/0.11.14/terraform_0.11.14_linux_amd64.zip
-        unzip terraform_0.11.14_linux_amd64.zip
+        unzip -o terraform_0.11.14_linux_amd64.zip
         sudo mv terraform /usr/local/bin/ && rm terraform_0.11.14_linux_amd64.zip
     """
 


### PR DESCRIPTION
If the job is re-run on same executor it can fail like this:
```
18:28:29  2023-12-18 17:28:28 (204 MB/s) - ‘terraform_0.11.14_linux_amd64.zip.1’ saved [12569267/12569267]
18:28:29  
18:28:29  + unzip terraform_0.11.14_linux_amd64.zip
18:28:29  Archive:  terraform_0.11.14_linux_amd64.zip
18:28:29  replace terraform? [y]es, [n]o, [A]ll, [N]one, [r]ename:  NULL
18:28:29  (EOF or read error, treating as "[N]one" ...)
```
