### PR TITLE
K8SPXC-1295 Remove redundant slackSend calls

### DIFF
--- a/cloud/jenkins/psmdb_operator_aks_version.groovy
+++ b/cloud/jenkins/psmdb_operator_aks_version.groovy
@@ -377,7 +377,6 @@ EOF
             script {
                 if (currentBuild.result != null && currentBuild.result != 'SUCCESS') {
                     slackSend channel: '#cloud-dev-ci', color: '#FF0000', message: "[${JOB_NAME}]: build ${currentBuild.result}, ${BUILD_URL}"
-                    slackSend channel: '@${OWNER_SLACK}', color: '#FF0000', message: "[${JOB_NAME}]: build ${currentBuild.result}, ${BUILD_URL}"
                 }
 
                 clusters.each { shutdownCluster(it) }

--- a/cloud/jenkins/pxc_operator_aks_version.groovy
+++ b/cloud/jenkins/pxc_operator_aks_version.groovy
@@ -410,7 +410,6 @@ EOF
             script {
                 if (currentBuild.result != null && currentBuild.result != 'SUCCESS') {
                     slackSend channel: '#cloud-dev-ci', color: '#FF0000', message: "[${JOB_NAME}]: build ${currentBuild.result}, ${BUILD_URL}"
-                    slackSend channel: '@${OWNER_SLACK}', color: '#FF0000', message: "[${JOB_NAME}]: build ${currentBuild.result}, ${BUILD_URL}"
                 }
 
                 clusters.each { shutdownCluster(it) }


### PR DESCRIPTION
Remove `@${OWNER_SLACK}` notification, because it gives this error (and is also redundant):

```
Slack Send Pipeline step running, values are - baseUrl: <empty>, teamDomain: percona, channel: @${OWNER_SLACK}, color: #FF0000, botUser: true, tokenCredentialId: 4b9ed281-7282-4684-b250-7a02e4dd6ebb, notifyCommitters: false, iconEmoji: <empty>, username: <empty>, timestamp: <empty>
22:40:00  ERROR: Slack notification failed with exception: {"ok":false,"error":"channel_not_found"}
22:40:00  ERROR: Slack notification failed. See Jenkins logs for details.
```