### PR TITLE
PMM-7 FIx deletion of droplets in ovf-staging

### DIFF
--- a/pmm/pmm2-ovf-staging-start.groovy
+++ b/pmm/pmm2-ovf-staging-start.groovy
@@ -234,7 +234,7 @@ pipeline {
 
                     # https://docs.digitalocean.com/products/droplets/how-to/retrieve-droplet-metadata/
                     DROPLET_ID=$(curl -s http://169.254.169.254/metadata/v1/id)
-                    doctl compute droplet delete $DROPLET_ID
+                    doctl compute droplet delete $DROPLET_ID --force
                 '''
             }
         }

--- a/pmm/v3/pmm3-ovf-staging-start.groovy
+++ b/pmm/v3/pmm3-ovf-staging-start.groovy
@@ -204,7 +204,7 @@ pipeline {
 
                     # https://docs.digitalocean.com/products/droplets/how-to/retrieve-droplet-metadata/
                     DROPLET_ID=$(curl -s http://169.254.169.254/metadata/v1/id)
-                    doctl compute droplet delete $DROPLET_ID
+                    doctl compute droplet delete $DROPLET_ID --force
                 '''
                 }
             }


### PR DESCRIPTION
The droplets are not getting deleted because of the introduction of a new `--force` flag, which is required when calling `doctl compute droplet delete`.

Ref: https://pmm.cd.percona.com/job/pmm3-ovf-staging-start/85/console