### PR TITLE
Use static OC_VER 4.15.25 for not latest builds due to GLIBC_2.32+ re…

### DIFF
--- a/cloud/jenkins/psmdb_operator_aws_openshift-4.groovy
+++ b/cloud/jenkins/psmdb_operator_aws_openshift-4.groovy
@@ -29,7 +29,11 @@ void prepareNode() {
         USED_PLATFORM_VER = sh(script: "curl -s https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/$PLATFORM_VER/release.txt | sed -n 's/^\\s*Version:\\s\\+\\(\\S\\+\\)\\s*\$/\\1/p'", , returnStdout: true).trim()
     } else {
         USED_PLATFORM_VER="$PLATFORM_VER"
-        OC_VER="4.15.25"
+        if ("$PLATFORM_VER" <= "4.15.25") {
+            OC_VER="$USED_PLATFORM_VER"
+        } else {
+            OC_VER="4.15.25"
+        }
     }
     echo "USED_PLATFORM_VER=$USED_PLATFORM_VER"
     echo "OC_VER=$OC_VER"

--- a/cloud/jenkins/psmdb_operator_aws_openshift-4.groovy
+++ b/cloud/jenkins/psmdb_operator_aws_openshift-4.groovy
@@ -29,7 +29,7 @@ void prepareNode() {
         USED_PLATFORM_VER = sh(script: "curl -s https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/$PLATFORM_VER/release.txt | sed -n 's/^\\s*Version:\\s\\+\\(\\S\\+\\)\\s*\$/\\1/p'", , returnStdout: true).trim()
     } else {
         USED_PLATFORM_VER="$PLATFORM_VER"
-        OC_VER="$PLATFORM_VER"
+        OC_VER="4.15.25"
     }
     echo "USED_PLATFORM_VER=$USED_PLATFORM_VER"
     echo "OC_VER=$OC_VER"

--- a/cloud/jenkins/psmdb_operator_aws_openshift_latest.groovy
+++ b/cloud/jenkins/psmdb_operator_aws_openshift_latest.groovy
@@ -29,7 +29,11 @@ void prepareNode() {
         USED_PLATFORM_VER = sh(script: "curl -s https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/$PLATFORM_VER/release.txt | sed -n 's/^\\s*Version:\\s\\+\\(\\S\\+\\)\\s*\$/\\1/p'", , returnStdout: true).trim()
     } else {
         USED_PLATFORM_VER="$PLATFORM_VER"
-        OC_VER="4.15.25"
+        if ("$PLATFORM_VER" <= "4.15.25") {
+            OC_VER="$USED_PLATFORM_VER"
+        } else {
+            OC_VER="4.15.25"
+        }
     }
     echo "USED_PLATFORM_VER=$USED_PLATFORM_VER"
     echo "OC_VER=$OC_VER"

--- a/cloud/jenkins/psmdb_operator_aws_openshift_latest.groovy
+++ b/cloud/jenkins/psmdb_operator_aws_openshift_latest.groovy
@@ -29,7 +29,7 @@ void prepareNode() {
         USED_PLATFORM_VER = sh(script: "curl -s https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/$PLATFORM_VER/release.txt | sed -n 's/^\\s*Version:\\s\\+\\(\\S\\+\\)\\s*\$/\\1/p'", , returnStdout: true).trim()
     } else {
         USED_PLATFORM_VER="$PLATFORM_VER"
-        OC_VER="$PLATFORM_VER"
+        OC_VER="4.15.25"
     }
     echo "USED_PLATFORM_VER=$USED_PLATFORM_VER"
     echo "OC_VER=$OC_VER"


### PR DESCRIPTION
oc version older than 4.15.25 requires glibc GLIBC_2.32+
AWS instances used for tests have older glibc version and as a result our tests on jenkins fail with: 

```
11:18:25  + KUBECONFIG=/mnt/jenkins/workspace/psmdb-operator-aws-openshift-latest/openshift/cluster1/auth/kubeconfig
11:18:25  + oc whoami
11:18:25  oc: /lib64/libc.so.6: version `GLIBC_2.33' not found (required by oc)
11:18:25  oc: /lib64/libc.so.6: version `GLIBC_2.34' not found (required by oc)
11:18:25  oc: /lib64/libc.so.6: version `GLIBC_2.32' not found (required by oc)
```

Fix: use static OC version 4.15.25 till it is possible to install  GLIBC_2.32+ on worker nodes.