### PR TITLE
PXC-4386: PXC 8.2.0 refresh - Q4 2023 (Remove binlog_57_decryption suite

### DIFF
--- a/pxc/jenkins/suites-groups.sh
+++ b/pxc/jenkins/suites-groups.sh
@@ -24,7 +24,7 @@ function set_suites() {
   if [[ "$1" == "RelWithDebInfo" ]]; then
     echo "Setting WORKER_x_MTR_SUITES for BUILD_TYPE=RelWithDebInfo"
     # Unit tests will be executed by worker 1
-    WORKER_1_MTR_SUITES="innodb_undo,test_services,audit_null,service_sys_var_registration,connection_control,data_masking,binlog_57_decryption,service_udf_registration,service_status_var_registration,procfs,interactive_utilities,percona-pam-for-mysql"
+    WORKER_1_MTR_SUITES="innodb_undo,test_services,audit_null,service_sys_var_registration,connection_control,data_masking,service_udf_registration,service_status_var_registration,procfs,interactive_utilities,percona-pam-for-mysql"
     WORKER_2_MTR_SUITES="galera_nbo,galera_3nodes,galera_sr,galera_3nodes_nbo,galera_3nodes_sr,galera_encryption,galera-x,wsrep"
     WORKER_3_MTR_SUITES="engines/funcs,innodb"
     WORKER_4_MTR_SUITES="main,rpl"
@@ -35,7 +35,7 @@ function set_suites() {
   else # Debug (and everything different from "RelWithDebInfo")
     echo "Setting WORKER_x_MTR_SUITES for BUILD_TYPE=Debug"
     # Unit tests will be executed by worker 1
-    WORKER_1_MTR_SUITES="innodb_undo,test_services,audit_null,service_sys_var_registration,connection_control,data_masking,binlog_57_decryption,service_udf_registration,service_status_var_registration,procfs,interactive_utilities,percona-pam-for-mysql"
+    WORKER_1_MTR_SUITES="innodb_undo,test_services,audit_null,service_sys_var_registration,connection_control,data_masking,service_udf_registration,service_status_var_registration,procfs,interactive_utilities,percona-pam-for-mysql"
     WORKER_2_MTR_SUITES="galera_nbo,galera_3nodes,galera_sr,galera_3nodes_nbo,galera_3nodes_sr,galera_encryption,galera-x,wsrep"
     WORKER_3_MTR_SUITES="engines/funcs,innodb"
     WORKER_4_MTR_SUITES="main,rpl"


### PR DESCRIPTION
from checks)

https://perconadev.atlassian.net/browse/PXC-4386

***
binlog_57_decryption suite was specified in Jenkins scripts but it not present in PXC-8.2 MTR suites as it was removed by percona/percona-server@1ebd086a6.

***
Reference: https://pxc.cd.percona.com/view/8.0%20parallel%20MTR/job/pxc-8.0-pipeline-parallel-mtr-innovative/20/console