### PR TITLE
ENG-1235 Adds "--sanitize" to MTR arguments for ASAN runs

### DIFF
--- a/pxc/local/test-binary-pxc57
+++ b/pxc/local/test-binary-pxc57
@@ -73,7 +73,8 @@ if [[ $MTR_ARGS == *"--big-test"* ]] || [[ $MTR_ARGS == *"--only-big-test"* ]]; 
     TESTCASE_TIMEOUT=$((TESTCASE_TIMEOUT * 2))
 fi
 
-if [[ $WITH_ASAN == "YES" ]]; then
+WITH_ASAN=$(echo "${WITH_ASAN}" | tr '[:upper:]' '[:lower:]')
+if [[ $WITH_ASAN == "yes" ]]; then
     MTR_ARGS+=" --sanitize "
 fi
 


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/ENG-1235

Post-push fix. Fix string comparison for WITH_ASAN.