### PR TITLE
Bump go version to 1.21

### DIFF
--- a/proxysql/build-binary-proxysql
+++ b/proxysql/build-binary-proxysql
@@ -54,17 +54,17 @@ elif [ -f /usr/bin/apt ]; then
   fi
 fi
 
-# We need to use golang version > 1.16. Downloading golang from tarball to ensure each platform uses the same version.
-sudo wget https://dl.google.com/go/go1.17.7.linux-amd64.tar.gz
+# We need to use golang version >= 1.21. Downloading golang from tarball to ensure each platform uses the same version.
+sudo wget https://go.dev/dl/go1.21.9.linux-amd64.tar.gz
 
 # /usr/local is the default path included in the $PATH variable. Using any other custom installation path will not work
 # Example:
-# sudo tar -C /usr/local/bin -xzf go1.17.7.linux-amd64.tar.gz
+# sudo tar -C /usr/local/bin -xzf go1.21.9.linux-amd64.tar.gz
 # PATH=$PATH:/usr/local/bin
 #
 # The above method will not work. This is because the value of $PATH is not preserved/passed on to the child scipt from the parent script
 # Hence using the default $PATH that is available to every new session (both parent and child script)
-sudo tar -C /usr/local/ -xzf go1.17.7.linux-amd64.tar.gz
+sudo tar -C /usr/local/ -xzf go1.21.9.linux-amd64.tar.gz
 sudo cp /usr/local/go/bin/go /usr/local/bin/go
 if [ -f /usr/bin/yum ]; then
   RHEL=$(rpm --eval %rhel)


### PR DESCRIPTION
Bump the go version to 1.21 for building pxc_scheduler_handler for proxysql Jenkins.