### PR TITLE
Use proper sudo for CentOS 7

### DIFF
--- a/pxc/local/build-binary-pxc57
+++ b/pxc/local/build-binary-pxc57
@@ -131,6 +131,9 @@ fi
 # ------------------------------------------------------------------------------
 pushd ${SOURCEDIR}
     export SUDO=$(which sudo)
+    if [[ ${RHVER} -eq 7 ]]; then
+        SUDO="/usr/bin/sudo"
+    fi
     if [[ "${CMAKE_BUILD_TYPE}" = "Debug" ]]; then
         $SUDO -E bash -x ./build-ps/build-binary.sh -d ./target
     else


### PR DESCRIPTION
The sudo binary provided in devtoolset-7 is broken. So, the binary from /usr/bin is used instead.