### PR TITLE
PXB Jenkins fixes

### DIFF
--- a/pxb/v2/docker/run-test
+++ b/pxb/v2/docker/run-test
@@ -57,7 +57,8 @@ fi
 
 if [[ ${WITH_KMIP_TESTS} == "true" ]]; then
     check_pxb_network
-    docker run -d --security-opt seccomp=unconfined --cap-add=NET_ADMIN --rm -p 5696:5696 ${DOCKER_NETWORK_FLAG} --name kmip altmannmarcelo/kmip:latest
+    # The certificate expires on Sep 23 15:02:39 2025 GMT and then docker image should be rebuilt.
+    docker run -d --security-opt seccomp=unconfined --cap-add=NET_ADMIN --rm -p 5696:5696 ${DOCKER_NETWORK_FLAG} --name kmip satyapercona/kmip:latest
 
     docker cp kmip:/opt/certs/root_certificate.pem ${ROOT_DIR}
     docker cp kmip:/opt/certs/client_key_jane_doe.pem ${ROOT_DIR}

--- a/pxb/v2/jenkins/percona-xtrabackup-8.1-test-param.yml
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.1-test-param.yml
@@ -79,7 +79,7 @@
         type: user-defined
         values:
         - innodb80
-#        - xtradb80
+        - xtradb80
     builders:
     - trigger-builds:
       - project: percona-xtrabackup-8.1-test-pipeline


### PR DESCRIPTION
1. Fix pxb docker images to use satyapercona instead of marce's image.   
    kmip certificate expired and will again expire in an year.
2. Enable xtradb80, that is test pxb against Percona Server