### PR TITLE
K8SPSMDB-1136: implement file with images

### DIFF
--- a/cloud/jenkins/psmdb_operator_aks_latest.groovy
+++ b/cloud/jenkins/psmdb_operator_aks_latest.groovy
@@ -2,6 +2,27 @@ location='eastus'
 tests=[]
 clusters=[]
 
+void verifyParams() {
+    if ("$RELEASE_RUN" == "YES" && (!"$PILLAR_VERSION" && !"$IMAGE_MONGOD")){
+        error("This is RELEASE_RUN. Either PILLAR_VERSION or IMAGE_MONGOD should be provided")
+    }
+}
+
+void getImage(String IMAGE_NAME) {
+    versions_file="source/e2e-tests/release_images"
+    IMAGE = """${sh(
+        returnStdout: true,
+        script: "cat ${versions_file} | egrep \"${IMAGE_NAME}=\" | cut -d = -f 2 | tr -d \'\"\' "
+    ).trim()}"""
+    if ("$IMAGE") {
+        return "$IMAGE"
+    }
+    else{
+        error("Empty image is returned for $IMAGE_NAME. Check PILLAR_VERSION or content of file with images")
+
+    }
+}
+
 void prepareNode() {
     echo "=========================[ Installing tools on the Jenkins executor ]========================="
     sh """
@@ -28,10 +49,6 @@ void prepareNode() {
         """
     }
 
-    if ("$IMAGE_MONGOD") {
-        currentBuild.description = "$GIT_BRANCH-$PLATFORM_VER-CW_$CLUSTER_WIDE-" + "$IMAGE_MONGOD".split(":")[1]
-    }
-
     if ("$PLATFORM_VER" == "latest") {
         USED_PLATFORM_VER = sh(script: "az aks get-versions --location $location --output json | jq -r '.values | max_by(.patchVersions) | .patchVersions | keys[]' | sort --version-sort | tail -1", , returnStdout: true).trim()
     } else {
@@ -50,6 +67,51 @@ void prepareNode() {
         sudo rm -rf source
         cloud/local/checkout $GIT_REPO $GIT_BRANCH
     """
+
+    echo "=========================[ Assigning images for release test ]========================="
+    if ("$RELEASE_RUN" == "YES") {
+        if ("$OPERATOR_IMAGE") {
+            echo "OPERATOR_IMAGE was provided. Not doing anything"}
+        else{
+            echo "OPERATOR_IMAGE was NOT provided. Will use file params!"
+            OPERATOR_IMAGE = getImage("OPERATOR_IMAGE")
+            echo "OPERATOR_IMAGE is $OPERATOR_IMAGE "
+        }
+        if ("$IMAGE_MONGOD") {
+            echo "IMAGE_MONGOD was provided. Not doing anything"}
+        else{
+            echo "IMAGE_MONGOD was NOT provided. Will use file params!"
+            IMAGE_MONGOD = getImage("IMAGE_MONGOD${PILLAR_VERSION}")
+            echo "IMAGE_MONGOD is $IMAGE_MONGOD "
+        }
+        if ("$IMAGE_BACKUP") {
+            echo "IMAGE_BACKUP was provided. Not doing anything"}
+        else{
+            echo "IMAGE_BACKUP was NOT provided. Will use file params!"
+            IMAGE_BACKUP  =getImage("IMAGE_BACKUP")
+            echo "IMAGE_BACKUP is $IMAGE_BACKUP "
+        }
+        if ("$IMAGE_PMM_CLIENT") {
+            echo "IMAGE_PMM_CLIENT was provided. Not doing anything"}
+        else{
+            echo "IMAGE_PMM_CLIENT was NOT provided. Will use file params!"
+            IMAGE_PMM_CLIENT = getImage("IMAGE_PMM_CLIENT")
+            echo "IMAGE_PMM_CLIENT is $IMAGE_PMM_CLIENT "
+        }
+        if ("$IMAGE_PMM_SERVER") {
+            echo "IMAGE_PMM_SERVER was provided. Not doing anything"}
+        else{
+            echo "IMAGE_PMM_SERVER was NOT provided. Will use file params!"
+            IMAGE_PMM_SERVER = getImage("IMAGE_PMM_SERVER")
+            echo "IMAGE_PMM_SERVER is $IMAGE_PMM_SERVER "
+        }
+    } else {
+        echo "This is not release run. Using params only!"
+    }
+
+    if ("$IMAGE_MONGOD") {
+        currentBuild.description = "$GIT_BRANCH-$PLATFORM_VER-CW_$CLUSTER_WIDE-" + "$IMAGE_MONGOD".split(":")[1]
+    }
 
     script {
         GIT_SHORT_COMMIT = sh(script: 'git -C source rev-parse --short HEAD', , returnStdout: true).trim()
@@ -290,6 +352,16 @@ pipeline {
             description: 'Ignore passed tests in previous run (run all)',
             name: 'IGNORE_PREVIOUS_RUN'
         )
+        choice(
+            choices: 'YES\nNO',
+            description: 'Release run?',
+            name: 'RELEASE_RUN'
+        )
+        string(
+            defaultValue: '70',
+            description: 'For RELEASE_RUN only. Major version like 70,60, etc',
+            name: 'PILLAR_VERSION'
+        )
         string(
             defaultValue: 'main',
             description: 'Tag/Branch for percona/percona-server-mongodb-operator repository',
@@ -339,6 +411,7 @@ pipeline {
     stages {
         stage('Prepare node') {
             steps {
+                verifyParams()
                 prepareNode()
             }
         }

--- a/cloud/jenkins/psmdb_operator_aks_version.groovy
+++ b/cloud/jenkins/psmdb_operator_aks_version.groovy
@@ -2,6 +2,27 @@ location='eastus'
 tests=[]
 clusters=[]
 
+void verifyParams() {
+    if ("$RELEASE_RUN" == "YES" && (!"$PILLAR_VERSION" && !"$IMAGE_MONGOD")){
+        error("This is RELEASE_RUN. Either PILLAR_VERSION or IMAGE_MONGOD should be provided")
+    }
+}
+
+void getImage(String IMAGE_NAME) {
+    versions_file="source/e2e-tests/release_images"
+    IMAGE = """${sh(
+        returnStdout: true,
+        script: "cat ${versions_file} | egrep \"${IMAGE_NAME}=\" | cut -d = -f 2 | tr -d \'\"\' "
+    ).trim()}"""
+    if ("$IMAGE") {
+        return "$IMAGE"
+    }
+    else{
+        error("Empty image is returned for $IMAGE_NAME. Check PILLAR_VERSION or content of file with images")
+
+    }
+}
+
 void prepareNode() {
     echo "=========================[ Installing tools on the Jenkins executor ]========================="
     sh """
@@ -28,10 +49,6 @@ void prepareNode() {
         """
     }
 
-    if ("$IMAGE_MONGOD") {
-        currentBuild.description = "$GIT_BRANCH-$PLATFORM_VER-CW_$CLUSTER_WIDE-" + "$IMAGE_MONGOD".split(":")[1]
-    }
-
     if ("$PLATFORM_VER" == "latest") {
         USED_PLATFORM_VER = sh(script: "az aks get-versions --location $location --output json | jq -r '.values | max_by(.patchVersions) | .patchVersions | keys[]' | sort --version-sort | tail -1", , returnStdout: true).trim()
     } else {
@@ -50,6 +67,51 @@ void prepareNode() {
         sudo rm -rf source
         cloud/local/checkout $GIT_REPO $GIT_BRANCH
     """
+
+    echo "=========================[ Assigning images for release test ]========================="
+    if ("$RELEASE_RUN" == "YES") {
+        if ("$OPERATOR_IMAGE") {
+            echo "OPERATOR_IMAGE was provided. Not doing anything"}
+        else{
+            echo "OPERATOR_IMAGE was NOT provided. Will use file params!"
+            OPERATOR_IMAGE = getImage("OPERATOR_IMAGE")
+            echo "OPERATOR_IMAGE is $OPERATOR_IMAGE "
+        }
+        if ("$IMAGE_MONGOD") {
+            echo "IMAGE_MONGOD was provided. Not doing anything"}
+        else{
+            echo "IMAGE_MONGOD was NOT provided. Will use file params!"
+            IMAGE_MONGOD = getImage("IMAGE_MONGOD${PILLAR_VERSION}")
+            echo "IMAGE_MONGOD is $IMAGE_MONGOD "
+        }
+        if ("$IMAGE_BACKUP") {
+            echo "IMAGE_BACKUP was provided. Not doing anything"}
+        else{
+            echo "IMAGE_BACKUP was NOT provided. Will use file params!"
+            IMAGE_BACKUP  =getImage("IMAGE_BACKUP")
+            echo "IMAGE_BACKUP is $IMAGE_BACKUP "
+        }
+        if ("$IMAGE_PMM_CLIENT") {
+            echo "IMAGE_PMM_CLIENT was provided. Not doing anything"}
+        else{
+            echo "IMAGE_PMM_CLIENT was NOT provided. Will use file params!"
+            IMAGE_PMM_CLIENT = getImage("IMAGE_PMM_CLIENT")
+            echo "IMAGE_PMM_CLIENT is $IMAGE_PMM_CLIENT "
+        }
+        if ("$IMAGE_PMM_SERVER") {
+            echo "IMAGE_PMM_SERVER was provided. Not doing anything"}
+        else{
+            echo "IMAGE_PMM_SERVER was NOT provided. Will use file params!"
+            IMAGE_PMM_SERVER = getImage("IMAGE_PMM_SERVER")
+            echo "IMAGE_PMM_SERVER is $IMAGE_PMM_SERVER "
+        }
+    } else {
+        echo "This is not release run. Using params only!"
+    }
+
+    if ("$IMAGE_MONGOD") {
+        currentBuild.description = "$GIT_BRANCH-$PLATFORM_VER-CW_$CLUSTER_WIDE-" + "$IMAGE_MONGOD".split(":")[1]
+    }
 
     script {
         GIT_SHORT_COMMIT = sh(script: 'git -C source rev-parse --short HEAD', , returnStdout: true).trim()
@@ -290,6 +352,16 @@ pipeline {
             description: 'Ignore passed tests in previous run (run all)',
             name: 'IGNORE_PREVIOUS_RUN'
         )
+        choice(
+            choices: 'YES\nNO',
+            description: 'Release run?',
+            name: 'RELEASE_RUN'
+        )
+        string(
+            defaultValue: '70',
+            description: 'For RELEASE_RUN only. Major version like 70,60, etc',
+            name: 'PILLAR_VERSION'
+        )
         string(
             defaultValue: 'main',
             description: 'Tag/Branch for percona/percona-server-mongodb-operator repository',
@@ -339,6 +411,7 @@ pipeline {
     stages {
         stage('Prepare node') {
             steps {
+                verifyParams()
                 prepareNode()
             }
         }

--- a/cloud/jenkins/psmdb_operator_aws_openshift-4.groovy
+++ b/cloud/jenkins/psmdb_operator_aws_openshift-4.groovy
@@ -2,6 +2,27 @@ region='eu-west-3'
 tests=[]
 clusters=[]
 
+void verifyParams() {
+    if ("$RELEASE_RUN" == "YES" && (!"$PILLAR_VERSION" && !"$IMAGE_MONGOD")){
+        error("This is RELEASE_RUN. Either PILLAR_VERSION or IMAGE_MONGOD should be provided")
+    }
+}
+
+void getImage(String IMAGE_NAME) {
+    versions_file="source/e2e-tests/release_images"
+    IMAGE = """${sh(
+        returnStdout: true,
+        script: "cat ${versions_file} | egrep \"${IMAGE_NAME}=\" | cut -d = -f 2 | tr -d \'\"\' "
+    ).trim()}"""
+    if ("$IMAGE") {
+        return "$IMAGE"
+    }
+    else{
+        error("Empty image is returned for $IMAGE_NAME. Check PILLAR_VERSION or content of file with images")
+
+    }
+}
+
 void prepareNode() {
     echo "=========================[ Installing tools on the Jenkins executor ]========================="
     if ("$PLATFORM_VER" == "latest") {
@@ -27,10 +48,6 @@ void prepareNode() {
         sudo curl -fsSL https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux64 -o /usr/local/bin/jq && sudo chmod +x /usr/local/bin/jq
     """
 
-    if ("$IMAGE_MONGOD") {
-        currentBuild.description = "$GIT_BRANCH-$PLATFORM_VER-CW_$CLUSTER_WIDE-" + "$IMAGE_MONGOD".split(":")[1]
-    }
-
     echo "=========================[ Cloning the sources ]========================="
     git branch: 'master', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
     sh """
@@ -42,6 +59,50 @@ void prepareNode() {
         sudo rm -rf source
         cloud/local/checkout $GIT_REPO $GIT_BRANCH
     """
+    echo "=========================[ Assigning images for release test ]========================="
+    if ("$RELEASE_RUN" == "YES") {
+        if ("$OPERATOR_IMAGE") {
+            echo "OPERATOR_IMAGE was provided. Not doing anything"}
+        else{
+            echo "OPERATOR_IMAGE was NOT provided. Will use file params!"
+            OPERATOR_IMAGE = getImage("OPERATOR_IMAGE")
+            echo "OPERATOR_IMAGE is $OPERATOR_IMAGE "
+        }
+        if ("$IMAGE_MONGOD") {
+            echo "IMAGE_MONGOD was provided. Not doing anything"}
+        else{
+            echo "IMAGE_MONGOD was NOT provided. Will use file params!"
+            IMAGE_MONGOD = getImage("IMAGE_MONGOD${PILLAR_VERSION}")
+            echo "IMAGE_MONGOD is $IMAGE_MONGOD "
+        }
+        if ("$IMAGE_BACKUP") {
+            echo "IMAGE_BACKUP was provided. Not doing anything"}
+        else{
+            echo "IMAGE_BACKUP was NOT provided. Will use file params!"
+            IMAGE_BACKUP  =getImage("IMAGE_BACKUP")
+            echo "IMAGE_BACKUP is $IMAGE_BACKUP "
+        }
+        if ("$IMAGE_PMM_CLIENT") {
+            echo "IMAGE_PMM_CLIENT was provided. Not doing anything"}
+        else{
+            echo "IMAGE_PMM_CLIENT was NOT provided. Will use file params!"
+            IMAGE_PMM_CLIENT = getImage("IMAGE_PMM_CLIENT")
+            echo "IMAGE_PMM_CLIENT is $IMAGE_PMM_CLIENT "
+        }
+        if ("$IMAGE_PMM_SERVER") {
+            echo "IMAGE_PMM_SERVER was provided. Not doing anything"}
+        else{
+            echo "IMAGE_PMM_SERVER was NOT provided. Will use file params!"
+            IMAGE_PMM_SERVER = getImage("IMAGE_PMM_SERVER")
+            echo "IMAGE_PMM_SERVER is $IMAGE_PMM_SERVER "
+        }
+    } else {
+        echo "This is not release run. Using params only!"
+    }
+
+    if ("$IMAGE_MONGOD") {
+        currentBuild.description = "$GIT_BRANCH-$PLATFORM_VER-CW_$CLUSTER_WIDE-" + "$IMAGE_MONGOD".split(":")[1]
+    }
 
     script {
         GIT_SHORT_COMMIT = sh(script: 'git -C source rev-parse --short HEAD', , returnStdout: true).trim()
@@ -322,6 +383,16 @@ pipeline {
             description: 'Ignore passed tests in previous run (run all)',
             name: 'IGNORE_PREVIOUS_RUN'
         )
+        choice(
+            choices: 'YES\nNO',
+            description: 'Release run?',
+            name: 'RELEASE_RUN'
+        )
+        string(
+            defaultValue: '70',
+            description: 'For RELEASE_RUN only. Major version like 70,60, etc',
+            name: 'PILLAR_VERSION'
+        )
         string(
             defaultValue: 'main',
             description: 'Tag/Branch for percona/percona-server-mongodb-operator repository',
@@ -371,6 +442,7 @@ pipeline {
     stages {
         stage('Prepare node') {
             steps {
+                verifyParams()
                 prepareNode()
             }
         }

--- a/cloud/jenkins/psmdb_operator_aws_openshift_latest.groovy
+++ b/cloud/jenkins/psmdb_operator_aws_openshift_latest.groovy
@@ -2,6 +2,27 @@ region='eu-west-3'
 tests=[]
 clusters=[]
 
+void verifyParams() {
+    if ("$RELEASE_RUN" == "YES" && (!"$PILLAR_VERSION" && !"$IMAGE_MONGOD")){
+        error("This is RELEASE_RUN. Either PILLAR_VERSION or IMAGE_MONGOD should be provided")
+    }
+}
+
+void getImage(String IMAGE_NAME) {
+    versions_file="source/e2e-tests/release_images"
+    IMAGE = """${sh(
+        returnStdout: true,
+        script: "cat ${versions_file} | egrep \"${IMAGE_NAME}=\" | cut -d = -f 2 | tr -d \'\"\' "
+    ).trim()}"""
+    if ("$IMAGE") {
+        return "$IMAGE"
+    }
+    else{
+        error("Empty image is returned for $IMAGE_NAME. Check PILLAR_VERSION or content of file with images")
+
+    }
+}
+
 void prepareNode() {
     echo "=========================[ Installing tools on the Jenkins executor ]========================="
     if ("$PLATFORM_VER" == "latest") {
@@ -27,10 +48,6 @@ void prepareNode() {
         sudo curl -fsSL https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux64 -o /usr/local/bin/jq && sudo chmod +x /usr/local/bin/jq
     """
 
-    if ("$IMAGE_MONGOD") {
-        currentBuild.description = "$GIT_BRANCH-$PLATFORM_VER-CW_$CLUSTER_WIDE-" + "$IMAGE_MONGOD".split(":")[1]
-    }
-
     echo "=========================[ Cloning the sources ]========================="
     git branch: 'master', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
     sh """
@@ -42,6 +59,51 @@ void prepareNode() {
         sudo rm -rf source
         cloud/local/checkout $GIT_REPO $GIT_BRANCH
     """
+
+    echo "=========================[ Assigning images for release test ]========================="
+    if ("$RELEASE_RUN" == "YES") {
+        if ("$OPERATOR_IMAGE") {
+            echo "OPERATOR_IMAGE was provided. Not doing anything"}
+        else{
+            echo "OPERATOR_IMAGE was NOT provided. Will use file params!"
+            OPERATOR_IMAGE = getImage("OPERATOR_IMAGE")
+            echo "OPERATOR_IMAGE is $OPERATOR_IMAGE "
+        }
+        if ("$IMAGE_MONGOD") {
+            echo "IMAGE_MONGOD was provided. Not doing anything"}
+        else{
+            echo "IMAGE_MONGOD was NOT provided. Will use file params!"
+            IMAGE_MONGOD = getImage("IMAGE_MONGOD${PILLAR_VERSION}")
+            echo "IMAGE_MONGOD is $IMAGE_MONGOD "
+        }
+        if ("$IMAGE_BACKUP") {
+            echo "IMAGE_BACKUP was provided. Not doing anything"}
+        else{
+            echo "IMAGE_BACKUP was NOT provided. Will use file params!"
+            IMAGE_BACKUP  =getImage("IMAGE_BACKUP")
+            echo "IMAGE_BACKUP is $IMAGE_BACKUP "
+        }
+        if ("$IMAGE_PMM_CLIENT") {
+            echo "IMAGE_PMM_CLIENT was provided. Not doing anything"}
+        else{
+            echo "IMAGE_PMM_CLIENT was NOT provided. Will use file params!"
+            IMAGE_PMM_CLIENT = getImage("IMAGE_PMM_CLIENT")
+            echo "IMAGE_PMM_CLIENT is $IMAGE_PMM_CLIENT "
+        }
+        if ("$IMAGE_PMM_SERVER") {
+            echo "IMAGE_PMM_SERVER was provided. Not doing anything"}
+        else{
+            echo "IMAGE_PMM_SERVER was NOT provided. Will use file params!"
+            IMAGE_PMM_SERVER = getImage("IMAGE_PMM_SERVER")
+            echo "IMAGE_PMM_SERVER is $IMAGE_PMM_SERVER "
+        }
+    } else {
+        echo "This is not release run. Using params only!"
+    }
+
+    if ("$IMAGE_MONGOD") {
+        currentBuild.description = "$GIT_BRANCH-$PLATFORM_VER-CW_$CLUSTER_WIDE-" + "$IMAGE_MONGOD".split(":")[1]
+    }
 
     script {
         GIT_SHORT_COMMIT = sh(script: 'git -C source rev-parse --short HEAD', , returnStdout: true).trim()
@@ -322,6 +384,16 @@ pipeline {
             description: 'Ignore passed tests in previous run (run all)',
             name: 'IGNORE_PREVIOUS_RUN'
         )
+        choice(
+            choices: 'YES\nNO',
+            description: 'Release run?',
+            name: 'RELEASE_RUN'
+        )
+        string(
+            defaultValue: '70',
+            description: 'For RELEASE_RUN only. Major version like 70,60, etc',
+            name: 'PILLAR_VERSION'
+        )
         string(
             defaultValue: 'main',
             description: 'Tag/Branch for percona/percona-server-mongodb-operator repository',
@@ -371,6 +443,7 @@ pipeline {
     stages {
         stage('Prepare node') {
             steps {
+                verifyParams()
                 prepareNode()
             }
         }

--- a/cloud/jenkins/psmdb_operator_eks_latest.groovy
+++ b/cloud/jenkins/psmdb_operator_eks_latest.groovy
@@ -2,6 +2,27 @@ region='eu-west-3'
 tests=[]
 clusters=[]
 
+void verifyParams() {
+    if ("$RELEASE_RUN" == "YES" && (!"$PILLAR_VERSION" && !"$IMAGE_MONGOD")){
+        error("This is RELEASE_RUN. Either PILLAR_VERSION or IMAGE_MONGOD should be provided")
+    }
+}
+
+void getImage(String IMAGE_NAME) {
+    versions_file="source/e2e-tests/release_images"
+    IMAGE = """${sh(
+        returnStdout: true,
+        script: "cat ${versions_file} | egrep \"${IMAGE_NAME}=\" | cut -d = -f 2 | tr -d \'\"\' "
+    ).trim()}"""
+    if ("$IMAGE") {
+        return "$IMAGE"
+    }
+    else{
+        error("Empty image is returned for $IMAGE_NAME. Check PILLAR_VERSION or content of file with images")
+
+    }
+}
+
 void prepareNode() {
     echo "=========================[ Installing tools on the Jenkins executor ]========================="
     sh """
@@ -15,10 +36,6 @@ void prepareNode() {
 
         curl -sL https://github.com/eksctl-io/eksctl/releases/latest/download/eksctl_\$(uname -s)_amd64.tar.gz | sudo tar -C /usr/local/bin -xzf - && sudo chmod +x /usr/local/bin/eksctl
     """
-
-    if ("$IMAGE_MONGOD") {
-        currentBuild.description = "$GIT_BRANCH-$PLATFORM_VER-CW_$CLUSTER_WIDE-" + "$IMAGE_MONGOD".split(":")[1]
-    }
 
     if ("$PLATFORM_VER" == "latest") {
         USED_PLATFORM_VER = sh(script: "eksctl version -ojson | jq -r '.EKSServerSupportedVersions | max'", , returnStdout: true).trim()
@@ -38,6 +55,51 @@ void prepareNode() {
         sudo rm -rf source
         cloud/local/checkout $GIT_REPO $GIT_BRANCH
     """
+
+    echo "=========================[ Assigning images for release test ]========================="
+    if ("$RELEASE_RUN" == "YES") {
+        if ("$OPERATOR_IMAGE") {
+            echo "OPERATOR_IMAGE was provided. Not doing anything"}
+        else{
+            echo "OPERATOR_IMAGE was NOT provided. Will use file params!"
+            OPERATOR_IMAGE = getImage("OPERATOR_IMAGE")
+            echo "OPERATOR_IMAGE is $OPERATOR_IMAGE "
+        }
+        if ("$IMAGE_MONGOD") {
+            echo "IMAGE_MONGOD was provided. Not doing anything"}
+        else{
+            echo "IMAGE_MONGOD was NOT provided. Will use file params!"
+            IMAGE_MONGOD = getImage("IMAGE_MONGOD${PILLAR_VERSION}")
+            echo "IMAGE_MONGOD is $IMAGE_MONGOD "
+        }
+        if ("$IMAGE_BACKUP") {
+            echo "IMAGE_BACKUP was provided. Not doing anything"}
+        else{
+            echo "IMAGE_BACKUP was NOT provided. Will use file params!"
+            IMAGE_BACKUP  =getImage("IMAGE_BACKUP")
+            echo "IMAGE_BACKUP is $IMAGE_BACKUP "
+        }
+        if ("$IMAGE_PMM_CLIENT") {
+            echo "IMAGE_PMM_CLIENT was provided. Not doing anything"}
+        else{
+            echo "IMAGE_PMM_CLIENT was NOT provided. Will use file params!"
+            IMAGE_PMM_CLIENT = getImage("IMAGE_PMM_CLIENT")
+            echo "IMAGE_PMM_CLIENT is $IMAGE_PMM_CLIENT "
+        }
+        if ("$IMAGE_PMM_SERVER") {
+            echo "IMAGE_PMM_SERVER was provided. Not doing anything"}
+        else{
+            echo "IMAGE_PMM_SERVER was NOT provided. Will use file params!"
+            IMAGE_PMM_SERVER = getImage("IMAGE_PMM_SERVER")
+            echo "IMAGE_PMM_SERVER is $IMAGE_PMM_SERVER "
+        }
+    } else {
+        echo "This is not release run. Using params only!"
+    }
+
+    if ("$IMAGE_MONGOD") {
+        currentBuild.description = "$GIT_BRANCH-$PLATFORM_VER-CW_$CLUSTER_WIDE-" + "$IMAGE_MONGOD".split(":")[1]
+    }
 
     script {
         GIT_SHORT_COMMIT = sh(script: 'git -C source rev-parse --short HEAD', , returnStdout: true).trim()
@@ -341,6 +403,16 @@ pipeline {
             description: 'Ignore passed tests in previous run (run all)',
             name: 'IGNORE_PREVIOUS_RUN'
         )
+        choice(
+            choices: 'YES\nNO',
+            description: 'Release run?',
+            name: 'RELEASE_RUN'
+        )
+        string(
+            defaultValue: '70',
+            description: 'For RELEASE_RUN only. Major version like 70,60, etc',
+            name: 'PILLAR_VERSION'
+        )
         string(
             defaultValue: 'main',
             description: 'Tag/Branch for percona/percona-server-mongodb-operator repository',
@@ -390,6 +462,7 @@ pipeline {
     stages {
         stage('Prepare node') {
             steps {
+                verifyParams()
                 prepareNode()
             }
         }

--- a/cloud/jenkins/psmdb_operator_eks_version.groovy
+++ b/cloud/jenkins/psmdb_operator_eks_version.groovy
@@ -2,6 +2,27 @@ region='eu-west-3'
 tests=[]
 clusters=[]
 
+void verifyParams() {
+    if ("$RELEASE_RUN" == "YES" && (!"$PILLAR_VERSION" && !"$IMAGE_MONGOD")){
+        error("This is RELEASE_RUN. Either PILLAR_VERSION or IMAGE_MONGOD should be provided")
+    }
+}
+
+void getImage(String IMAGE_NAME) {
+    versions_file="source/e2e-tests/release_images"
+    IMAGE = """${sh(
+        returnStdout: true,
+        script: "cat ${versions_file} | egrep \"${IMAGE_NAME}=\" | cut -d = -f 2 | tr -d \'\"\' "
+    ).trim()}"""
+    if ("$IMAGE") {
+        return "$IMAGE"
+    }
+    else{
+        error("Empty image is returned for $IMAGE_NAME. Check PILLAR_VERSION or content of file with images")
+
+    }
+}
+
 void prepareNode() {
     echo "=========================[ Installing tools on the Jenkins executor ]========================="
     sh """
@@ -15,10 +36,6 @@ void prepareNode() {
 
         curl -sL https://github.com/eksctl-io/eksctl/releases/latest/download/eksctl_\$(uname -s)_amd64.tar.gz | sudo tar -C /usr/local/bin -xzf - && sudo chmod +x /usr/local/bin/eksctl
     """
-
-    if ("$IMAGE_MONGOD") {
-        currentBuild.description = "$GIT_BRANCH-$PLATFORM_VER-CW_$CLUSTER_WIDE-" + "$IMAGE_MONGOD".split(":")[1]
-    }
 
     if ("$PLATFORM_VER" == "latest") {
         USED_PLATFORM_VER = sh(script: "eksctl version -ojson | jq -r '.EKSServerSupportedVersions | max'", , returnStdout: true).trim()
@@ -38,6 +55,50 @@ void prepareNode() {
         sudo rm -rf source
         cloud/local/checkout $GIT_REPO $GIT_BRANCH
     """
+    echo "=========================[ Assigning images for release test ]========================="
+    if ("$RELEASE_RUN" == "YES") {
+        if ("$OPERATOR_IMAGE") {
+            echo "OPERATOR_IMAGE was provided. Not doing anything"}
+        else{
+            echo "OPERATOR_IMAGE was NOT provided. Will use file params!"
+            OPERATOR_IMAGE = getImage("OPERATOR_IMAGE")
+            echo "OPERATOR_IMAGE is $OPERATOR_IMAGE "
+        }
+        if ("$IMAGE_MONGOD") {
+            echo "IMAGE_MONGOD was provided. Not doing anything"}
+        else{
+            echo "IMAGE_MONGOD was NOT provided. Will use file params!"
+            IMAGE_MONGOD = getImage("IMAGE_MONGOD${PILLAR_VERSION}")
+            echo "IMAGE_MONGOD is $IMAGE_MONGOD "
+        }
+        if ("$IMAGE_BACKUP") {
+            echo "IMAGE_BACKUP was provided. Not doing anything"}
+        else{
+            echo "IMAGE_BACKUP was NOT provided. Will use file params!"
+            IMAGE_BACKUP  =getImage("IMAGE_BACKUP")
+            echo "IMAGE_BACKUP is $IMAGE_BACKUP "
+        }
+        if ("$IMAGE_PMM_CLIENT") {
+            echo "IMAGE_PMM_CLIENT was provided. Not doing anything"}
+        else{
+            echo "IMAGE_PMM_CLIENT was NOT provided. Will use file params!"
+            IMAGE_PMM_CLIENT = getImage("IMAGE_PMM_CLIENT")
+            echo "IMAGE_PMM_CLIENT is $IMAGE_PMM_CLIENT "
+        }
+        if ("$IMAGE_PMM_SERVER") {
+            echo "IMAGE_PMM_SERVER was provided. Not doing anything"}
+        else{
+            echo "IMAGE_PMM_SERVER was NOT provided. Will use file params!"
+            IMAGE_PMM_SERVER = getImage("IMAGE_PMM_SERVER")
+            echo "IMAGE_PMM_SERVER is $IMAGE_PMM_SERVER "
+        }
+    } else {
+        echo "This is not release run. Using params only!"
+    }
+
+    if ("$IMAGE_MONGOD") {
+        currentBuild.description = "$GIT_BRANCH-$PLATFORM_VER-CW_$CLUSTER_WIDE-" + "$IMAGE_MONGOD".split(":")[1]
+    }
 
     script {
         GIT_SHORT_COMMIT = sh(script: 'git -C source rev-parse --short HEAD', , returnStdout: true).trim()
@@ -343,6 +404,16 @@ pipeline {
             description: 'Ignore passed tests in previous run (run all)',
             name: 'IGNORE_PREVIOUS_RUN'
         )
+        choice(
+            choices: 'YES\nNO',
+            description: 'Release run?',
+            name: 'RELEASE_RUN'
+        )
+        string(
+            defaultValue: '70',
+            description: 'For RELEASE_RUN only. Major version like 70,60, etc',
+            name: 'PILLAR_VERSION'
+        )
         string(
             defaultValue: 'main',
             description: 'Tag/Branch for percona/percona-server-mongodb-operator repository',
@@ -392,6 +463,7 @@ pipeline {
     stages {
         stage('Prepare node') {
             steps {
+                verifyParams()
                 prepareNode()
             }
         }

--- a/cloud/jenkins/psmdb_operator_gke_latest.groovy
+++ b/cloud/jenkins/psmdb_operator_gke_latest.groovy
@@ -2,6 +2,28 @@ region='us-central1-a'
 tests=[]
 clusters=[]
 
+
+void verifyParams() {
+    if ("$RELEASE_RUN" == "YES" && (!"$PILLAR_VERSION" && !"$IMAGE_MONGOD")){
+        error("This is RELEASE_RUN. Either PILLAR_VERSION or IMAGE_MONGOD should be provided")
+    }
+}
+
+void getImage(String IMAGE_NAME) {
+    versions_file="source/e2e-tests/release_images"
+    IMAGE = """${sh(
+        returnStdout: true,
+        script: "cat ${versions_file} | egrep \"${IMAGE_NAME}=\" | cut -d = -f 2 | tr -d \'\"\' "
+    ).trim()}"""
+    if ("$IMAGE") {
+        return "$IMAGE"
+    }
+    else{
+        error("Empty image is returned for $IMAGE_NAME. Check PILLAR_VERSION or content of file with images")
+
+    }
+}
+
 void prepareNode() {
     echo "=========================[ Installing tools on the Jenkins executor ]========================="
     sh """
@@ -34,7 +56,7 @@ EOF
     }
 
     if ("$IMAGE_MONGOD") {
-        currentBuild.description = "$GIT_BRANCH-$PLATFORM_VER-CW_$CLUSTER_WIDE-" + "$IMAGE_MONGOD".split(":")[1]
+        currentBuild.description = "$GIT_BRANCH-$PLATFORM_VER-CHANNEL-$GKE_RELEASE_CHANNEL-CW_$CLUSTER_WIDE-" + "$IMAGE_MONGOD".split(":")[1]
     }
 
     if ("$PLATFORM_VER" == "latest") {
@@ -56,10 +78,55 @@ EOF
         cloud/local/checkout $GIT_REPO $GIT_BRANCH
     """
 
+    echo "=========================[ Assigning images for release test ]========================="
+    if ("$RELEASE_RUN" == "YES") {
+        if ("$OPERATOR_IMAGE") {
+            echo "OPERATOR_IMAGE was provided. Not doing anything"}
+        else{
+            echo "OPERATOR_IMAGE was NOT provided. Will use file params!"
+            OPERATOR_IMAGE = getImage("OPERATOR_IMAGE")
+            echo "OPERATOR_IMAGE is $OPERATOR_IMAGE "
+        }
+        if ("$IMAGE_MONGOD") {
+            echo "IMAGE_MONGOD was provided. Not doing anything"}
+        else{
+            echo "IMAGE_MONGOD was NOT provided. Will use file params!"
+            IMAGE_MONGOD = getImage("IMAGE_MONGOD${PILLAR_VERSION}")
+            echo "IMAGE_MONGOD is $IMAGE_MONGOD "
+        }
+        if ("$IMAGE_BACKUP") {
+            echo "IMAGE_BACKUP was provided. Not doing anything"}
+        else{
+            echo "IMAGE_BACKUP was NOT provided. Will use file params!"
+            IMAGE_BACKUP  =getImage("IMAGE_BACKUP")
+            echo "IMAGE_BACKUP is $IMAGE_BACKUP "
+        }
+        if ("$IMAGE_PMM_CLIENT") {
+            echo "IMAGE_PMM_CLIENT was provided. Not doing anything"}
+        else{
+            echo "IMAGE_PMM_CLIENT was NOT provided. Will use file params!"
+            IMAGE_PMM_CLIENT = getImage("IMAGE_PMM_CLIENT")
+            echo "IMAGE_PMM_CLIENT is $IMAGE_PMM_CLIENT "
+        }
+        if ("$IMAGE_PMM_SERVER") {
+            echo "IMAGE_PMM_SERVER was provided. Not doing anything"}
+        else{
+            echo "IMAGE_PMM_SERVER was NOT provided. Will use file params!"
+            IMAGE_PMM_SERVER = getImage("IMAGE_PMM_SERVER")
+            echo "IMAGE_PMM_SERVER is $IMAGE_PMM_SERVER "
+        }
+    } else {
+        echo "This is not release run. Using params only!"
+    }
+
+    if ("$IMAGE_MONGOD") {
+        currentBuild.description = "$GIT_BRANCH-$PLATFORM_VER-CW_$CLUSTER_WIDE-" + "$IMAGE_MONGOD".split(":")[1]
+    }
+
     script {
         GIT_SHORT_COMMIT = sh(script: 'git -C source rev-parse --short HEAD', , returnStdout: true).trim()
         CLUSTER_NAME = sh(script: "echo jenkins-lat-psmdb-$GIT_SHORT_COMMIT | tr '[:upper:]' '[:lower:]'", , returnStdout: true).trim()
-        PARAMS_HASH = sh(script: "echo $GIT_BRANCH-$GIT_SHORT_COMMIT-$USED_PLATFORM_VER-$CLUSTER_WIDE-$OPERATOR_IMAGE-$IMAGE_MONGOD-$IMAGE_BACKUP-$IMAGE_PMM_CLIENT-$IMAGE_PMM_SERVER | md5sum | cut -d' ' -f1", , returnStdout: true).trim()
+        PARAMS_HASH = sh(script: "echo $GIT_BRANCH-$GIT_SHORT_COMMIT-$GKE_RELEASE_CHANNEL-$USED_PLATFORM_VER-$CLUSTER_WIDE-$OPERATOR_IMAGE-$IMAGE_MONGOD-$IMAGE_BACKUP-$IMAGE_PMM_CLIENT-$IMAGE_PMM_SERVER | md5sum | cut -d' ' -f1", , returnStdout: true).trim()
     }
 }
 
@@ -167,7 +234,7 @@ void createCluster(String CLUSTER_SUFFIX) {
             exitCode=1
             while [[ \$exitCode != 0 && \$maxRetries > 0 ]]; do
                 gcloud container clusters create $CLUSTER_NAME-$CLUSTER_SUFFIX \
-                    --release-channel rapid \
+                    --release-channel $GKE_RELEASE_CHANNEL \
                     --zone $region \
                     --cluster-version $USED_PLATFORM_VER \
                     --preemptible \
@@ -304,6 +371,16 @@ pipeline {
             description: 'Ignore passed tests in previous run (run all)',
             name: 'IGNORE_PREVIOUS_RUN'
         )
+        choice(
+            choices: 'YES\nNO',
+            description: 'Release run?',
+            name: 'RELEASE_RUN'
+        )
+        string(
+            defaultValue: '70',
+            description: 'For RELEASE_RUN only. Major version like 70,60, etc',
+            name: 'PILLAR_VERSION'
+        )
         string(
             defaultValue: 'main',
             description: 'Tag/Branch for percona/percona-server-mongodb-operator repository',
@@ -316,6 +393,10 @@ pipeline {
             defaultValue: 'latest',
             description: 'GKE kubernetes version',
             name: 'PLATFORM_VER')
+        choice(
+            choices: 'rapid\nstable\nregular',
+            description: 'GKE release channel',
+            name: 'GKE_RELEASE_CHANNEL')
         choice(
             choices: 'YES\nNO',
             description: 'Run tests in cluster wide mode',
@@ -353,6 +434,7 @@ pipeline {
     stages {
         stage('Prepare node') {
             steps {
+                verifyParams()
                 prepareNode()
             }
         }

--- a/cloud/jenkins/psmdb_operator_gke_version.groovy
+++ b/cloud/jenkins/psmdb_operator_gke_version.groovy
@@ -2,6 +2,27 @@ region='us-central1-a'
 tests=[]
 clusters=[]
 
+void verifyParams() {
+    if ("$RELEASE_RUN" == "YES" && (!"$PILLAR_VERSION" && !"$IMAGE_MONGOD")){
+        error("This is RELEASE_RUN. Either PILLAR_VERSION or IMAGE_MONGOD should be provided")
+    }
+}
+
+void getImage(String IMAGE_NAME) {
+    versions_file="source/e2e-tests/release_images"
+    IMAGE = """${sh(
+        returnStdout: true,
+        script: "cat ${versions_file} | egrep \"${IMAGE_NAME}=\" | cut -d = -f 2 | tr -d \'\"\' "
+    ).trim()}"""
+    if ("$IMAGE") {
+        return "$IMAGE"
+    }
+    else{
+        error("Empty image is returned for $IMAGE_NAME. Check PILLAR_VERSION or content of file with images")
+
+    }
+}
+
 void prepareNode() {
     echo "=========================[ Installing tools on the Jenkins executor ]========================="
     sh """
@@ -33,10 +54,6 @@ EOF
         """
     }
 
-    if ("$IMAGE_MONGOD") {
-        currentBuild.description = "$GIT_BRANCH-$PLATFORM_VER-CW_$CLUSTER_WIDE-" + "$IMAGE_MONGOD".split(":")[1]
-    }
-
     if ("$PLATFORM_VER" == "latest") {
         USED_PLATFORM_VER = sh(script: "gcloud container get-server-config --region=$region --flatten=channels --filter='channels.channel=RAPID' --format='value(channels.defaultVersion)' | cut -d- -f1", , returnStdout: true).trim()
     } else {
@@ -55,6 +72,50 @@ EOF
         sudo rm -rf source
         cloud/local/checkout $GIT_REPO $GIT_BRANCH
     """
+    echo "=========================[ Assigning images for release test ]========================="
+    if ("$RELEASE_RUN" == "YES") {
+        if ("$OPERATOR_IMAGE") {
+            echo "OPERATOR_IMAGE was provided. Not doing anything"}
+        else{
+            echo "OPERATOR_IMAGE was NOT provided. Will use file params!"
+            OPERATOR_IMAGE = getImage("OPERATOR_IMAGE")
+            echo "OPERATOR_IMAGE is $OPERATOR_IMAGE "
+        }
+        if ("$IMAGE_MONGOD") {
+            echo "IMAGE_MONGOD was provided. Not doing anything"}
+        else{
+            echo "IMAGE_MONGOD was NOT provided. Will use file params!"
+            IMAGE_MONGOD = getImage("IMAGE_MONGOD${PILLAR_VERSION}")
+            echo "IMAGE_MONGOD is $IMAGE_MONGOD "
+        }
+        if ("$IMAGE_BACKUP") {
+            echo "IMAGE_BACKUP was provided. Not doing anything"}
+        else{
+            echo "IMAGE_BACKUP was NOT provided. Will use file params!"
+            IMAGE_BACKUP  =getImage("IMAGE_BACKUP")
+            echo "IMAGE_BACKUP is $IMAGE_BACKUP "
+        }
+        if ("$IMAGE_PMM_CLIENT") {
+            echo "IMAGE_PMM_CLIENT was provided. Not doing anything"}
+        else{
+            echo "IMAGE_PMM_CLIENT was NOT provided. Will use file params!"
+            IMAGE_PMM_CLIENT = getImage("IMAGE_PMM_CLIENT")
+            echo "IMAGE_PMM_CLIENT is $IMAGE_PMM_CLIENT "
+        }
+        if ("$IMAGE_PMM_SERVER") {
+            echo "IMAGE_PMM_SERVER was provided. Not doing anything"}
+        else{
+            echo "IMAGE_PMM_SERVER was NOT provided. Will use file params!"
+            IMAGE_PMM_SERVER = getImage("IMAGE_PMM_SERVER")
+            echo "IMAGE_PMM_SERVER is $IMAGE_PMM_SERVER "
+        }
+    } else {
+        echo "This is not release run. Using params only!"
+    }
+
+    if ("$IMAGE_MONGOD") {
+        currentBuild.description = "$GIT_BRANCH-$PLATFORM_VER-CW_$CLUSTER_WIDE-" + "$IMAGE_MONGOD".split(":")[1]
+    }
 
     script {
         GIT_SHORT_COMMIT = sh(script: 'git -C source rev-parse --short HEAD', , returnStdout: true).trim()
@@ -304,6 +365,16 @@ pipeline {
             description: 'Ignore passed tests in previous run (run all)',
             name: 'IGNORE_PREVIOUS_RUN'
         )
+        choice(
+            choices: 'YES\nNO',
+            description: 'Release run?',
+            name: 'RELEASE_RUN'
+        )
+        string(
+            defaultValue: '70',
+            description: 'For RELEASE_RUN only. Major version like 70,60, etc',
+            name: 'PILLAR_VERSION'
+        )
         string(
             defaultValue: 'main',
             description: 'Tag/Branch for percona/percona-server-mongodb-operator repository',
@@ -357,6 +428,7 @@ pipeline {
     stages {
         stage('Prepare node') {
             steps {
+                verifyParams()
                 prepareNode()
             }
         }


### PR DESCRIPTION
Implement usage of `release_images` file from **percona-server-mongodb-operator** repo as a source of IMAGES for jenkins job.
Two new parameters are added:
- RELEASE_RUN - if set to YES, the job will use file for IMAGES
- PILLAR_VERSION - which pillar version to use.

If any image is provided in job params during run - it will overwrite image from file.