### PR TITLE
clang package is getting installed from builder script. No need to in…

### DIFF
--- a/ppg/pg_stat_monitor-autobuild.groovy
+++ b/ppg/pg_stat_monitor-autobuild.groovy
@@ -50,7 +50,7 @@ void buildStage(String DOCKER_OS, String STAGE_PARAM) {
                 sleep 30
                 echo "Waiting ..."
             done
-            until sudo apt-get -y install gpgv curl clang-11 gnupg; do
+            until sudo apt-get -y install gpgv curl gnupg; do
                 sleep 30
                 echo "Waiting ..."
             done


### PR DESCRIPTION
…stall older version from jenkins job.