### PR TITLE
PMM-7 Fix rewind pipelines

### DIFF
--- a/pmm/pmm2-client-autobuild.groovy
+++ b/pmm/pmm2-client-autobuild.groovy
@@ -221,9 +221,8 @@ pipeline {
                 withCredentials([sshUserPrivateKey(credentialsId: 'repo.ci.percona.com', keyFileVariable: 'KEY_PATH', usernameVariable: 'USER')]) {
                     script {
                         sh '''
-                            PATH_TO_BUILD=$(cat uploadPath)
                             ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ${KEY_PATH} ${USER}@repo.ci.percona.com "
-                                scp -P 2222 -o ConnectTimeout=1 -o StrictHostKeyChecking=no ${PATH_TO_BUILD}/binary/tarball/*.tar.gz jenkins@jenkins-deploy.jenkins-deploy.web.r.int.percona.com:/data/downloads/TESTING/pmm/
+                                scp -P 2222 -o ConnectTimeout=1 -o StrictHostKeyChecking=no ${UPLOAD_PATH}/binary/tarball/*.tar.gz jenkins@jenkins-deploy.jenkins-deploy.web.r.int.percona.com:/data/downloads/TESTING/pmm/
                             "
                         '''
                     }  

--- a/pmm/pmm2-submodules-rewind.groovy
+++ b/pmm/pmm2-submodules-rewind.groovy
@@ -22,7 +22,7 @@ pipeline {
                         export GIT_SSH_COMMAND="/usr/bin/ssh -i ${SSHKEY} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
 
                         git clone --single-branch --branch "PMM-2.0" git@github.com:Percona-Lab/pmm-submodules .
-                        git submodule update --remote --init --recommend-shallow --jobs 10
+                        git submodule update --remote --init --jobs 10
                         git submodule status
                         git status --untracked-files=all --ignore-submodules=none
                     '''
@@ -39,18 +39,15 @@ pipeline {
         }
         stage('Commit') {
             steps {
-                sh '''
-                    git config user.email "noreply@percona.com"
-                    git config user.name "PMM Jenkins"
-
-                    git commit -a -m "chore: rewind submodules for dev-latest"
-                    git show
-                '''
-
                 withCredentials([sshUserPrivateKey(credentialsId: 'GitHub SSH Key', keyFileVariable: 'SSHKEY', passphraseVariable: '', usernameVariable: '')]) {
                     sh '''
                         export GIT_SSH_COMMAND="/usr/bin/ssh -i ${SSHKEY} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
                         git config --global push.default matching
+                        git config user.email "noreply@percona.com"
+                        git config user.name "PMM Jenkins"
+
+                        git commit -a -m "chore: rewind submodules for dev-latest"
+                        git show                        
                         git push
                     '''
                 }

--- a/pmm/pmm2-submodules.groovy
+++ b/pmm/pmm2-submodules.groovy
@@ -351,7 +351,7 @@ pipeline {
                                 -H "Accept: application/vnd.github.v3+json" \
                                 -H "Authorization: token ${GITHUB_API_TOKEN}" \
                                 "https://api.github.com/repos/\$(echo ${CHANGE_URL} | cut -d '/' -f 4-5)/actions/workflows/pmm-qa-fb-checks.yml/dispatches" \
-                                -d '{"ref":"${PMM_BRANCH}","inputs":{"server_image":"${IMAGE}","client_image":"${CLIENT_IMAGE}","sha":"${FB_COMMIT_HASH}", "pmm_qa_branch": "${PMM_QA_GIT_BRANCH}", "pmm_ui_branch": "${PMM_UI_TESTS_GIT_BRANCH}", "client_version": "${CLIENT_URL}"}}'
+                                -d '{"ref":"${PMM_BRANCH}","inputs":{"pmm_server_image":"${IMAGE}","pmm_client_image":"${CLIENT_IMAGE}","sha":"${FB_COMMIT_HASH}", "pmm_qa_branch": "${PMM_QA_GIT_BRANCH}", "pmm_ui_tests_branch": "${PMM_UI_TESTS_GIT_BRANCH}", "pmm_client_version": "${CLIENT_URL}"}}'
                         """
                     }
                 }

--- a/pmm/v3/pmm3-aws-staging-start.groovy
+++ b/pmm/v3/pmm3-aws-staging-start.groovy
@@ -353,7 +353,6 @@ pipeline {
                                 set -o xtrace
 
                                 docker exec --user root pmm-server yum update -y percona-release
-                                docker exec --user root pmm-server sed -i'' -e 's^/release/^/testing/^' /etc/yum.repos.d/${PMM_VERSION}-server.repo
                                 docker exec --user root pmm-server percona-release enable percona testing
                                 docker exec --user root pmm-server yum clean all
                             '''
@@ -374,7 +373,6 @@ pipeline {
                                 set -o errexit
                                 set -o xtrace
                                 docker exec --user root pmm-server yum update -y percona-release
-                                docker exec --user root pmm-server sed -i'' -e 's^/release/^/experimental/^' /etc/yum.repos.d/${PMM_VERSION}-server.repo
                                 docker exec --user root pmm-server percona-release enable percona experimental
                                 docker exec --user root pmm-server yum clean all
                             '''
@@ -390,10 +388,7 @@ pipeline {
                     setupPMMClient(SERVER_IP, CLIENT_VERSION.trim(), PMM_VERSION, ENABLE_PULL_MODE, ENABLE_TESTING_REPO, CLIENT_INSTANCE, 'aws-staging', ADMIN_PASSWORD)
 
                     script {
-                        env.PMM_REPO="experimental"
-                        if (env.CLIENT_VERSION == "pmm-rc") {
-                            env.PMM_REPO="testing"
-                        }
+                        env.PMM_REPO = params.CLIENT_VERSION == "pmm-rc" ? "testing" : "experimental"
                     }
 
                     sh '''

--- a/pmm/v3/pmm3-aws-staging-start.groovy
+++ b/pmm/v3/pmm3-aws-staging-start.groovy
@@ -3,7 +3,7 @@ import hudson.slaves.*
 import jenkins.model.Jenkins
 import hudson.plugins.sshslaves.SSHLauncher
 
-library changelog: false, identifier: 'lib@master', retriever: modernSCM([
+library changelog: false, identifier: 'lib@PMM-7-fix-rewind-pipelines', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/Percona-Lab/jenkins-pipelines.git'
 ]) _

--- a/pmm/v3/pmm3-aws-staging-start.groovy
+++ b/pmm/v3/pmm3-aws-staging-start.groovy
@@ -243,7 +243,7 @@ pipeline {
                         sudo yum repolist
 
                         sudo amazon-linux-extras enable epel
-                        sudo amazon-linux-extras enable php7.4
+                        sudo amazon-linux-extras enable php8.2
                         sudo yum --enablerepo epel install php -y
 
                         sudo yum install sysbench mysql-client -y
@@ -352,9 +352,7 @@ pipeline {
                                 set -o errexit
                                 set -o xtrace
 
-                                docker exec --user root pmm-server yum update -y percona-release
                                 docker exec --user root pmm-server percona-release enable percona testing
-                                docker exec --user root pmm-server yum clean all
                             '''
                         }
                     }
@@ -372,9 +370,7 @@ pipeline {
                             sh '''
                                 set -o errexit
                                 set -o xtrace
-                                docker exec --user root pmm-server yum update -y percona-release
                                 docker exec --user root pmm-server percona-release enable percona experimental
-                                docker exec --user root pmm-server yum clean all
                             '''
                         }
                     }

--- a/pmm/v3/pmm3-aws-staging-start.groovy
+++ b/pmm/v3/pmm3-aws-staging-start.groovy
@@ -3,7 +3,7 @@ import hudson.slaves.*
 import jenkins.model.Jenkins
 import hudson.plugins.sshslaves.SSHLauncher
 
-library changelog: false, identifier: 'lib@PMM-7-fix-rewind-pipelines', retriever: modernSCM([
+library changelog: false, identifier: 'lib@master', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/Percona-Lab/jenkins-pipelines.git'
 ]) _

--- a/pmm/v3/pmm3-submodules-rewind.groovy
+++ b/pmm/v3/pmm3-submodules-rewind.groovy
@@ -18,11 +18,10 @@ pipeline {
                 withCredentials([sshUserPrivateKey(credentialsId: 'GitHub SSH Key', keyFileVariable: 'SSHKEY', passphraseVariable: '', usernameVariable: '')]) {
                     sh '''
                         export GIT_SSH_COMMAND="/usr/bin/ssh -i ${SSHKEY} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+                        
                         # Clone 'v3' branch and update submodules
                         git clone --single-branch --branch v3 git@github.com:Percona-Lab/pmm-submodules .
-                        git reset --hard
-                        git clean -xdff
-                        git submodule update --remote --init --recommend-shallow --jobs 10
+                        git submodule update --remote --init --jobs 10
                         git submodule status
                         git status --untracked-files=all --ignore-submodules=none
                     '''

--- a/pmm/v3/pmm3-submodules.groovy
+++ b/pmm/v3/pmm3-submodules.groovy
@@ -94,6 +94,7 @@ pipeline {
                 }
                 script {
                     env.PMM_VERSION = sh(returnStdout: true, script: "cat VERSION").trim()
+                    env.GIT_COMMIT = sh(returnStdout: true, script: "cat fbCommitSha").trim()
                 }
                 stash includes: 'apiBranch', name: 'apiBranch'
                 stash includes: 'apiURL', name: 'apiURL'
@@ -121,9 +122,6 @@ pipeline {
         }
         stage('Build client binary') {
             steps {
-                script {
-                    env.GIT_COMMIT = sh(returnStdout: true, script: "cat fbCommitSha").trim()
-                }
                 withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AMI/OVF', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
                     sh '''
                         set -o errexit
@@ -241,6 +239,7 @@ pipeline {
                         unstash 'IMAGE'
                         unstash 'pmmQABranch'
                         unstash 'pmmUITestBranch'
+                        unstash 'fbCommitSha'
                         def IMAGE = sh(returnStdout: true, script: "cat results/docker/TAG").trim()
                         def CLIENT_IMAGE = sh(returnStdout: true, script: "cat results/docker/CLIENT_TAG").trim()
                         def FB_COMMIT_HASH = sh(returnStdout: true, script: "cat fbCommitSha").trim()

--- a/psmdb/jenkins/percona-server-for-mongodb-6.0.groovy
+++ b/psmdb/jenkins/percona-server-for-mongodb-6.0.groovy
@@ -326,6 +326,24 @@ pipeline {
                     }
                 }
 */
+                stage('Centos 8 binary tarball(glibc2.28)') {
+                    agent {
+                        label 'docker-64gb'
+                    }
+                    steps {
+                        cleanUpWS()
+                        popArtifactFolder("source_tarball/", AWS_STASH_PATH)
+                        script {
+                            if (env.FIPSMODE == 'yes') {
+                                buildStage("oraclelinux:8", "--build_tarball=1 --enable_fipsmode=1")
+                                pushArtifactFolder("tarball/", AWS_STASH_PATH)
+                                uploadTarballfromAWS("tarball/", AWS_STASH_PATH, 'binary')
+                            } else {
+                                echo "The step is skiped ..."
+                            }
+                        }
+                    }
+                }
                 stage('Oracle Linux 9 binary tarball(glibc2.34)') {
                     agent {
                         label 'docker-64gb'

--- a/vars/setupPMMClient.groovy
+++ b/vars/setupPMMClient.groovy
@@ -33,7 +33,7 @@ def call(String SERVER_IP, String CLIENT_VERSION, String PMM_VERSION, String ENA
                 sudo yum makecache
             fi
 
-            if [[ "$CLIENT_VERSION" =~ dev-latest|3-dev-latest ]]; then
+            if [[ "$CLIENT_VERSION" = dev-latest ]]; then
                 sudo percona-release enable-only original experimental
                 sudo yum -y install pmm2-client
             elif [[ "$CLIENT_VERSION" = pmm2-rc ]]; then
@@ -56,7 +56,9 @@ def call(String SERVER_IP, String CLIENT_VERSION, String PMM_VERSION, String ENA
                 fi
                 sleep 10
             else
-                if [[ "$CLIENT_VERSION" = http* ]]; then
+                if [[ "$CLIENT_VERSION" = 3-dev-latest ]]; then
+                    aws s3 cp --only-show-errors s3://pmm-build-cache/PR-BUILDS/pmm-client/pmm-client-latest.tar.gz pmm-client.tar.gz
+                elif [[ "$CLIENT_VERSION" = http* ]]; then
                     curl -o pmm-client.tar.gz "${CLIENT_VERSION}"
                 else
                     curl -o pmm-client.tar.gz "https://www.percona.com/downloads/pmm2/${CLIENT_VERSION}/binary/tarball/pmm2-client-${CLIENT_VERSION}.tar.gz"

--- a/vars/setupPMMClient.groovy
+++ b/vars/setupPMMClient.groovy
@@ -27,9 +27,11 @@ def call(String SERVER_IP, String CLIENT_VERSION, String PMM_VERSION, String ENA
             if [ "${PMM_VERSION}" = pmm2 ]; then
               echo exclude=mirror.es.its.nyu.edu | sudo tee -a /etc/yum/pluginconf.d/fastestmirror.conf
             fi
-            sudo yum -y install https://repo.percona.com/yum/percona-release-latest.noarch.rpm || true
-            sudo yum clean all
-            sudo yum makecache
+            if ! command -v percona-release > /dev/null; then
+                sudo yum -y install https://repo.percona.com/yum/percona-release-latest.noarch.rpm || true
+                sudo yum clean all
+                sudo yum makecache
+            fi
 
             if [[ "$CLIENT_VERSION" =~ dev-latest|3-dev-latest ]]; then
                 sudo percona-release enable-only original experimental

--- a/vars/setupPMMClient.groovy
+++ b/vars/setupPMMClient.groovy
@@ -33,7 +33,7 @@ def call(String SERVER_IP, String CLIENT_VERSION, String PMM_VERSION, String ENA
                 sudo yum makecache
             fi
 
-            if [[ "$CLIENT_VERSION" = dev-latest ]]; then
+            if [[ "$CLIENT_VERSION" =~ dev-latest|3-dev-latest ]]; then
                 sudo percona-release enable-only original experimental
                 sudo yum -y install pmm2-client
             elif [[ "$CLIENT_VERSION" = pmm2-rc ]]; then
@@ -56,9 +56,7 @@ def call(String SERVER_IP, String CLIENT_VERSION, String PMM_VERSION, String ENA
                 fi
                 sleep 10
             else
-                if [[ "$CLIENT_VERSION" = 3-dev-latest ]]; then
-                    aws s3 cp --only-show-errors s3://pmm-build-cache/PR-BUILDS/pmm-client/pmm-client-latest.tar.gz pmm-client.tar.gz
-                elif [[ "$CLIENT_VERSION" = http* ]]; then
+                if [[ "$CLIENT_VERSION" = http* ]]; then
                     curl -o pmm-client.tar.gz "${CLIENT_VERSION}"
                 else
                     curl -o pmm-client.tar.gz "https://www.percona.com/downloads/pmm2/${CLIENT_VERSION}/binary/tarball/pmm2-client-${CLIENT_VERSION}.tar.gz"


### PR DESCRIPTION
This PR fixes a couple of issues:
1/ bad upload_path was being passed to pmm2-client-autobuild
2/ rewind jobs cannot use `--recommend-shallow` for they don't allow to properly rewind the submodules' branches.