### PR TITLE
Removing centos7 and Debian10 from list of ppg testing platforms as both will be EOL at end of this month.

### DIFF
--- a/vars/ppgOperatingSystems.groovy
+++ b/vars/ppgOperatingSystems.groovy
@@ -1,5 +1,5 @@
 def call() {
   // centos8 - centos8.3
   // rhel8 - rhel 8.0
-  return ['centos-7', 'ol-8', 'ol-9', 'debian-10', 'debian-11', 'debian-12', 'ubuntu-focal', 'ubuntu-jammy', 'ubuntu-noble']
+  return ['ol-8', 'ol-9', 'debian-11', 'debian-12', 'ubuntu-focal', 'ubuntu-jammy', 'ubuntu-noble']
 }


### PR DESCRIPTION
Removing centos7 and Debian10 from list of ppg testing platforms as both will be EOL at end of this month.