### PR TITLE
PMM-7 Remove rpmbuild for RHEL7

### DIFF
--- a/pmm/infrastructure/rpm-build.groovy
+++ b/pmm/infrastructure/rpm-build.groovy
@@ -53,14 +53,6 @@ pipeline {
                 }
             }
         }
-        stage('Build rpmbuild images el7') {
-            steps {
-                sh '''
-                    cd build/docker/rpmbuild/
-                    docker buildx build --pull --platform linux/amd64,linux/arm64 --tag ${IMAGE_REGISTRY}/${DOCKER_TAG}:2 --push .
-                '''
-            }
-        }
         stage('Build rpmbuild images ol9') {
             steps {
                 sh '''


### PR DESCRIPTION
We have deprecated RHEL7 build, so we no longer need to build the `rpmbuild:2` image. Moreover, it's [failing](https://pmm.cd.percona.com/job/rpm-build/95/) because of RHEL7 EOL.