### PR TITLE
PMM-7 remove latest tags from v3 release

### DIFF
--- a/pmm/aws-staging-start.groovy
+++ b/pmm/aws-staging-start.groovy
@@ -237,7 +237,7 @@ pipeline {
                         sudo amazon-linux-extras enable php7.4
                         sudo yum --enablerepo epel install php -y
 
-                        sudo yum install sysbench mysql-client -y
+                        sudo yum install sysbench mysql -y
                         sudo mkdir -p /srv/pmm-qa || :
                         pushd /srv/pmm-qa
                             sudo git clone --single-branch --branch ${PMM_QA_GIT_BRANCH} https://github.com/percona/pmm-qa.git .

--- a/pmm/v3/pmm3-release.groovy
+++ b/pmm/v3/pmm3-release.groovy
@@ -239,16 +239,12 @@ ENDSSH
                                 done
                             fi
 
-                            #
                             cd \${RELEASEDIR}/..
-                            #
                             ln -s \${RELEASE} LATEST
-                            #
                             cd /srv/UPLOAD/${PATH_TO_CLIENT}/.tmp
 
                             rsync -avt -e "ssh -p 2222" --bwlimit=50000 --exclude="*yassl*" --progress \${PRODUCT} jenkins-deploy.jenkins-deploy.web.r.int.percona.com:/data/downloads/
 
-                            #
                             rm -fr /srv/UPLOAD/${PATH_TO_CLIENT}/.tmp
 ENDSSH
                 """
@@ -279,8 +275,6 @@ ENDSSH
                         set -ex
                         # push pmm-server el9
                         docker pull \${SERVER_IMAGE}
-                        docker tag \${SERVER_IMAGE} percona/pmm-server:latest
-                        docker push percona/pmm-server:latest
 
                         docker tag \${SERVER_IMAGE} percona/pmm-server:\${TOP_TAG}
                         docker tag \${SERVER_IMAGE} percona/pmm-server:\${MID_TAG}
@@ -300,8 +294,6 @@ ENDSSH
 
                         # push pmm-client
                         docker pull \${CLIENT_IMAGE}
-                        docker tag \${CLIENT_IMAGE} percona/pmm-client:latest
-                        docker push percona/pmm-client:latest
 
                         docker tag \${CLIENT_IMAGE} percona/pmm-client:\${TOP_TAG}
                         docker tag \${CLIENT_IMAGE} percona/pmm-client:\${MID_TAG}

--- a/pmm/v3/pmm3-release.groovy
+++ b/pmm/v3/pmm3-release.groovy
@@ -11,7 +11,6 @@ pipeline {
     environment {
         CLIENT_IMAGE     = "perconalab/pmm-client:${VERSION}-rc"
         SERVER_IMAGE     = "perconalab/pmm-server:${VERSION}-rc"
-        SERVER_IMAGE_EL7 = "perconalab/pmm-server:${VERSION}-rc-el7"
         PATH_TO_CLIENT   = "testing/pmm-client-autobuilds/pmm/${VERSION}/pmm-${VERSION}/${PATH_TO_CLIENT}"
     }
 
@@ -47,7 +46,7 @@ pipeline {
                                 cd /srv/UPLOAD/${PATH_TO_CLIENT}
 
                                 # getting the list of RH systems
-                                RHVERS=\$(ls -1 binary/redhat | grep -v 6)
+                                RHVERS=\$(ls -1 binary/redhat | grep -v 6 | grep -v 7)
 
                                 # source processing
                                 if [ -d source/redhat ]; then
@@ -273,7 +272,7 @@ ENDSSH
                     MID_TAG="\$TOP_TAG.\$MID_TAG"
                     sg docker -c "
                         set -ex
-                        # push pmm-server el9
+                        # push pmm-server
                         docker pull \${SERVER_IMAGE}
 
                         docker tag \${SERVER_IMAGE} percona/pmm-server:\${TOP_TAG}

--- a/pmm/v3/pmm3-submodules.groovy
+++ b/pmm/v3/pmm3-submodules.groovy
@@ -390,14 +390,17 @@ pipeline {
                     unstash 'IMAGE'
                     def IMAGE = sh(returnStdout: true, script: "cat results/docker/TAG").trim()
                     slackSend channel: '#pmm-ci', color: '#00FF00', message: "[${JOB_NAME}]: build finished, image: ${IMAGE}, URL: ${BUILD_URL}"
+                    if (env.API_TESTS_RESULT.equals("SUCCESS") && env.API_TESTS_URL) {
+                      addComment("API tests have succeded: ${API_TESTS_URL}")
+                    }
                 }
             }
         }
         always {
             script {
                 if (currentBuild.result != 'SUCCESS') {
-                    if (env.API_TESTS_RESULT != "SUCCESS" && env.API_TESTS_URL) {
-                        addComment("API tests have failed. Please check: ${API_TESTS_URL}")
+                    if (!env.API_TESTS_RESULT.equals("SUCCESS") && env.API_TESTS_URL) {
+                        addComment("API tests have failed: ${API_TESTS_URL}")
                     }
                     slackSend channel: '#pmm-ci', color: '#FF0000', message: "[${JOB_NAME}]: build ${currentBuild.result}, URL: ${BUILD_URL}"
                 }


### PR DESCRIPTION
Let's remove those commands asap since we have identified them as harmful, since they could overwrite the tags of product versions that have already been released.