### PR TITLE
PMM-7 Fix git commit hash

### DIFF
--- a/pmm/pmm2-submodules.groovy
+++ b/pmm/pmm2-submodules.groovy
@@ -105,7 +105,7 @@ pipeline {
                 }
                 script {
                     env.PMM_VERSION = sh(returnStdout: true, script: "cat VERSION").trim()
-                    env.GIT_COMMIT = sh(returnStdout: true, script: "cat fbCommitSha").trim()
+                    env.FB_COMMIT = sh(returnStdout: true, script: "cat fbCommitSha").trim()
                 }
                 stash includes: 'apiBranch', name: 'apiBranch'
                 stash includes: 'apiURL', name: 'apiURL'
@@ -143,11 +143,11 @@ pipeline {
                         aws s3 cp \
                             --acl public-read \
                             results/tarball/pmm2-client-*.tar.gz \
-                            s3://pmm-build-cache/PR-BUILDS/pmm2-client/pmm2-client-${BRANCH_NAME}-${GIT_COMMIT:0:7}.tar.gz
+                            s3://pmm-build-cache/PR-BUILDS/pmm2-client/pmm2-client-${BRANCH_NAME}-${FB_COMMIT:0:7}.tar.gz
                     '''
                 }
                 script {
-                    def clientPackageURL = sh script:'echo "https://s3.us-east-2.amazonaws.com/pmm-build-cache/PR-BUILDS/pmm2-client/pmm2-client-${BRANCH_NAME}-${GIT_COMMIT:0:7}.tar.gz" | tee CLIENT_URL', returnStdout: true
+                    def clientPackageURL = sh script:'echo "https://s3.us-east-2.amazonaws.com/pmm-build-cache/PR-BUILDS/pmm2-client/pmm2-client-${BRANCH_NAME}-${FB_COMMIT:0:7}.tar.gz" | tee CLIENT_URL', returnStdout: true
                     env.CLIENT_URL = sh(returnStdout: true, script: "cat CLIENT_URL").trim()
                 }
                 stash includes: 'CLIENT_URL', name: 'CLIENT_URL'
@@ -228,7 +228,7 @@ pipeline {
                     sh '''
                         set -o errexit
                         export PUSH_DOCKER=1
-                        export DOCKER_CLIENT_TAG=perconalab/pmm-client-fb:${BRANCH_NAME}-${GIT_COMMIT:0:7}
+                        export DOCKER_CLIENT_TAG=perconalab/pmm-client-fb:${BRANCH_NAME}-${FB_COMMIT:0:7}
                         ${PATH_TO_SCRIPTS}/build-client-docker
                     '''
                 }
@@ -288,7 +288,7 @@ pipeline {
                     sh '''
                         set -o errexit
                         export PUSH_DOCKER=1
-                        export DOCKER_TAG=perconalab/pmm-server-fb:${BRANCH_NAME}-${GIT_COMMIT:0:7}
+                        export DOCKER_TAG=perconalab/pmm-server-fb:${BRANCH_NAME}-${FB_COMMIT:0:7}
                         ${PATH_TO_SCRIPTS}/build-server-docker
                     '''
                 }
@@ -311,7 +311,7 @@ pipeline {
                         set -o errexit
 
                         export PUSH_DOCKER=1
-                        export DOCKER_TAG=perconalab/pmm-server-fb:${BRANCH_NAME}-${GIT_COMMIT:0:7}
+                        export DOCKER_TAG=perconalab/pmm-server-fb:${BRANCH_NAME}-${FB_COMMIT:0:7}
 
                         export RPMBUILD_DOCKER_IMAGE=public.ecr.aws/e7j3v3n0/rpmbuild:ol9
                         export RPMBUILD_DIST="el9"

--- a/pmm/v3/pmm3-api-tests.groovy
+++ b/pmm/v3/pmm3-api-tests.groovy
@@ -29,11 +29,6 @@ pipeline {
             name: 'DOCKER_VERSION'
         )
         string(
-            defaultValue: '3-dev-latest',
-            description: 'PMM Client version',
-            name: 'CLIENT_VERSION'
-        )
-        string(
             defaultValue: 'percona:5.7',
             description: 'Percona Server Docker Container Image',
             name: 'MYSQL_IMAGE'

--- a/pmm/v3/pmm3-submodules.groovy
+++ b/pmm/v3/pmm3-submodules.groovy
@@ -377,7 +377,7 @@ pipeline {
                     env.API_TESTS_RESULT = apiTestJob.result
 
                     if (!env.API_TESTS_RESULT.equals("SUCCESS")) {
-                        sh "exit 1"
+                        error "API tests failed."
                     }
                 }
             }

--- a/pmm/v3/pmm3-submodules.groovy
+++ b/pmm/v3/pmm3-submodules.groovy
@@ -54,6 +54,7 @@ pipeline {
                 git poll: false,
                     branch: PMM_BRANCH,
                     url: 'http://github.com/Percona-Lab/pmm-submodules'
+
                 withCredentials([string(credentialsId: 'GITHUB_API_TOKEN', variable: 'GITHUB_API_TOKEN')]) {
                 sh '''
                     set -o errexit
@@ -94,7 +95,7 @@ pipeline {
                 }
                 script {
                     env.PMM_VERSION = sh(returnStdout: true, script: "cat VERSION").trim()
-                    env.GIT_COMMIT = sh(returnStdout: true, script: "cat fbCommitSha").trim()
+                    env.FB_COMMIT = sh(returnStdout: true, script: "cat fbCommitSha").trim()
                 }
                 stash includes: 'apiBranch', name: 'apiBranch'
                 stash includes: 'apiURL', name: 'apiURL'
@@ -132,11 +133,11 @@ pipeline {
                         aws s3 cp \
                             --acl public-read \
                             results/tarball/pmm-client-*.tar.gz \
-                            s3://pmm-build-cache/PR-BUILDS/pmm-client/pmm-client-${BRANCH_NAME}-${GIT_COMMIT:0:7}.tar.gz
+                            s3://pmm-build-cache/PR-BUILDS/pmm-client/pmm-client-${BRANCH_NAME}-${FB_COMMIT:0:7}.tar.gz
                     '''
                 }
                 script {
-                    sh (script: 'echo "https://s3.us-east-2.amazonaws.com/pmm-build-cache/PR-BUILDS/pmm-client/pmm-client-${BRANCH_NAME}-${GIT_COMMIT:0:7}.tar.gz" | tee CLIENT_URL')
+                    sh (script: 'echo "https://s3.us-east-2.amazonaws.com/pmm-build-cache/PR-BUILDS/pmm-client/pmm-client-${BRANCH_NAME}-${FB_COMMIT:0:7}.tar.gz" | tee CLIENT_URL')
                     env.CLIENT_URL = sh (script: "cat CLIENT_URL", returnStdout: true).trim()
                 }
             }
@@ -180,7 +181,7 @@ pipeline {
                     sh '''
                         set -o errexit
                         export PUSH_DOCKER=1
-                        export DOCKER_CLIENT_TAG=perconalab/pmm-client-fb:${BRANCH_NAME}-${GIT_COMMIT:0:7}
+                        export DOCKER_CLIENT_TAG=perconalab/pmm-client-fb:${BRANCH_NAME}-${FB_COMMIT:0:7}
                         ${PATH_TO_SCRIPTS}/build-client-docker
                     '''
                 }
@@ -219,7 +220,7 @@ pipeline {
                         set -o errexit
 
                         export PUSH_DOCKER=1
-                        export DOCKER_TAG=perconalab/pmm-server-fb:${BRANCH_NAME}-${GIT_COMMIT:0:7}
+                        export DOCKER_TAG=perconalab/pmm-server-fb:${BRANCH_NAME}-${FB_COMMIT:0:7}
 
                         export RPMBUILD_DOCKER_IMAGE=public.ecr.aws/e7j3v3n0/rpmbuild:3
                         export RPMBUILD_DIST=el9

--- a/pmm/v3/pmm3-submodules.groovy
+++ b/pmm/v3/pmm3-submodules.groovy
@@ -371,7 +371,6 @@ pipeline {
                         string(name: 'DOCKER_VERSION', value: IMAGE),
                         string(name: 'GIT_URL', value: API_TESTS_URL),
                         string(name: 'GIT_BRANCH', value: API_TESTS_BRANCH),
-                        string(name: 'OWNER', value: "FB"),
                         string(name: 'GIT_COMMIT_HASH', value: GIT_COMMIT_HASH)
                     ]
                     env.API_TESTS_URL = apiTestJob.absoluteUrl


### PR DESCRIPTION
This PR fixes the GIT_COMMIT hash, which currently does not change between subsequent pushes. The problem was due to the use of a standard variable, which was overwritten by Jenkins ([check envvars here](https://pmm.cd.percona.com/env-vars.html/)).