### PR TITLE
K8SPXC-1508 Enhance pipelines with release run parameters

### DIFF
--- a/cloud/jenkins/pxc_operator_aks_latest.groovy
+++ b/cloud/jenkins/pxc_operator_aks_latest.groovy
@@ -10,7 +10,6 @@ void verifyParams() {
             error("Either PILLAR_VERSION or IMAGE_PXC should be provided for release run!")
         }
     }
-    USED_PLATFORM_VER="$PLATFORM_VER"
 }
 
 String getParam(String PARAM_NAME) {
@@ -85,7 +84,7 @@ void prepareNode() {
     }
 
     if ("$PLATFORM_VER" == "latest") {
-        USED_PLATFORM_VER = sh(script: "az aks get-versions --location $location --output json | jq -r '.values | max_by(.patchVersions) | .patchVersions | keys[]' | sort --version-sort | tail -1", , returnStdout: true).trim()
+        PLATFORM_VER = sh(script: "az aks get-versions --location $location --output json | jq -r '.values | max_by(.patchVersions) | .patchVersions | keys[]' | sort --version-sort | tail -1", , returnStdout: true).trim()
     }
 
     if ("$IMAGE_PXC") {
@@ -97,7 +96,7 @@ void prepareNode() {
     script {
         GIT_SHORT_COMMIT = sh(script: 'git -C source rev-parse --short HEAD', , returnStdout: true).trim()
         CLUSTER_NAME = sh(script: "echo jenkins-lat-pxc-$GIT_SHORT_COMMIT | tr '[:upper:]' '[:lower:]'", , returnStdout: true).trim()
-        PARAMS_HASH = sh(script: "echo $GIT_BRANCH-$GIT_SHORT_COMMIT-$USED_PLATFORM_VER-$CLUSTER_WIDE-$IMAGE_OPERATOR-$IMAGE_PXC-$IMAGE_PROXY-$IMAGE_HAPROXY-$IMAGE_BACKUP-$IMAGE_LOGCOLLECTOR-$IMAGE_PMM_CLIENT-$IMAGE_PMM_SERVER | md5sum | cut -d' ' -f1", , returnStdout: true).trim()
+        PARAMS_HASH = sh(script: "echo $GIT_BRANCH-$GIT_SHORT_COMMIT-$PLATFORM_VER-$CLUSTER_WIDE-$IMAGE_OPERATOR-$IMAGE_PXC-$IMAGE_PROXY-$IMAGE_HAPROXY-$IMAGE_BACKUP-$IMAGE_LOGCOLLECTOR-$IMAGE_PMM_CLIENT-$IMAGE_PMM_SERVER | md5sum | cut -d' ' -f1", , returnStdout: true).trim()
     }
 }
 
@@ -153,7 +152,7 @@ void initTests() {
 
             for (int i=0; i<tests.size(); i++) {
                 def testName = tests[i]["name"]
-                def file="$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$USED_PLATFORM_VER-$PXC_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH"
+                def file="$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$PXC_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH"
                 def retFileExists = sh(script: "aws s3api head-object --bucket percona-jenkins-artifactory --key $JOB_NAME/$GIT_SHORT_COMMIT/$file >/dev/null 2>&1", returnStatus: true)
 
                 if (retFileExists == 0) {
@@ -213,7 +212,7 @@ void createCluster(String CLUSTER_SUFFIX) {
             --generate-ssh-keys \
             --enable-cluster-autoscaler \
             --outbound-type loadbalancer \
-            --kubernetes-version $USED_PLATFORM_VER \
+            --kubernetes-version $PLATFORM_VER \
             -l $location
         az aks get-credentials --subscription eng-cloud-dev --resource-group percona-operators --name $CLUSTER_NAME-$CLUSTER_SUFFIX --overwrite-existing
     """
@@ -249,7 +248,7 @@ void runTest(Integer TEST_ID) {
                     e2e-tests/$testName/run
                 """
             }
-            pushArtifactFile("$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$USED_PLATFORM_VER-$PXC_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH")
+            pushArtifactFile("$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$PXC_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH")
             tests[TEST_ID]["result"] = "passed"
             return true
         }
@@ -302,7 +301,7 @@ void makeReport() {
         IMAGE_LOGCOLLECTOR=$IMAGE_LOGCOLLECTOR
         IMAGE_PMM_CLIENT=$IMAGE_PMM_CLIENT
         IMAGE_PMM_SERVER=$IMAGE_PMM_SERVER
-        USED_PLATFORM_VER=$USED_PLATFORM_VER
+        PLATFORM_VER=$PLATFORM_VER
     """
 
     writeFile file: "TestsReport.xml", text: testsReport

--- a/cloud/jenkins/pxc_operator_aks_latest.groovy
+++ b/cloud/jenkins/pxc_operator_aks_latest.groovy
@@ -9,8 +9,8 @@ void verifyParams() {
         if (!"$PILLAR_VERSION" && !"$IMAGE_PXC") {
             error("Either PILLAR_VERSION or IMAGE_PXC should be provided for release run!")
         }
-        USED_PLATFORM_VER="$PLATFORM_VER"
     }
+    USED_PLATFORM_VER="$PLATFORM_VER"
 }
 
 String getParam(String PARAM_NAME) {

--- a/cloud/jenkins/pxc_operator_aks_latest.groovy
+++ b/cloud/jenkins/pxc_operator_aks_latest.groovy
@@ -394,7 +394,7 @@ pipeline {
         copyArtifactPermission('pxc-operator-latest-scheduler');
     }
     stages {
-        stage('Prepare node') {
+        stage('Prepare Node') {
             steps {
                 prepareNode()
             }
@@ -404,7 +404,7 @@ pipeline {
                 dockerBuildPush()
             }
         }
-        stage('Init tests') {
+        stage('Init Tests') {
             steps {
                 initTests()
             }

--- a/cloud/jenkins/pxc_operator_aks_latest.groovy
+++ b/cloud/jenkins/pxc_operator_aks_latest.groovy
@@ -60,6 +60,10 @@ void prepareNode() {
             printf "/usr/azure-cli\\n/usr/bin" | sudo python3 install.py
             sudo /usr/azure-cli/bin/python -m pip install "urllib3<2.0.0" > /dev/null
         fi
+
+        sudo yum install -y https://repo.percona.com/yum/percona-release-latest.noarch.rpm || true
+        sudo percona-release enable-only tools
+        sudo yum install -y percona-xtrabackup-80 | true
     """
 
     echo "=========================[ Logging in the Kubernetes provider ]========================="

--- a/cloud/jenkins/pxc_operator_aks_latest.groovy
+++ b/cloud/jenkins/pxc_operator_aks_latest.groovy
@@ -1,4 +1,4 @@
-location='westeurope'
+location='eastus'
 tests=[]
 clusters=[]
 release_versions="source/e2e-tests/release_versions"

--- a/cloud/jenkins/pxc_operator_aks_latest.groovy
+++ b/cloud/jenkins/pxc_operator_aks_latest.groovy
@@ -333,7 +333,7 @@ pipeline {
         )
         choice(
             choices: 'none\n80\n57',
-            description: 'Can be 08, 57, etc. or none. Implies release run.',
+            description: 'Can be 80, 57, etc. or none. Implies release run.',
             name: 'PILLAR_VERSION')
         string(
             defaultValue: 'main',

--- a/cloud/jenkins/pxc_operator_aks_latest.groovy
+++ b/cloud/jenkins/pxc_operator_aks_latest.groovy
@@ -332,12 +332,9 @@ pipeline {
             name: 'IGNORE_PREVIOUS_RUN'
         )
         choice(
-        )
-        choice(
             choices: 'none\n80\n57',
             description: 'Can be 08, 57, etc. or none. Implies release run.',
-            name: 'PILLAR_VERSION'
-        )
+            name: 'PILLAR_VERSION')
         string(
             defaultValue: 'main',
             description: 'Tag/Branch for percona/percona-xtradb-cluster-operator repository',

--- a/cloud/jenkins/pxc_operator_aks_latest.groovy
+++ b/cloud/jenkins/pxc_operator_aks_latest.groovy
@@ -12,18 +12,14 @@ void verifyParams() {
     }
 }
 
-String getParam(String PARAM_NAME) {
-    def param = "${params[PARAM_NAME]}"
+String getParam(String paramName, String keyName = null) {
+    keyName = keyName ?: paramName
 
-    if ("$param" && "$param" != "null" && param != "") {
-        echo "$PARAM_NAME=$param (from job parameters)"
+    param = sh(script: "grep -iE '^\\s*$keyName=' $release_versions | cut -d = -f 2 | tr -d \'\"\'| tail -1", , returnStdout: true).trim()
+    if ("$param") {
+        echo "$paramName=$param (from params file)"
     } else {
-        param = sh(script: "grep -iE '^\\s*$PARAM_NAME=' $release_versions | cut -d = -f 2 | tr -d \'\"\'| tail -1", , returnStdout: true).trim()
-        if ("$param") {
-            echo "$PARAM_NAME=$param (from params file)"
-        } else {
-            error("$PARAM_NAME not found in params file $release_versions")
-        }
+        error("$keyName not found in params file $release_versions")
     }
     return param
 }
@@ -43,16 +39,16 @@ void prepareNode() {
 
     if ("$RELEASE_RUN" == "YES") {
         echo "=========================[ Getting parameters for release test ]========================="
-        IMAGE_OPERATOR = getParam("IMAGE_OPERATOR")
-        IMAGE_PXC = getParam("IMAGE_PXC${PILLAR_VERSION}")
-        IMAGE_PROXY = getParam("IMAGE_PROXY")
-        IMAGE_HAPROXY = getParam("IMAGE_HAPROXY")
-        IMAGE_BACKUP = getParam("IMAGE_BACKUP${PILLAR_VERSION}")
-        IMAGE_LOGCOLLECTOR = getParam("IMAGE_LOGCOLLECTOR")
-        IMAGE_PMM_CLIENT = getParam("IMAGE_PMM_CLIENT")
-        IMAGE_PMM_SERVER = getParam("IMAGE_PMM_SERVER")
+        IMAGE_OPERATOR = params["IMAGE_OPERATOR"] ?: getParam("IMAGE_OPERATOR")
+        IMAGE_PXC = params["IMAGE_PXC"] ?: getParam("IMAGE_PXC", "IMAGE_PXC${PILLAR_VERSION}")
+        IMAGE_PROXY = params["IMAGE_PROXY"] ?: getParam("IMAGE_PROXY")
+        IMAGE_HAPROXY = params["IMAGE_HAPROXY"] ?: getParam("IMAGE_HAPROXY")
+        IMAGE_BACKUP = params["IMAGE_BACKUP"] ?: getParam("IMAGE_BACKUP", "IMAGE_BACKUP${PILLAR_VERSION}")
+        IMAGE_LOGCOLLECTOR = params["IMAGE_LOGCOLLECTOR"] ?: getParam("IMAGE_LOGCOLLECTOR")
+        IMAGE_PMM_CLIENT = params["IMAGE_PMM_CLIENT"] ?: getParam("IMAGE_PMM_CLIENT")
+        IMAGE_PMM_SERVER = params["IMAGE_PMM_SERVER"] ?: getParam("IMAGE_PMM_SERVER")
         if ("$PLATFORM_VER" == "min".toLowerCase() || "$PLATFORM_VER" == "max".toLowerCase()) {
-            PLATFORM_VER = getParam("AKS_${PLATFORM_VER}")
+            PLATFORM_VER = getParam("PLATFORM_VER", "AKS_${PLATFORM_VER}")
         }
     } else {
         echo "=========================[ Not a release run. Using job params only! ]========================="

--- a/cloud/jenkins/pxc_operator_aks_latest.groovy
+++ b/cloud/jenkins/pxc_operator_aks_latest.groovy
@@ -148,7 +148,7 @@ void initTests() {
 
             for (int i=0; i<tests.size(); i++) {
                 def testName = tests[i]["name"]
-                def file="$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$PXC_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH"
+                def file="$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$DB_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH"
                 def retFileExists = sh(script: "aws s3api head-object --bucket percona-jenkins-artifactory --key $JOB_NAME/$GIT_SHORT_COMMIT/$file >/dev/null 2>&1", returnStatus: true)
 
                 if (retFileExists == 0) {
@@ -244,7 +244,7 @@ void runTest(Integer TEST_ID) {
                     e2e-tests/$testName/run
                 """
             }
-            pushArtifactFile("$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$PXC_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH")
+            pushArtifactFile("$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$DB_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH")
             tests[TEST_ID]["result"] = "passed"
             return true
         }
@@ -326,7 +326,7 @@ void shutdownCluster(String CLUSTER_SUFFIX) {
 pipeline {
     environment {
         CLEAN_NAMESPACE = 1
-        PXC_TAG = sh(script: "[[ \"$IMAGE_PXC\" ]] && echo $IMAGE_PXC | awk -F':' '{print \$2}' || echo main", , returnStdout: true).trim()
+        DB_TAG = sh(script: "[[ \"$IMAGE_PXC\" ]] && echo $IMAGE_PXC | awk -F':' '{print \$2}' || echo main", , returnStdout: true).trim()
     }
     parameters {
         choice(

--- a/cloud/jenkins/pxc_operator_aks_latest.groovy
+++ b/cloud/jenkins/pxc_operator_aks_latest.groovy
@@ -224,7 +224,7 @@ void runTest(Integer TEST_ID) {
 
                     export DEBUG_TESTS=1
                     [[ "$CLUSTER_WIDE" == "YES" ]] && export OPERATOR_NS=pxc-operator
-                    export IMAGE=$IMAGE_OPERATOR
+                    [[ "$IMAGE_OPERATOR" ]] && export IMAGE=$IMAGE_OPERATOR || export IMAGE=perconalab/percona-xtradb-cluster-operator:$GIT_BRANCH
                     export IMAGE_PXC=$IMAGE_PXC
                     export IMAGE_PROXY=$IMAGE_PROXY
                     export IMAGE_HAPROXY=$IMAGE_HAPROXY

--- a/cloud/jenkins/pxc_operator_aks_latest.groovy
+++ b/cloud/jenkins/pxc_operator_aks_latest.groovy
@@ -1,8 +1,64 @@
 location='westeurope'
 tests=[]
 clusters=[]
+release_versions="source/e2e-tests/release_versions"
+
+void verifyParams() {
+    if ("$RELEASE_RUN" == "YES") {
+        echo "=========================[ RELEASE RUN ]========================="
+        if (!"$PILLAR_VERSION" && !"$IMAGE_PXC") {
+            error("Either PILLAR_VERSION or IMAGE_PXC should be provided for release run!")
+        }
+        USED_PLATFORM_VER="$PLATFORM_VER"
+    }
+}
+
+String getParam(String PARAM_NAME) {
+    def param = "${params[PARAM_NAME]}"
+
+    if ("$param" && "$param" != "null" && param != "") {
+        echo "$PARAM_NAME=$param (from job parameters)"
+    } else {
+        param = sh(script: "grep -iE '^\\s*$PARAM_NAME=' $release_versions | cut -d = -f 2 | tr -d \'\"\'| tail -1", , returnStdout: true).trim()
+        if ("$param") {
+            echo "$PARAM_NAME=$param (from params file)"
+        } else {
+            error("$PARAM_NAME not found in params file $release_versions")
+        }
+    }
+    return param
+}
 
 void prepareNode() {
+    echo "=========================[ Cloning the sources ]========================="
+    git branch: 'master', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
+    sh """
+        # sudo is needed for better node recovery after compilation failure
+        # if building failed on compilation stage directory will have files owned by docker user
+        sudo git config --global --add safe.directory '*'
+        sudo git reset --hard
+        sudo git clean -xdf
+        sudo rm -rf source
+        cloud/local/checkout $GIT_REPO $GIT_BRANCH
+    """
+
+    if ("$RELEASE_RUN" == "YES") {
+        echo "=========================[ Getting parameters for release test ]========================="
+        IMAGE_OPERATOR = getParam("IMAGE_OPERATOR")
+        IMAGE_PXC = getParam("IMAGE_PXC${PILLAR_VERSION}")
+        IMAGE_PROXY = getParam("IMAGE_PROXY")
+        IMAGE_HAPROXY = getParam("IMAGE_HAPROXY")
+        IMAGE_BACKUP = getParam("IMAGE_BACKUP${PILLAR_VERSION}")
+        IMAGE_LOGCOLLECTOR = getParam("IMAGE_LOGCOLLECTOR")
+        IMAGE_PMM_CLIENT = getParam("IMAGE_PMM_CLIENT")
+        IMAGE_PMM_SERVER = getParam("IMAGE_PMM_SERVER")
+        if ("$PLATFORM_VER" == "min".toLowerCase() || "$PLATFORM_VER" == "max".toLowerCase()) {
+            PLATFORM_VER = getParam("AKS_${PLATFORM_VER}")
+        }
+    } else {
+        echo "=========================[ Not a release run. Using job params only! ]========================="
+    }
+
     echo "=========================[ Installing tools on the Jenkins executor ]========================="
     sh """
         sudo curl -s -L -o /usr/local/bin/kubectl https://dl.k8s.io/release/\$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl && sudo chmod +x /usr/local/bin/kubectl
@@ -18,10 +74,6 @@ void prepareNode() {
             printf "/usr/azure-cli\\n/usr/bin" | sudo python3 install.py
             sudo /usr/azure-cli/bin/python -m pip install "urllib3<2.0.0" > /dev/null
         fi
-
-        sudo yum install -y https://repo.percona.com/yum/percona-release-latest.noarch.rpm || true
-        sudo percona-release enable-only tools
-        sudo yum install -y percona-xtrabackup-80 | true
     """
 
     echo "=========================[ Logging in the Kubernetes provider ]========================="
@@ -34,31 +86,18 @@ void prepareNode() {
 
     if ("$PLATFORM_VER" == "latest") {
         USED_PLATFORM_VER = sh(script: "az aks get-versions --location $location --output json | jq -r '.values | max_by(.patchVersions) | .patchVersions | keys[]' | sort --version-sort | tail -1", , returnStdout: true).trim()
-    } else {
-        USED_PLATFORM_VER="$PLATFORM_VER"
     }
-    echo "USED_PLATFORM_VER=$USED_PLATFORM_VER"
 
     if ("$IMAGE_PXC") {
-        currentBuild.description = "$GIT_BRANCH-$USED_PLATFORM_VER-CW_$CLUSTER_WIDE-" + "$IMAGE_PXC".split(":")[1]
+        release = ("$RELEASE_RUN" == "YES") ? "RELEASE-" : ""
+        cw = ("$CLUSTER_WIDE" == "YES") ? "CW" : "NON-CW"
+        currentBuild.description = "$release$GIT_BRANCH-$PLATFORM_VER-$cw-" + "$IMAGE_PXC".split(":")[1]
     }
-
-    echo "=========================[ Cloning the sources ]========================="
-    git branch: 'master', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
-    sh """
-        # sudo is needed for better node recovery after compilation failure
-        # if building failed on compilation stage directory will have files owned by docker user
-        sudo git config --global --add safe.directory '*'
-        sudo git reset --hard
-        sudo git clean -xdf
-        sudo rm -rf source
-        cloud/local/checkout $GIT_REPO $GIT_BRANCH
-    """
 
     script {
         GIT_SHORT_COMMIT = sh(script: 'git -C source rev-parse --short HEAD', , returnStdout: true).trim()
         CLUSTER_NAME = sh(script: "echo jenkins-lat-pxc-$GIT_SHORT_COMMIT | tr '[:upper:]' '[:lower:]'", , returnStdout: true).trim()
-        PARAMS_HASH = sh(script: "echo $GIT_BRANCH-$GIT_SHORT_COMMIT-$USED_PLATFORM_VER-$CLUSTER_WIDE-$OPERATOR_IMAGE-$IMAGE_PXC-$IMAGE_PROXY-$IMAGE_HAPROXY-$IMAGE_BACKUP-$IMAGE_LOGCOLLECTOR-$IMAGE_PMM_CLIENT-$IMAGE_PMM_SERVER | md5sum | cut -d' ' -f1", , returnStdout: true).trim()
+        PARAMS_HASH = sh(script: "echo $GIT_BRANCH-$GIT_SHORT_COMMIT-$USED_PLATFORM_VER-$CLUSTER_WIDE-$IMAGE_OPERATOR-$IMAGE_PXC-$IMAGE_PROXY-$IMAGE_HAPROXY-$IMAGE_BACKUP-$IMAGE_LOGCOLLECTOR-$IMAGE_PMM_CLIENT-$IMAGE_PMM_SERVER | md5sum | cut -d' ' -f1", , returnStdout: true).trim()
     }
 }
 
@@ -66,7 +105,7 @@ void dockerBuildPush() {
     echo "=========================[ Building and Pushing the operator Docker image ]========================="
     withCredentials([usernamePassword(credentialsId: 'hub.docker.com', passwordVariable: 'PASS', usernameVariable: 'USER')]) {
         sh """
-            if [[ "$OPERATOR_IMAGE" ]]; then
+            if [[ "$IMAGE_OPERATOR" ]]; then
                 echo "SKIP: Build is not needed, operator image was set!"
             else
                 cd source
@@ -106,8 +145,8 @@ void initTests() {
     }
 
     echo "Marking passed tests in the tests map!"
-    if ("$IGNORE_PREVIOUS_RUN" == "NO") {
-        withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AMI/OVF', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
+    withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AMI/OVF', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
+        if ("$IGNORE_PREVIOUS_RUN" == "NO") {
             sh """
                 aws s3 ls s3://percona-jenkins-artifactory/$JOB_NAME/$GIT_SHORT_COMMIT/ || :
             """
@@ -121,9 +160,7 @@ void initTests() {
                     tests[i]["result"] = "passed"
                 }
             }
-        }
-    } else {
-        withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AMI/OVF', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
+        } else {
             sh """
                 aws s3 rm "s3://percona-jenkins-artifactory/$JOB_NAME/$GIT_SHORT_COMMIT/" --recursive --exclude "*" --include "*-$PARAMS_HASH" || :
             """
@@ -199,7 +236,7 @@ void runTest(Integer TEST_ID) {
 
                     export DEBUG_TESTS=1
                     [[ "$CLUSTER_WIDE" == "YES" ]] && export OPERATOR_NS=pxc-operator
-                    [[ "$OPERATOR_IMAGE" ]] && export IMAGE=$OPERATOR_IMAGE || export IMAGE=perconalab/percona-xtradb-cluster-operator:$GIT_BRANCH
+                    export IMAGE=$IMAGE_OPERATOR
                     export IMAGE_PXC=$IMAGE_PXC
                     export IMAGE_PROXY=$IMAGE_PROXY
                     export IMAGE_HAPROXY=$IMAGE_HAPROXY
@@ -246,17 +283,30 @@ void pushArtifactFile(String FILE_NAME) {
     }
 }
 
-TestsReport = '<testsuite name=\\"PXC-AKS-latest\\">\n'
 void makeReport() {
     echo "=========================[ Generating Test Report ]========================="
-    for (int i=0; i<tests.size(); i++) {
-        def testResult = tests[i]["result"]
-        def testTime = tests[i]["time"]
-        def testName = tests[i]["name"]
-
-        TestsReport = TestsReport + '<testcase name=\\"' + testName + '\\" time=\\"' + testTime + '\\"><'+ testResult +'/></testcase>\n'
+    testsReport = '<testsuite name="PXC-AKS-latest">\n'
+    for (int i = 0; i < tests.size(); i ++) {
+        testsReport += '<testcase name="' + tests[i]["name"] + '" time="' + tests[i]["time"] + '"><'+ tests[i]["result"] +'/></testcase>\n'
     }
-    TestsReport = TestsReport + '</testsuite>\n'
+    testsReport += '</testsuite>\n'
+
+    echo "=========================[ Generating Parameters Report ]========================="
+    pipelineParameters = """
+        testsuite name=PXC-AKS-latest
+        IMAGE_OPERATOR=$IMAGE_OPERATOR
+        IMAGE_PXC=$IMAGE_PXC
+        IMAGE_PROXY=$IMAGE_PROXY
+        IMAGE_HAPROXY=$IMAGE_HAPROXY
+        IMAGE_BACKUP=$IMAGE_BACKUP
+        IMAGE_LOGCOLLECTOR=$IMAGE_LOGCOLLECTOR
+        IMAGE_PMM_CLIENT=$IMAGE_PMM_CLIENT
+        IMAGE_PMM_SERVER=$IMAGE_PMM_SERVER
+        USED_PLATFORM_VER=$USED_PLATFORM_VER
+    """
+
+    writeFile file: "TestsReport.xml", text: testsReport
+    writeFile file: 'PipelineParameters.txt', text: pipelineParameters
 }
 
 void shutdownCluster(String CLUSTER_SUFFIX) {
@@ -280,7 +330,6 @@ void shutdownCluster(String CLUSTER_SUFFIX) {
 
 pipeline {
     environment {
-        CLOUDSDK_CORE_DISABLE_PROMPTS = 1
         CLEAN_NAMESPACE = 1
         PXC_TAG = sh(script: "[[ \"$IMAGE_PXC\" ]] && echo $IMAGE_PXC | awk -F':' '{print \$2}' || echo main", , returnStdout: true).trim()
     }
@@ -297,6 +346,16 @@ pipeline {
             choices: 'NO\nYES',
             description: 'Ignore passed tests in previous run (run all)',
             name: 'IGNORE_PREVIOUS_RUN'
+        )
+        choice(
+            choices: 'NO\nYES',
+            description: 'Release run?',
+            name: 'RELEASE_RUN'
+        )
+        string(
+            defaultValue: '80',
+            description: 'For RELEASE_RUN only. Major version like 80, 57, etc',
+            name: 'PILLAR_VERSION'
         )
         string(
             defaultValue: 'main',
@@ -317,7 +376,7 @@ pipeline {
         string(
             defaultValue: '',
             description: 'Operator image: perconalab/percona-xtradb-cluster-operator:main',
-            name: 'OPERATOR_IMAGE')
+            name: 'IMAGE_OPERATOR')
         string(
             defaultValue: '',
             description: 'PXC image: perconalab/percona-xtradb-cluster-operator:main-pxc8.0',
@@ -359,6 +418,7 @@ pipeline {
     stages {
         stage('Prepare node') {
             steps {
+                verifyParams()
                 prepareNode()
             }
         }
@@ -421,11 +481,8 @@ pipeline {
         always {
             echo "CLUSTER ASSIGNMENTS\n" + tests.toString().replace("], ","]\n").replace("]]","]").replaceFirst("\\[","")
             makeReport()
-            sh """
-                echo "$TestsReport" > TestsReport.xml
-            """
             step([$class: 'JUnitResultArchiver', testResults: '*.xml', healthScaleFactor: 1.0])
-            archiveArtifacts '*.xml'
+            archiveArtifacts '*.xml,*.txt'
 
             script {
                 if (currentBuild.result != null && currentBuild.result != 'SUCCESS') {
@@ -437,7 +494,6 @@ pipeline {
 
             sh """
                 sudo docker system prune --volumes -af
-                sudo rm -rf *
             """
             deleteDir()
         }

--- a/cloud/jenkins/pxc_operator_aks_latest.groovy
+++ b/cloud/jenkins/pxc_operator_aks_latest.groovy
@@ -336,8 +336,8 @@ pipeline {
             name: 'IGNORE_PREVIOUS_RUN'
         )
         choice(
-            choices: 'none\n80\n57',
-            description: 'Can be 80, 57, etc. or none. Implies release run.',
+            choices: 'none\n84\n80\n57',
+            description: 'Implies release run.',
             name: 'PILLAR_VERSION')
         string(
             defaultValue: 'main',
@@ -349,7 +349,7 @@ pipeline {
             name: 'GIT_REPO')
         string(
             defaultValue: 'latest',
-            description: 'AKS kubernetes version',
+            description: 'AKS kubernetes version. If set to min or max, value will be automatically taken from release_versions file.',
             name: 'PLATFORM_VER')
         choice(
             choices: 'YES\nNO',

--- a/cloud/jenkins/pxc_operator_aks_version.groovy
+++ b/cloud/jenkins/pxc_operator_aks_version.groovy
@@ -3,15 +3,6 @@ tests=[]
 clusters=[]
 release_versions="source/e2e-tests/release_versions"
 
-void verifyParams() {
-    if ("$RELEASE_RUN" == "YES") {
-        echo "=========================[ RELEASE RUN ]========================="
-        if (!"$PILLAR_VERSION" && !"$IMAGE_PXC") {
-            error("Either PILLAR_VERSION or IMAGE_PXC should be provided for release run!")
-        }
-    }
-}
-
 String getParam(String paramName, String keyName = null) {
     keyName = keyName ?: paramName
 
@@ -37,16 +28,16 @@ void prepareNode() {
         cloud/local/checkout $GIT_REPO $GIT_BRANCH
     """
 
-    if ("$RELEASE_RUN" == "YES") {
+    if ("$PILLAR_VERSION" != "none") {
         echo "=========================[ Getting parameters for release test ]========================="
-        IMAGE_OPERATOR = params["IMAGE_OPERATOR"] ?: getParam("IMAGE_OPERATOR")
-        IMAGE_PXC = params["IMAGE_PXC"] ?: getParam("IMAGE_PXC", "IMAGE_PXC${PILLAR_VERSION}")
-        IMAGE_PROXY = params["IMAGE_PROXY"] ?: getParam("IMAGE_PROXY")
-        IMAGE_HAPROXY = params["IMAGE_HAPROXY"] ?: getParam("IMAGE_HAPROXY")
-        IMAGE_BACKUP = params["IMAGE_BACKUP"] ?: getParam("IMAGE_BACKUP", "IMAGE_BACKUP${PILLAR_VERSION}")
-        IMAGE_LOGCOLLECTOR = params["IMAGE_LOGCOLLECTOR"] ?: getParam("IMAGE_LOGCOLLECTOR")
-        IMAGE_PMM_CLIENT = params["IMAGE_PMM_CLIENT"] ?: getParam("IMAGE_PMM_CLIENT")
-        IMAGE_PMM_SERVER = params["IMAGE_PMM_SERVER"] ?: getParam("IMAGE_PMM_SERVER")
+        IMAGE_OPERATOR = IMAGE_OPERATOR ?: getParam("IMAGE_OPERATOR")
+        IMAGE_PXC = IMAGE_PXC ?: getParam("IMAGE_PXC", "IMAGE_PXC${PILLAR_VERSION}")
+        IMAGE_PROXY = IMAGE_PROXY ?: getParam("IMAGE_PROXY")
+        IMAGE_HAPROXY = IMAGE_HAPROXY ?: getParam("IMAGE_HAPROXY")
+        IMAGE_BACKUP = IMAGE_BACKUP ?: getParam("IMAGE_BACKUP", "IMAGE_BACKUP${PILLAR_VERSION}")
+        IMAGE_LOGCOLLECTOR = IMAGE_LOGCOLLECTOR ?: getParam("IMAGE_LOGCOLLECTOR")
+        IMAGE_PMM_CLIENT = IMAGE_PMM_CLIENT ?: getParam("IMAGE_PMM_CLIENT")
+        IMAGE_PMM_SERVER = IMAGE_PMM_SERVER ?: getParam("IMAGE_PMM_SERVER")
         if ("$PLATFORM_VER" == "min".toLowerCase() || "$PLATFORM_VER" == "max".toLowerCase()) {
             PLATFORM_VER = getParam("PLATFORM_VER", "AKS_${PLATFORM_VER}")
         }
@@ -84,16 +75,14 @@ void prepareNode() {
     }
 
     if ("$IMAGE_PXC") {
-        release = ("$RELEASE_RUN" == "YES") ? "RELEASE-" : ""
+        release = ("$PILLAR_VERSION" != "none") ? "RELEASE-" : ""
         cw = ("$CLUSTER_WIDE" == "YES") ? "CW" : "NON-CW"
         currentBuild.description = "$release$GIT_BRANCH-$PLATFORM_VER-$cw-" + "$IMAGE_PXC".split(":")[1]
     }
 
-    script {
-        GIT_SHORT_COMMIT = sh(script: 'git -C source rev-parse --short HEAD', , returnStdout: true).trim()
-        CLUSTER_NAME = sh(script: "echo jenkins-ver-pxc-$GIT_SHORT_COMMIT | tr '[:upper:]' '[:lower:]'", , returnStdout: true).trim()
-        PARAMS_HASH = sh(script: "echo $GIT_BRANCH-$GIT_SHORT_COMMIT-$PLATFORM_VER-$CLUSTER_WIDE-$IMAGE_OPERATOR-$IMAGE_PXC-$IMAGE_PROXY-$IMAGE_HAPROXY-$IMAGE_BACKUP-$IMAGE_LOGCOLLECTOR-$IMAGE_PMM_CLIENT-$IMAGE_PMM_SERVER | md5sum | cut -d' ' -f1", , returnStdout: true).trim()
-    }
+    GIT_SHORT_COMMIT = sh(script: 'git -C source rev-parse --short HEAD', , returnStdout: true).trim()
+    CLUSTER_NAME = sh(script: "echo jenkins-ver-pxc-$GIT_SHORT_COMMIT | tr '[:upper:]' '[:lower:]'", , returnStdout: true).trim()
+    PARAMS_HASH = sh(script: "echo $GIT_BRANCH-$GIT_SHORT_COMMIT-$PLATFORM_VER-$CLUSTER_WIDE-$IMAGE_OPERATOR-$IMAGE_PXC-$IMAGE_PROXY-$IMAGE_HAPROXY-$IMAGE_BACKUP-$IMAGE_LOGCOLLECTOR-$IMAGE_PMM_CLIENT-$IMAGE_PMM_SERVER | md5sum | cut -d' ' -f1", , returnStdout: true).trim()
 }
 
 void dockerBuildPush() {
@@ -343,13 +332,10 @@ pipeline {
             name: 'IGNORE_PREVIOUS_RUN'
         )
         choice(
-            choices: 'NO\nYES',
-            description: 'Release run?',
-            name: 'RELEASE_RUN'
         )
-        string(
-            defaultValue: '80',
-            description: 'For RELEASE_RUN only. Major version like 80, 57, etc',
+        choice(
+            choices: 'none\n80\n57',
+            description: 'Can be 08, 57, etc. or none. Implies release run.',
             name: 'PILLAR_VERSION'
         )
         string(
@@ -413,7 +399,6 @@ pipeline {
     stages {
         stage('Prepare node') {
             steps {
-                verifyParams()
                 prepareNode()
             }
         }

--- a/cloud/jenkins/pxc_operator_aks_version.groovy
+++ b/cloud/jenkins/pxc_operator_aks_version.groovy
@@ -9,8 +9,8 @@ void verifyParams() {
         if (!"$PILLAR_VERSION" && !"$IMAGE_PXC") {
             error("Either PILLAR_VERSION or IMAGE_PXC should be provided for release run!")
         }
-        USED_PLATFORM_VER="$PLATFORM_VER"
     }
+    USED_PLATFORM_VER="$PLATFORM_VER"
 }
 
 String getParam(String PARAM_NAME) {

--- a/cloud/jenkins/pxc_operator_aks_version.groovy
+++ b/cloud/jenkins/pxc_operator_aks_version.groovy
@@ -394,7 +394,7 @@ pipeline {
         copyArtifactPermission('pxc-operator-latest-scheduler');
     }
     stages {
-        stage('Prepare node') {
+        stage('Prepare Node') {
             steps {
                 prepareNode()
             }
@@ -404,7 +404,7 @@ pipeline {
                 dockerBuildPush()
             }
         }
-        stage('Init tests') {
+        stage('Init Tests') {
             steps {
                 initTests()
             }

--- a/cloud/jenkins/pxc_operator_aks_version.groovy
+++ b/cloud/jenkins/pxc_operator_aks_version.groovy
@@ -60,6 +60,10 @@ void prepareNode() {
             printf "/usr/azure-cli\\n/usr/bin" | sudo python3 install.py
             sudo /usr/azure-cli/bin/python -m pip install "urllib3<2.0.0" > /dev/null
         fi
+
+        sudo yum install -y https://repo.percona.com/yum/percona-release-latest.noarch.rpm || true
+        sudo percona-release enable-only tools
+        sudo yum install -y percona-xtrabackup-80 | true
     """
 
     echo "=========================[ Logging in the Kubernetes provider ]========================="

--- a/cloud/jenkins/pxc_operator_aks_version.groovy
+++ b/cloud/jenkins/pxc_operator_aks_version.groovy
@@ -333,7 +333,7 @@ pipeline {
         )
         choice(
             choices: 'none\n80\n57',
-            description: 'Can be 08, 57, etc. or none. Implies release run.',
+            description: 'Can be 80, 57, etc. or none. Implies release run.',
             name: 'PILLAR_VERSION')
         string(
             defaultValue: 'main',

--- a/cloud/jenkins/pxc_operator_aks_version.groovy
+++ b/cloud/jenkins/pxc_operator_aks_version.groovy
@@ -332,12 +332,9 @@ pipeline {
             name: 'IGNORE_PREVIOUS_RUN'
         )
         choice(
-        )
-        choice(
             choices: 'none\n80\n57',
             description: 'Can be 08, 57, etc. or none. Implies release run.',
-            name: 'PILLAR_VERSION'
-        )
+            name: 'PILLAR_VERSION')
         string(
             defaultValue: 'main',
             description: 'Tag/Branch for percona/percona-xtradb-cluster-operator repository',

--- a/cloud/jenkins/pxc_operator_aks_version.groovy
+++ b/cloud/jenkins/pxc_operator_aks_version.groovy
@@ -1,4 +1,4 @@
-location='westeurope'
+location='eastus'
 tests=[]
 clusters=[]
 release_versions="source/e2e-tests/release_versions"
@@ -10,7 +10,6 @@ void verifyParams() {
             error("Either PILLAR_VERSION or IMAGE_PXC should be provided for release run!")
         }
     }
-    USED_PLATFORM_VER="$PLATFORM_VER"
 }
 
 String getParam(String PARAM_NAME) {
@@ -85,7 +84,7 @@ void prepareNode() {
     }
 
     if ("$PLATFORM_VER" == "latest") {
-        USED_PLATFORM_VER = sh(script: "az aks get-versions --location $location --output json | jq -r '.values | max_by(.patchVersions) | .patchVersions | keys[]' | sort --version-sort | tail -1", , returnStdout: true).trim()
+        PLATFORM_VER = sh(script: "az aks get-versions --location $location --output json | jq -r '.values | max_by(.patchVersions) | .patchVersions | keys[]' | sort --version-sort | tail -1", , returnStdout: true).trim()
     }
 
     if ("$IMAGE_PXC") {
@@ -97,7 +96,7 @@ void prepareNode() {
     script {
         GIT_SHORT_COMMIT = sh(script: 'git -C source rev-parse --short HEAD', , returnStdout: true).trim()
         CLUSTER_NAME = sh(script: "echo jenkins-ver-pxc-$GIT_SHORT_COMMIT | tr '[:upper:]' '[:lower:]'", , returnStdout: true).trim()
-        PARAMS_HASH = sh(script: "echo $GIT_BRANCH-$GIT_SHORT_COMMIT-$USED_PLATFORM_VER-$CLUSTER_WIDE-$IMAGE_OPERATOR-$IMAGE_PXC-$IMAGE_PROXY-$IMAGE_HAPROXY-$IMAGE_BACKUP-$IMAGE_LOGCOLLECTOR-$IMAGE_PMM_CLIENT-$IMAGE_PMM_SERVER | md5sum | cut -d' ' -f1", , returnStdout: true).trim()
+        PARAMS_HASH = sh(script: "echo $GIT_BRANCH-$GIT_SHORT_COMMIT-$PLATFORM_VER-$CLUSTER_WIDE-$IMAGE_OPERATOR-$IMAGE_PXC-$IMAGE_PROXY-$IMAGE_HAPROXY-$IMAGE_BACKUP-$IMAGE_LOGCOLLECTOR-$IMAGE_PMM_CLIENT-$IMAGE_PMM_SERVER | md5sum | cut -d' ' -f1", , returnStdout: true).trim()
     }
 }
 
@@ -153,7 +152,7 @@ void initTests() {
 
             for (int i=0; i<tests.size(); i++) {
                 def testName = tests[i]["name"]
-                def file="$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$USED_PLATFORM_VER-$PXC_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH"
+                def file="$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$PXC_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH"
                 def retFileExists = sh(script: "aws s3api head-object --bucket percona-jenkins-artifactory --key $JOB_NAME/$GIT_SHORT_COMMIT/$file >/dev/null 2>&1", returnStatus: true)
 
                 if (retFileExists == 0) {
@@ -213,7 +212,7 @@ void createCluster(String CLUSTER_SUFFIX) {
             --generate-ssh-keys \
             --enable-cluster-autoscaler \
             --outbound-type loadbalancer \
-            --kubernetes-version $USED_PLATFORM_VER \
+            --kubernetes-version $PLATFORM_VER \
             -l $location
         az aks get-credentials --subscription eng-cloud-dev --resource-group percona-operators --name $CLUSTER_NAME-$CLUSTER_SUFFIX --overwrite-existing
     """
@@ -249,7 +248,7 @@ void runTest(Integer TEST_ID) {
                     e2e-tests/$testName/run
                 """
             }
-            pushArtifactFile("$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$USED_PLATFORM_VER-$PXC_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH")
+            pushArtifactFile("$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$PXC_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH")
             tests[TEST_ID]["result"] = "passed"
             return true
         }
@@ -302,7 +301,7 @@ void makeReport() {
         IMAGE_LOGCOLLECTOR=$IMAGE_LOGCOLLECTOR
         IMAGE_PMM_CLIENT=$IMAGE_PMM_CLIENT
         IMAGE_PMM_SERVER=$IMAGE_PMM_SERVER
-        USED_PLATFORM_VER=$USED_PLATFORM_VER
+        PLATFORM_VER=$PLATFORM_VER
     """
 
     writeFile file: "TestsReport.xml", text: testsReport

--- a/cloud/jenkins/pxc_operator_aks_version.groovy
+++ b/cloud/jenkins/pxc_operator_aks_version.groovy
@@ -12,18 +12,14 @@ void verifyParams() {
     }
 }
 
-String getParam(String PARAM_NAME) {
-    def param = "${params[PARAM_NAME]}"
+String getParam(String paramName, String keyName = null) {
+    keyName = keyName ?: paramName
 
-    if ("$param" && "$param" != "null" && param != "") {
-        echo "$PARAM_NAME=$param (from job parameters)"
+    param = sh(script: "grep -iE '^\\s*$keyName=' $release_versions | cut -d = -f 2 | tr -d \'\"\'| tail -1", , returnStdout: true).trim()
+    if ("$param") {
+        echo "$paramName=$param (from params file)"
     } else {
-        param = sh(script: "grep -iE '^\\s*$PARAM_NAME=' $release_versions | cut -d = -f 2 | tr -d \'\"\'| tail -1", , returnStdout: true).trim()
-        if ("$param") {
-            echo "$PARAM_NAME=$param (from params file)"
-        } else {
-            error("$PARAM_NAME not found in params file $release_versions")
-        }
+        error("$keyName not found in params file $release_versions")
     }
     return param
 }
@@ -43,16 +39,16 @@ void prepareNode() {
 
     if ("$RELEASE_RUN" == "YES") {
         echo "=========================[ Getting parameters for release test ]========================="
-        IMAGE_OPERATOR = getParam("IMAGE_OPERATOR")
-        IMAGE_PXC = getParam("IMAGE_PXC${PILLAR_VERSION}")
-        IMAGE_PROXY = getParam("IMAGE_PROXY")
-        IMAGE_HAPROXY = getParam("IMAGE_HAPROXY")
-        IMAGE_BACKUP = getParam("IMAGE_BACKUP${PILLAR_VERSION}")
-        IMAGE_LOGCOLLECTOR = getParam("IMAGE_LOGCOLLECTOR")
-        IMAGE_PMM_CLIENT = getParam("IMAGE_PMM_CLIENT")
-        IMAGE_PMM_SERVER = getParam("IMAGE_PMM_SERVER")
+        IMAGE_OPERATOR = params["IMAGE_OPERATOR"] ?: getParam("IMAGE_OPERATOR")
+        IMAGE_PXC = params["IMAGE_PXC"] ?: getParam("IMAGE_PXC", "IMAGE_PXC${PILLAR_VERSION}")
+        IMAGE_PROXY = params["IMAGE_PROXY"] ?: getParam("IMAGE_PROXY")
+        IMAGE_HAPROXY = params["IMAGE_HAPROXY"] ?: getParam("IMAGE_HAPROXY")
+        IMAGE_BACKUP = params["IMAGE_BACKUP"] ?: getParam("IMAGE_BACKUP", "IMAGE_BACKUP${PILLAR_VERSION}")
+        IMAGE_LOGCOLLECTOR = params["IMAGE_LOGCOLLECTOR"] ?: getParam("IMAGE_LOGCOLLECTOR")
+        IMAGE_PMM_CLIENT = params["IMAGE_PMM_CLIENT"] ?: getParam("IMAGE_PMM_CLIENT")
+        IMAGE_PMM_SERVER = params["IMAGE_PMM_SERVER"] ?: getParam("IMAGE_PMM_SERVER")
         if ("$PLATFORM_VER" == "min".toLowerCase() || "$PLATFORM_VER" == "max".toLowerCase()) {
-            PLATFORM_VER = getParam("AKS_${PLATFORM_VER}")
+            PLATFORM_VER = getParam("PLATFORM_VER", "AKS_${PLATFORM_VER}")
         }
     } else {
         echo "=========================[ Not a release run. Using job params only! ]========================="

--- a/cloud/jenkins/pxc_operator_aks_version.groovy
+++ b/cloud/jenkins/pxc_operator_aks_version.groovy
@@ -148,7 +148,7 @@ void initTests() {
 
             for (int i=0; i<tests.size(); i++) {
                 def testName = tests[i]["name"]
-                def file="$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$PXC_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH"
+                def file="$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$DB_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH"
                 def retFileExists = sh(script: "aws s3api head-object --bucket percona-jenkins-artifactory --key $JOB_NAME/$GIT_SHORT_COMMIT/$file >/dev/null 2>&1", returnStatus: true)
 
                 if (retFileExists == 0) {
@@ -244,7 +244,7 @@ void runTest(Integer TEST_ID) {
                     e2e-tests/$testName/run
                 """
             }
-            pushArtifactFile("$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$PXC_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH")
+            pushArtifactFile("$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$DB_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH")
             tests[TEST_ID]["result"] = "passed"
             return true
         }
@@ -326,7 +326,7 @@ void shutdownCluster(String CLUSTER_SUFFIX) {
 pipeline {
     environment {
         CLEAN_NAMESPACE = 1
-        PXC_TAG = sh(script: "[[ \"$IMAGE_PXC\" ]] && echo $IMAGE_PXC | awk -F':' '{print \$2}' || echo main", , returnStdout: true).trim()
+        DB_TAG = sh(script: "[[ \"$IMAGE_PXC\" ]] && echo $IMAGE_PXC | awk -F':' '{print \$2}' || echo main", , returnStdout: true).trim()
     }
     parameters {
         choice(

--- a/cloud/jenkins/pxc_operator_aks_version.groovy
+++ b/cloud/jenkins/pxc_operator_aks_version.groovy
@@ -224,7 +224,7 @@ void runTest(Integer TEST_ID) {
 
                     export DEBUG_TESTS=1
                     [[ "$CLUSTER_WIDE" == "YES" ]] && export OPERATOR_NS=pxc-operator
-                    export IMAGE=$IMAGE_OPERATOR
+                    [[ "$IMAGE_OPERATOR" ]] && export IMAGE=$IMAGE_OPERATOR || export IMAGE=perconalab/percona-xtradb-cluster-operator:$GIT_BRANCH
                     export IMAGE_PXC=$IMAGE_PXC
                     export IMAGE_PROXY=$IMAGE_PROXY
                     export IMAGE_HAPROXY=$IMAGE_HAPROXY

--- a/cloud/jenkins/pxc_operator_aks_version.groovy
+++ b/cloud/jenkins/pxc_operator_aks_version.groovy
@@ -336,8 +336,8 @@ pipeline {
             name: 'IGNORE_PREVIOUS_RUN'
         )
         choice(
-            choices: 'none\n80\n57',
-            description: 'Can be 80, 57, etc. or none. Implies release run.',
+            choices: 'none\n84\n80\n57',
+            description: 'Implies release run.',
             name: 'PILLAR_VERSION')
         string(
             defaultValue: 'main',
@@ -349,7 +349,7 @@ pipeline {
             name: 'GIT_REPO')
         string(
             defaultValue: 'latest',
-            description: 'AKS kubernetes version',
+            description: 'AKS kubernetes version. If set to min or max, value will be automatically taken from release_versions file.',
             name: 'PLATFORM_VER')
         choice(
             choices: 'YES\nNO',

--- a/cloud/jenkins/pxc_operator_aws_openshift-4.groovy
+++ b/cloud/jenkins/pxc_operator_aws_openshift-4.groovy
@@ -378,8 +378,8 @@ pipeline {
             description: 'Ignore passed tests in previous run (run all)',
             name: 'IGNORE_PREVIOUS_RUN')
         choice(
-            choices: 'none\n80\n57',
-            description: 'Can be 80, 57, etc. or none. Implies release run.',
+            choices: 'none\n84\n80\n57',
+            description: 'Implies release run.',
             name: 'PILLAR_VERSION')
         string(
             defaultValue: 'main',
@@ -391,7 +391,7 @@ pipeline {
             name: 'GIT_REPO')
         string(
             defaultValue: 'latest',
-            description: 'OpenShift kubernetes version',
+            description: 'OpenShift kubernetes version. If set to min or max, value will be automatically taken from release_versions file.',
             name: 'PLATFORM_VER')
         choice(
             choices: 'YES\nNO',

--- a/cloud/jenkins/pxc_operator_aws_openshift-4.groovy
+++ b/cloud/jenkins/pxc_operator_aws_openshift-4.groovy
@@ -375,7 +375,7 @@ pipeline {
             name: 'IGNORE_PREVIOUS_RUN')
         choice(
             choices: 'none\n80\n57',
-            description: 'Can be 08, 57, etc. or none. Implies release run.',
+            description: 'Can be 80, 57, etc. or none. Implies release run.',
             name: 'PILLAR_VERSION')
         string(
             defaultValue: 'main',

--- a/cloud/jenkins/pxc_operator_aws_openshift-4.groovy
+++ b/cloud/jenkins/pxc_operator_aws_openshift-4.groovy
@@ -145,7 +145,7 @@ void initTests() {
 
             for (int i=0; i<tests.size(); i++) {
                 def testName = tests[i]["name"]
-                def file="$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$PXC_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH"
+                def file="$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$DB_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH"
                 def retFileExists = sh(script: "aws s3api head-object --bucket percona-jenkins-artifactory --key $JOB_NAME/$GIT_SHORT_COMMIT/$file >/dev/null 2>&1", returnStatus: true)
 
                 if (retFileExists == 0) {
@@ -285,7 +285,7 @@ void runTest(Integer TEST_ID) {
                     e2e-tests/$testName/run
                 """
             }
-            pushArtifactFile("$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$PXC_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH")
+            pushArtifactFile("$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$DB_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH")
             tests[TEST_ID]["result"] = "passed"
             return true
         }
@@ -369,7 +369,7 @@ void shutdownCluster(String CLUSTER_SUFFIX) {
 pipeline {
     environment {
         CLEAN_NAMESPACE = 1
-        PXC_TAG = sh(script: "[[ \"$IMAGE_PXC\" ]] && echo $IMAGE_PXC | awk -F':' '{print \$2}' || echo main", , returnStdout: true).trim()
+        DB_TAG = sh(script: "[[ \"$IMAGE_PXC\" ]] && echo $IMAGE_PXC | awk -F':' '{print \$2}' || echo main", , returnStdout: true).trim()
     }
     parameters {
         choice(

--- a/cloud/jenkins/pxc_operator_aws_openshift-4.groovy
+++ b/cloud/jenkins/pxc_operator_aws_openshift-4.groovy
@@ -60,6 +60,18 @@ void prepareNode() {
         echo "=========================[ Not a release run. Using job params only! ]========================="
     }
 
+    if ("$PLATFORM_VER" == "latest") {
+        OC_VER = "4.15.25"
+        PLATFORM_VER = sh(script: "curl -s https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/$PLATFORM_VER/release.txt | sed -n 's/^\\s*Version:\\s\\+\\(\\S\\+\\)\\s*\$/\\1/p'", , returnStdout: true).trim()
+    } else {
+        if ("$PLATFORM_VER" <= "4.15.25") {
+            OC_VER="$PLATFORM_VER"
+        } else {
+            OC_VER="4.15.25"
+        }
+    }
+    echo "OC_VER=$OC_VER"
+
     echo "=========================[ Installing tools on the Jenkins executor ]========================="
     sh """
         sudo curl -s -L -o /usr/local/bin/kubectl https://dl.k8s.io/release/\$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl && sudo chmod +x /usr/local/bin/kubectl
@@ -73,18 +85,6 @@ void prepareNode() {
         sudo curl -fsSL https://github.com/mikefarah/yq/releases/download/v4.44.1/yq_linux_amd64 -o /usr/local/bin/yq && sudo chmod +x /usr/local/bin/yq
         sudo curl -fsSL https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux64 -o /usr/local/bin/jq && sudo chmod +x /usr/local/bin/jq
     """
-
-    if ("$PLATFORM_VER" == "latest") {
-        OC_VER = "4.15.25"
-        PLATFORM_VER = sh(script: "curl -s https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/$PLATFORM_VER/release.txt | sed -n 's/^\\s*Version:\\s\\+\\(\\S\\+\\)\\s*\$/\\1/p'", , returnStdout: true).trim()
-    } else {
-        if ("$PLATFORM_VER" <= "4.15.25") {
-            OC_VER="$PLATFORM_VER"
-        } else {
-            OC_VER="4.15.25"
-        }
-    }
-    echo "OC_VER=$OC_VER"
 
     if ("$IMAGE_PXC") {
         release = ("$RELEASE_RUN" == "YES") ? "RELEASE-" : ""

--- a/cloud/jenkins/pxc_operator_aws_openshift-4.groovy
+++ b/cloud/jenkins/pxc_operator_aws_openshift-4.groovy
@@ -263,7 +263,7 @@ void runTest(Integer TEST_ID) {
 
                     export DEBUG_TESTS=1
                     [[ "$CLUSTER_WIDE" == "YES" ]] && export OPERATOR_NS=pxc-operator
-                    export IMAGE=$IMAGE_OPERATOR
+                    [[ "$IMAGE_OPERATOR" ]] && export IMAGE=$IMAGE_OPERATOR || export IMAGE=perconalab/percona-xtradb-cluster-operator:$GIT_BRANCH
                     export IMAGE_PXC=$IMAGE_PXC
                     export IMAGE_PROXY=$IMAGE_PROXY
                     export IMAGE_HAPROXY=$IMAGE_HAPROXY

--- a/cloud/jenkins/pxc_operator_aws_openshift-4.groovy
+++ b/cloud/jenkins/pxc_operator_aws_openshift-4.groovy
@@ -9,8 +9,8 @@ void verifyParams() {
         if (!"$PILLAR_VERSION" && !"$IMAGE_PXC") {
             error("Either PILLAR_VERSION or IMAGE_PXC should be provided for release run!")
         }
-        USED_PLATFORM_VER="$PLATFORM_VER"
     }
+    USED_PLATFORM_VER="$PLATFORM_VER"
 }
 
 String getParam(String PARAM_NAME) {

--- a/cloud/jenkins/pxc_operator_aws_openshift-4.groovy
+++ b/cloud/jenkins/pxc_operator_aws_openshift-4.groovy
@@ -436,7 +436,7 @@ pipeline {
         copyArtifactPermission('pxc-operator-latest-scheduler');
     }
     stages {
-        stage('Prepare node') {
+        stage('Prepare Node') {
             steps {
                 prepareNode()
             }
@@ -446,7 +446,7 @@ pipeline {
                 dockerBuildPush()
             }
         }
-        stage('Init tests') {
+        stage('Init Tests') {
             steps {
                 initTests()
             }

--- a/cloud/jenkins/pxc_operator_aws_openshift-4.groovy
+++ b/cloud/jenkins/pxc_operator_aws_openshift-4.groovy
@@ -1,9 +1,80 @@
 region='eu-west-2'
 tests=[]
 clusters=[]
+release_versions="source/e2e-tests/release_versions"
+
+void verifyParams() {
+    if ("$RELEASE_RUN" == "YES") {
+        echo "=========================[ RELEASE RUN ]========================="
+        if (!"$PILLAR_VERSION" && !"$IMAGE_PXC") {
+            error("Either PILLAR_VERSION or IMAGE_PXC should be provided for release run!")
+        }
+        USED_PLATFORM_VER="$PLATFORM_VER"
+    }
+}
+
+String getParam(String PARAM_NAME) {
+    def param = "${params[PARAM_NAME]}"
+
+    if ("$param" && "$param" != "null" && param != "") {
+        echo "$PARAM_NAME=$param (from job parameters)"
+        return param
+    } else {
+        param = sh(script: "grep -iE '^\\s*$PARAM_NAME=' $release_versions | cut -d = -f 2 | tr -d \'\"\'| tail -1", , returnStdout: true).trim()
+        if ("$param") {
+            echo "$PARAM_NAME=$param (from params file)"
+            return param
+        } else {
+            error("$PARAM_NAME not found in params file $release_versions")
+        }
+    }
+    return param
+}
 
 void prepareNode() {
+    echo "=========================[ Cloning the sources ]========================="
+    git branch: 'master', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
+    sh """
+        # sudo is needed for better node recovery after compilation failure
+        # if building failed on compilation stage directory will have files owned by docker user
+        sudo git config --global --add safe.directory '*'
+        sudo git reset --hard
+        sudo git clean -xdf
+        sudo rm -rf source
+        cloud/local/checkout $GIT_REPO $GIT_BRANCH
+    """
+
+    if ("$RELEASE_RUN" == "YES") {
+        echo "=========================[ Getting parameters for release test ]========================="
+        IMAGE_OPERATOR = getParam("IMAGE_OPERATOR")
+        IMAGE_PXC = getParam("IMAGE_PXC${PILLAR_VERSION}")
+        IMAGE_PROXY = getParam("IMAGE_PROXY")
+        IMAGE_HAPROXY = getParam("IMAGE_HAPROXY")
+        IMAGE_BACKUP = getParam("IMAGE_BACKUP${PILLAR_VERSION}")
+        IMAGE_LOGCOLLECTOR = getParam("IMAGE_LOGCOLLECTOR")
+        IMAGE_PMM_CLIENT = getParam("IMAGE_PMM_CLIENT")
+        IMAGE_PMM_SERVER = getParam("IMAGE_PMM_SERVER")
+        if ("$PLATFORM_VER" == "min".toLowerCase() || "$PLATFORM_VER" == "max".toLowerCase()) {
+            PLATFORM_VER = getParam("OPENSHIFT_${PLATFORM_VER}")
+        }
+    } else {
+        echo "=========================[ Not a release run. Using job params only! ]========================="
+    }
+
     echo "=========================[ Installing tools on the Jenkins executor ]========================="
+    sh """
+        sudo curl -s -L -o /usr/local/bin/kubectl https://dl.k8s.io/release/\$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl && sudo chmod +x /usr/local/bin/kubectl
+        kubectl version --client --output=yaml
+
+        curl -fsSL https://get.helm.sh/helm-v3.12.3-linux-amd64.tar.gz | sudo tar -C /usr/local/bin --strip-components 1 -xzf - linux-amd64/helm
+
+        curl -s -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/$OC_VER/openshift-client-linux.tar.gz | sudo tar -C /usr/local/bin -xzf - oc
+        curl -s -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/$USED_PLATFORM_VER/openshift-install-linux.tar.gz | sudo tar -C /usr/local/bin -xzf - openshift-install
+
+        sudo curl -fsSL https://github.com/mikefarah/yq/releases/download/v4.44.1/yq_linux_amd64 -o /usr/local/bin/yq && sudo chmod +x /usr/local/bin/yq
+        sudo curl -fsSL https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux64 -o /usr/local/bin/jq && sudo chmod +x /usr/local/bin/jq
+    """
+
     if ("$PLATFORM_VER" == "latest") {
         OC_VER = "4.15.25"
         USED_PLATFORM_VER = sh(script: "curl -s https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/$PLATFORM_VER/release.txt | sed -n 's/^\\s*Version:\\s\\+\\(\\S\\+\\)\\s*\$/\\1/p'", , returnStdout: true).trim()
@@ -18,46 +89,16 @@ void prepareNode() {
     echo "USED_PLATFORM_VER=$USED_PLATFORM_VER"
     echo "OC_VER=$OC_VER"
 
-    sh """
-        sudo curl -s -L -o /usr/local/bin/kubectl https://dl.k8s.io/release/\$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl && sudo chmod +x /usr/local/bin/kubectl
-        kubectl version --client --output=yaml
-
-        curl -fsSL https://get.helm.sh/helm-v3.12.3-linux-amd64.tar.gz | sudo tar -C /usr/local/bin --strip-components 1 -xzf - linux-amd64/helm
-
-        curl -s -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/$OC_VER/openshift-client-linux.tar.gz | sudo tar -C /usr/local/bin -xzf - oc
-        curl -s -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/$USED_PLATFORM_VER/openshift-install-linux.tar.gz | sudo tar -C /usr/local/bin -xzf - openshift-install
-
-        sudo curl -fsSL https://github.com/mikefarah/yq/releases/download/v4.44.1/yq_linux_amd64 -o /usr/local/bin/yq && sudo chmod +x /usr/local/bin/yq
-        sudo curl -fsSL https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux64 -o /usr/local/bin/jq && sudo chmod +x /usr/local/bin/jq
-
-        sudo yum install -y https://repo.percona.com/yum/percona-release-latest.noarch.rpm || true
-        sudo percona-release enable-only tools
-        sudo yum install -y percona-xtrabackup-80 | true
-
-        wget https://releases.hashicorp.com/terraform/0.11.14/terraform_0.11.14_linux_amd64.zip
-        unzip -o terraform_0.11.14_linux_amd64.zip
-        sudo mv terraform /usr/local/bin/ && rm terraform_0.11.14_linux_amd64.zip
-    """
-
     if ("$IMAGE_PXC") {
-        currentBuild.description = "$GIT_BRANCH-$USED_PLATFORM_VER-CW_$CLUSTER_WIDE-" + "$IMAGE_PXC".split(":")[1]
+        release = ("$RELEASE_RUN" == "YES") ? "RELEASE-" : ""
+        cw = ("$CLUSTER_WIDE" == "YES") ? "CW" : "NON-CW"
+        currentBuild.description = "$release$GIT_BRANCH-$PLATFORM_VER-$cw-" + "$IMAGE_PXC".split(":")[1]
     }
-    
-    echo "=========================[ Cloning the sources ]========================="
-    git branch: 'master', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
-    sh """
-        # sudo is needed for better node recovery after compilation failure
-        # if building failed on compilation stage directory will have files owned by docker user
-        sudo git config --global --add safe.directory '*'
-        sudo git reset --hard
-        sudo git clean -xdf
-        sudo rm -rf source
-        cloud/local/checkout $GIT_REPO $GIT_BRANCH
-    """
+
     script {
         GIT_SHORT_COMMIT = sh(script: 'git -C source rev-parse --short HEAD', , returnStdout: true).trim()
         CLUSTER_NAME = sh(script: "echo jenkins-ver-pxc-$GIT_SHORT_COMMIT | tr '[:upper:]' '[:lower:]'", , returnStdout: true).trim()
-        PARAMS_HASH = sh(script: "echo $GIT_BRANCH-$GIT_SHORT_COMMIT-$USED_PLATFORM_VER-$CLUSTER_WIDE-$OPERATOR_IMAGE-$IMAGE_PXC-$IMAGE_PROXY-$IMAGE_HAPROXY-$IMAGE_BACKUP-$IMAGE_LOGCOLLECTOR-$IMAGE_PMM_CLIENT-$IMAGE_PMM_SERVER | md5sum | cut -d' ' -f1", , returnStdout: true).trim()
+        PARAMS_HASH = sh(script: "echo $GIT_BRANCH-$GIT_SHORT_COMMIT-$USED_PLATFORM_VER-$CLUSTER_WIDE-$IMAGE_OPERATOR-$IMAGE_PXC-$IMAGE_PROXY-$IMAGE_HAPROXY-$IMAGE_BACKUP-$IMAGE_LOGCOLLECTOR-$IMAGE_PMM_CLIENT-$IMAGE_PMM_SERVER | md5sum | cut -d' ' -f1", , returnStdout: true).trim()
     }
 }
 
@@ -65,7 +106,7 @@ void dockerBuildPush() {
     echo "=========================[ Building and Pushing the operator Docker image ]========================="
     withCredentials([usernamePassword(credentialsId: 'hub.docker.com', passwordVariable: 'PASS', usernameVariable: 'USER')]) {
         sh """
-            if [[ "$OPERATOR_IMAGE" ]]; then
+            if [[ "$IMAGE_OPERATOR" ]]; then
                 echo "SKIP: Build is not needed, operator image was set!"
             else
                 cd source
@@ -123,7 +164,7 @@ void initTests() {
         } else {
             sh """
                 aws s3 rm "s3://percona-jenkins-artifactory/$JOB_NAME/$GIT_SHORT_COMMIT/" --recursive --exclude "*" --include "*-$PARAMS_HASH" || :
-                """
+            """
         }
     }
 
@@ -154,7 +195,7 @@ void clusterRunner(String cluster) {
     }
 }
 
-void createCluster(String CLUSTER_SUFFIX){
+void createCluster(String CLUSTER_SUFFIX) {
     clusters.add("$CLUSTER_SUFFIX")
 
     withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'openshift-cicd'], file(credentialsId: 'aws-openshift-41-key-pub', variable: 'AWS_NODES_KEY_PUB'), file(credentialsId: 'openshift4-secrets', variable: 'OPENSHIFT_CONF_FILE')]) {
@@ -182,7 +223,7 @@ controlPlane:
   replicas: 1
 metadata:
   creationTimestamp: null
-  name: openshift-pxc-jenkins-$CLUSTER_SUFFIX
+  name: $CLUSTER_NAME-$CLUSTER_SUFFIX
 networking:
   clusterNetwork:
   - cidr: 10.128.0.0/14
@@ -221,52 +262,6 @@ EOF
     }
 }
 
-void shutdownCluster(String CLUSTER_SUFFIX) {
-    withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'openshift-cicd'], file(credentialsId: 'aws-openshift-41-key-pub', variable: 'AWS_NODES_KEY_PUB'), file(credentialsId: 'openshift-secret-file', variable: 'OPENSHIFT-CONF-FILE')]) {
-        sshagent(['aws-openshift-41-key']) {
-            sh """
-                export KUBECONFIG=$WORKSPACE/openshift/$CLUSTER_SUFFIX/auth/kubeconfig
-                for namespace in \$(kubectl get namespaces --no-headers | awk '{print \$1}' | grep -vE "^kube-|^openshift" | sed '/-operator/ s/^/1-/' | sort | sed 's/^1-//'); do
-                    kubectl delete deployments --all -n \$namespace --force --grace-period=0 || true
-                    kubectl delete sts --all -n \$namespace --force --grace-period=0 || true
-                    kubectl delete replicasets --all -n \$namespace --force --grace-period=0 || true
-                    kubectl delete poddisruptionbudget --all -n \$namespace --force --grace-period=0 || true
-                    kubectl delete services --all -n \$namespace --force --grace-period=0 || true
-                    kubectl delete pods --all -n \$namespace --force --grace-period=0 || true
-                done
-                kubectl get svc --all-namespaces || true
-
-                /usr/local/bin/openshift-install destroy cluster --dir=openshift/$CLUSTER_SUFFIX || true
-            """
-        }
-    }
-}
-
-void pushArtifactFile(String FILE_NAME) {
-    echo "Push $FILE_NAME file to S3!"
-
-    withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AMI/OVF', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
-        sh """
-            touch $FILE_NAME
-            S3_PATH=s3://percona-jenkins-artifactory/\$JOB_NAME/$GIT_SHORT_COMMIT
-            aws s3 ls \$S3_PATH/$FILE_NAME || :
-            aws s3 cp --quiet $FILE_NAME \$S3_PATH/$FILE_NAME || :
-        """
-    }
-}
-
-TestsReport = '<testsuite name=\\"PXC-OpenShift-version\\">\n'
-void makeReport() {
-    for (int i=0; i<tests.size(); i++) {
-        def testResult = tests[i]["result"]
-        def testTime = tests[i]["time"]
-        def testName = tests[i]["name"]
-
-        TestsReport = TestsReport + '<testcase name=\\"' + testName + '\\" time=\\"' + testTime + '\\"><'+ testResult +'/></testcase>\n'
-    }
-    TestsReport = TestsReport + '</testsuite>\n'
-}
-
 void runTest(Integer TEST_ID) {
     def retryCount = 0
     def testName = tests[TEST_ID]["name"]
@@ -284,7 +279,7 @@ void runTest(Integer TEST_ID) {
 
                     export DEBUG_TESTS=1
                     [[ "$CLUSTER_WIDE" == "YES" ]] && export OPERATOR_NS=pxc-operator
-                    [[ "$OPERATOR_IMAGE" ]] && export IMAGE=$OPERATOR_IMAGE || export IMAGE=perconalab/percona-xtradb-cluster-operator:$GIT_BRANCH
+                    export IMAGE=$IMAGE_OPERATOR
                     export IMAGE_PXC=$IMAGE_PXC
                     export IMAGE_PROXY=$IMAGE_PROXY
                     export IMAGE_HAPROXY=$IMAGE_HAPROXY
@@ -320,9 +315,68 @@ void runTest(Integer TEST_ID) {
     }
 }
 
+void pushArtifactFile(String FILE_NAME) {
+    echo "Push $FILE_NAME file to S3!"
+
+    withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AMI/OVF', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
+        sh """
+            touch $FILE_NAME
+            S3_PATH=s3://percona-jenkins-artifactory/\$JOB_NAME/$GIT_SHORT_COMMIT
+            aws s3 ls \$S3_PATH/$FILE_NAME || :
+            aws s3 cp --quiet $FILE_NAME \$S3_PATH/$FILE_NAME || :
+        """
+    }
+}
+
+void makeReport() {
+    echo "=========================[ Generating Test Report ]========================="
+    testsReport = '<testsuite name="PXC-OpenShift-version">\n'
+    for (int i = 0; i < tests.size(); i ++) {
+        testsReport += '<testcase name="' + tests[i]["name"] + '" time="' + tests[i]["time"] + '"><'+ tests[i]["result"] +'/></testcase>\n'
+    }
+    testsReport += '</testsuite>\n'
+
+    echo "=========================[ Generating Parameters Report ]========================="
+    pipelineParameters = """
+        testsuite name=PXC-OpenShift-version
+        IMAGE_OPERATOR=$IMAGE_OPERATOR
+        IMAGE_PXC=$IMAGE_PXC
+        IMAGE_PROXY=$IMAGE_PROXY
+        IMAGE_HAPROXY=$IMAGE_HAPROXY
+        IMAGE_BACKUP=$IMAGE_BACKUP
+        IMAGE_LOGCOLLECTOR=$IMAGE_LOGCOLLECTOR
+        IMAGE_PMM_CLIENT=$IMAGE_PMM_CLIENT
+        IMAGE_PMM_SERVER=$IMAGE_PMM_SERVER
+        USED_PLATFORM_VER=$USED_PLATFORM_VER
+    """
+
+    writeFile file: "TestsReport.xml", text: testsReport
+    writeFile file: 'PipelineParameters.txt', text: pipelineParameters
+}
+
+void shutdownCluster(String CLUSTER_SUFFIX) {
+    withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'openshift-cicd'], file(credentialsId: 'aws-openshift-41-key-pub', variable: 'AWS_NODES_KEY_PUB'), file(credentialsId: 'openshift-secret-file', variable: 'OPENSHIFT-CONF-FILE')]) {
+        sshagent(['aws-openshift-41-key']) {
+            sh """
+                export KUBECONFIG=$WORKSPACE/openshift/$CLUSTER_SUFFIX/auth/kubeconfig
+                for namespace in \$(kubectl get namespaces --no-headers | awk '{print \$1}' | grep -vE "^kube-|^openshift" | sed '/-operator/ s/^/1-/' | sort | sed 's/^1-//'); do
+                    kubectl delete deployments --all -n \$namespace --force --grace-period=0 || true
+                    kubectl delete sts --all -n \$namespace --force --grace-period=0 || true
+                    kubectl delete replicasets --all -n \$namespace --force --grace-period=0 || true
+                    kubectl delete poddisruptionbudget --all -n \$namespace --force --grace-period=0 || true
+                    kubectl delete services --all -n \$namespace --force --grace-period=0 || true
+                    kubectl delete pods --all -n \$namespace --force --grace-period=0 || true
+                done
+                kubectl get svc --all-namespaces || true
+
+                /usr/local/bin/openshift-install destroy cluster --dir=openshift/$CLUSTER_SUFFIX || true
+            """
+        }
+    }
+}
+
 pipeline {
     environment {
-        TF_IN_AUTOMATION = 'true'
         CLEAN_NAMESPACE = 1
         PXC_TAG = sh(script: "[[ \"$IMAGE_PXC\" ]] && echo $IMAGE_PXC | awk -F':' '{print \$2}' || echo main", , returnStdout: true).trim()
     }
@@ -340,10 +394,16 @@ pipeline {
             description: 'Ignore passed tests in previous run (run all)',
             name: 'IGNORE_PREVIOUS_RUN'
         )
+        choice(
+            choices: 'NO\nYES',
+            description: 'Release run?',
+            name: 'RELEASE_RUN'
+        )
         string(
-            defaultValue: 'latest',
-            description: 'OpenShift version to use',
-            name: 'PLATFORM_VER')
+            defaultValue: '80',
+            description: 'For RELEASE_RUN only. Major version like 80, 57, etc',
+            name: 'PILLAR_VERSION'
+        )
         string(
             defaultValue: 'main',
             description: 'Tag/Branch for percona/percona-xtradb-cluster-operator repository',
@@ -352,14 +412,18 @@ pipeline {
             defaultValue: 'https://github.com/percona/percona-xtradb-cluster-operator',
             description: 'percona-xtradb-cluster-operator repository',
             name: 'GIT_REPO')
+        string(
+            defaultValue: 'latest',
+            description: 'OpenShift kubernetes version',
+            name: 'PLATFORM_VER')
         choice(
             choices: 'YES\nNO',
-            description: 'Run tests with cluster wide',
+            description: 'Run tests in cluster wide mode',
             name: 'CLUSTER_WIDE')
         string(
             defaultValue: '',
             description: 'Operator image: perconalab/percona-xtradb-cluster-operator:main',
-            name: 'OPERATOR_IMAGE')
+            name: 'IMAGE_OPERATOR')
         string(
             defaultValue: '',
             description: 'PXC image: perconalab/percona-xtradb-cluster-operator:main-pxc8.0',
@@ -390,7 +454,7 @@ pipeline {
             name: 'IMAGE_PMM_SERVER')
     }
     agent {
-         label 'docker'
+        label 'docker'
     }
     options {
         buildDiscarder(logRotator(daysToKeepStr: '-1', artifactDaysToKeepStr: '-1', numToKeepStr: '30', artifactNumToKeepStr: '30'))
@@ -401,6 +465,7 @@ pipeline {
     stages {
         stage('Prepare node') {
             steps {
+                verifyParams()
                 prepareNode()
             }
         }
@@ -414,7 +479,7 @@ pipeline {
                 initTests()
             }
         }
-        stage('Run tests') {
+        stage('Run Tests') {
             parallel {
                 stage('cluster1') {
                     options {
@@ -479,11 +544,8 @@ pipeline {
         always {
             echo "CLUSTER ASSIGNMENTS\n" + tests.toString().replace("], ","]\n").replace("]]","]").replaceFirst("\\[","")
             makeReport()
-            sh """
-                echo "$TestsReport" > TestsReport.xml
-            """
             step([$class: 'JUnitResultArchiver', testResults: '*.xml', healthScaleFactor: 1.0])
-            archiveArtifacts '*.xml'
+            archiveArtifacts '*.xml,*.txt'
 
             script {
                 if (currentBuild.result != null && currentBuild.result != 'SUCCESS') {
@@ -495,7 +557,6 @@ pipeline {
 
             sh """
                 sudo docker system prune --volumes -af
-                sudo rm -rf *
             """
             deleteDir()
         }

--- a/cloud/jenkins/pxc_operator_aws_openshift-4.groovy
+++ b/cloud/jenkins/pxc_operator_aws_openshift-4.groovy
@@ -69,6 +69,10 @@ void prepareNode() {
 
         sudo curl -fsSL https://github.com/mikefarah/yq/releases/download/v4.44.1/yq_linux_amd64 -o /usr/local/bin/yq && sudo chmod +x /usr/local/bin/yq
         sudo curl -fsSL https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux64 -o /usr/local/bin/jq && sudo chmod +x /usr/local/bin/jq
+
+        sudo yum install -y https://repo.percona.com/yum/percona-release-latest.noarch.rpm || true
+        sudo percona-release enable-only tools
+        sudo yum install -y percona-xtrabackup-80 | true
     """
 
     if ("$IMAGE_PXC") {

--- a/cloud/jenkins/pxc_operator_aws_openshift-4.groovy
+++ b/cloud/jenkins/pxc_operator_aws_openshift-4.groovy
@@ -10,7 +10,6 @@ void verifyParams() {
             error("Either PILLAR_VERSION or IMAGE_PXC should be provided for release run!")
         }
     }
-    USED_PLATFORM_VER="$PLATFORM_VER"
 }
 
 String getParam(String PARAM_NAME) {
@@ -69,7 +68,7 @@ void prepareNode() {
         curl -fsSL https://get.helm.sh/helm-v3.12.3-linux-amd64.tar.gz | sudo tar -C /usr/local/bin --strip-components 1 -xzf - linux-amd64/helm
 
         curl -s -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/$OC_VER/openshift-client-linux.tar.gz | sudo tar -C /usr/local/bin -xzf - oc
-        curl -s -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/$USED_PLATFORM_VER/openshift-install-linux.tar.gz | sudo tar -C /usr/local/bin -xzf - openshift-install
+        curl -s -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/$PLATFORM_VER/openshift-install-linux.tar.gz | sudo tar -C /usr/local/bin -xzf - openshift-install
 
         sudo curl -fsSL https://github.com/mikefarah/yq/releases/download/v4.44.1/yq_linux_amd64 -o /usr/local/bin/yq && sudo chmod +x /usr/local/bin/yq
         sudo curl -fsSL https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux64 -o /usr/local/bin/jq && sudo chmod +x /usr/local/bin/jq
@@ -77,16 +76,14 @@ void prepareNode() {
 
     if ("$PLATFORM_VER" == "latest") {
         OC_VER = "4.15.25"
-        USED_PLATFORM_VER = sh(script: "curl -s https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/$PLATFORM_VER/release.txt | sed -n 's/^\\s*Version:\\s\\+\\(\\S\\+\\)\\s*\$/\\1/p'", , returnStdout: true).trim()
+        PLATFORM_VER = sh(script: "curl -s https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/$PLATFORM_VER/release.txt | sed -n 's/^\\s*Version:\\s\\+\\(\\S\\+\\)\\s*\$/\\1/p'", , returnStdout: true).trim()
     } else {
-        USED_PLATFORM_VER="$PLATFORM_VER"
         if ("$PLATFORM_VER" <= "4.15.25") {
-            OC_VER="$USED_PLATFORM_VER"
+            OC_VER="$PLATFORM_VER"
         } else {
             OC_VER="4.15.25"
         }
     }
-    echo "USED_PLATFORM_VER=$USED_PLATFORM_VER"
     echo "OC_VER=$OC_VER"
 
     if ("$IMAGE_PXC") {
@@ -98,7 +95,7 @@ void prepareNode() {
     script {
         GIT_SHORT_COMMIT = sh(script: 'git -C source rev-parse --short HEAD', , returnStdout: true).trim()
         CLUSTER_NAME = sh(script: "echo jenkins-ver-pxc-$GIT_SHORT_COMMIT | tr '[:upper:]' '[:lower:]'", , returnStdout: true).trim()
-        PARAMS_HASH = sh(script: "echo $GIT_BRANCH-$GIT_SHORT_COMMIT-$USED_PLATFORM_VER-$CLUSTER_WIDE-$IMAGE_OPERATOR-$IMAGE_PXC-$IMAGE_PROXY-$IMAGE_HAPROXY-$IMAGE_BACKUP-$IMAGE_LOGCOLLECTOR-$IMAGE_PMM_CLIENT-$IMAGE_PMM_SERVER | md5sum | cut -d' ' -f1", , returnStdout: true).trim()
+        PARAMS_HASH = sh(script: "echo $GIT_BRANCH-$GIT_SHORT_COMMIT-$PLATFORM_VER-$CLUSTER_WIDE-$IMAGE_OPERATOR-$IMAGE_PXC-$IMAGE_PROXY-$IMAGE_HAPROXY-$IMAGE_BACKUP-$IMAGE_LOGCOLLECTOR-$IMAGE_PMM_CLIENT-$IMAGE_PMM_SERVER | md5sum | cut -d' ' -f1", , returnStdout: true).trim()
     }
 }
 
@@ -154,7 +151,7 @@ void initTests() {
 
             for (int i=0; i<tests.size(); i++) {
                 def testName = tests[i]["name"]
-                def file="$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$USED_PLATFORM_VER-$PXC_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH"
+                def file="$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$PXC_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH"
                 def retFileExists = sh(script: "aws s3api head-object --bucket percona-jenkins-artifactory --key $JOB_NAME/$GIT_SHORT_COMMIT/$file >/dev/null 2>&1", returnStatus: true)
 
                 if (retFileExists == 0) {
@@ -294,7 +291,7 @@ void runTest(Integer TEST_ID) {
                     e2e-tests/$testName/run
                 """
             }
-            pushArtifactFile("$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$USED_PLATFORM_VER-$PXC_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH")
+            pushArtifactFile("$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$PXC_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH")
             tests[TEST_ID]["result"] = "passed"
             return true
         }
@@ -347,7 +344,7 @@ void makeReport() {
         IMAGE_LOGCOLLECTOR=$IMAGE_LOGCOLLECTOR
         IMAGE_PMM_CLIENT=$IMAGE_PMM_CLIENT
         IMAGE_PMM_SERVER=$IMAGE_PMM_SERVER
-        USED_PLATFORM_VER=$USED_PLATFORM_VER
+        PLATFORM_VER=$PLATFORM_VER
     """
 
     writeFile file: "TestsReport.xml", text: testsReport

--- a/cloud/jenkins/pxc_operator_aws_openshift-4.groovy
+++ b/cloud/jenkins/pxc_operator_aws_openshift-4.groovy
@@ -12,20 +12,14 @@ void verifyParams() {
     }
 }
 
-String getParam(String PARAM_NAME) {
-    def param = "${params[PARAM_NAME]}"
+String getParam(String paramName, String keyName = null) {
+    keyName = keyName ?: paramName
 
-    if ("$param" && "$param" != "null" && param != "") {
-        echo "$PARAM_NAME=$param (from job parameters)"
-        return param
+    param = sh(script: "grep -iE '^\\s*$keyName=' $release_versions | cut -d = -f 2 | tr -d \'\"\'| tail -1", , returnStdout: true).trim()
+    if ("$param") {
+        echo "$paramName=$param (from params file)"
     } else {
-        param = sh(script: "grep -iE '^\\s*$PARAM_NAME=' $release_versions | cut -d = -f 2 | tr -d \'\"\'| tail -1", , returnStdout: true).trim()
-        if ("$param") {
-            echo "$PARAM_NAME=$param (from params file)"
-            return param
-        } else {
-            error("$PARAM_NAME not found in params file $release_versions")
-        }
+        error("$keyName not found in params file $release_versions")
     }
     return param
 }
@@ -45,16 +39,16 @@ void prepareNode() {
 
     if ("$RELEASE_RUN" == "YES") {
         echo "=========================[ Getting parameters for release test ]========================="
-        IMAGE_OPERATOR = getParam("IMAGE_OPERATOR")
-        IMAGE_PXC = getParam("IMAGE_PXC${PILLAR_VERSION}")
-        IMAGE_PROXY = getParam("IMAGE_PROXY")
-        IMAGE_HAPROXY = getParam("IMAGE_HAPROXY")
-        IMAGE_BACKUP = getParam("IMAGE_BACKUP${PILLAR_VERSION}")
-        IMAGE_LOGCOLLECTOR = getParam("IMAGE_LOGCOLLECTOR")
-        IMAGE_PMM_CLIENT = getParam("IMAGE_PMM_CLIENT")
-        IMAGE_PMM_SERVER = getParam("IMAGE_PMM_SERVER")
+        IMAGE_OPERATOR = params["IMAGE_OPERATOR"] ?: getParam("IMAGE_OPERATOR")
+        IMAGE_PXC = params["IMAGE_PXC"] ?: getParam("IMAGE_PXC", "IMAGE_PXC${PILLAR_VERSION}")
+        IMAGE_PROXY = params["IMAGE_PROXY"] ?: getParam("IMAGE_PROXY")
+        IMAGE_HAPROXY = params["IMAGE_HAPROXY"] ?: getParam("IMAGE_HAPROXY")
+        IMAGE_BACKUP = params["IMAGE_BACKUP"] ?: getParam("IMAGE_BACKUP", "IMAGE_BACKUP${PILLAR_VERSION}")
+        IMAGE_LOGCOLLECTOR = params["IMAGE_LOGCOLLECTOR"] ?: getParam("IMAGE_LOGCOLLECTOR")
+        IMAGE_PMM_CLIENT = params["IMAGE_PMM_CLIENT"] ?: getParam("IMAGE_PMM_CLIENT")
+        IMAGE_PMM_SERVER = params["IMAGE_PMM_SERVER"] ?: getParam("IMAGE_PMM_SERVER")
         if ("$PLATFORM_VER" == "min".toLowerCase() || "$PLATFORM_VER" == "max".toLowerCase()) {
-            PLATFORM_VER = getParam("OPENSHIFT_${PLATFORM_VER}")
+            PLATFORM_VER = getParam("PLATFORM_VER", "OPENSHIFT_${PLATFORM_VER}")
         }
     } else {
         echo "=========================[ Not a release run. Using job params only! ]========================="

--- a/cloud/jenkins/pxc_operator_aws_openshift-4.groovy
+++ b/cloud/jenkins/pxc_operator_aws_openshift-4.groovy
@@ -3,15 +3,6 @@ tests=[]
 clusters=[]
 release_versions="source/e2e-tests/release_versions"
 
-void verifyParams() {
-    if ("$RELEASE_RUN" == "YES") {
-        echo "=========================[ RELEASE RUN ]========================="
-        if (!"$PILLAR_VERSION" && !"$IMAGE_PXC") {
-            error("Either PILLAR_VERSION or IMAGE_PXC should be provided for release run!")
-        }
-    }
-}
-
 String getParam(String paramName, String keyName = null) {
     keyName = keyName ?: paramName
 
@@ -37,16 +28,16 @@ void prepareNode() {
         cloud/local/checkout $GIT_REPO $GIT_BRANCH
     """
 
-    if ("$RELEASE_RUN" == "YES") {
+    if ("$PILLAR_VERSION" != "none") {
         echo "=========================[ Getting parameters for release test ]========================="
-        IMAGE_OPERATOR = params["IMAGE_OPERATOR"] ?: getParam("IMAGE_OPERATOR")
-        IMAGE_PXC = params["IMAGE_PXC"] ?: getParam("IMAGE_PXC", "IMAGE_PXC${PILLAR_VERSION}")
-        IMAGE_PROXY = params["IMAGE_PROXY"] ?: getParam("IMAGE_PROXY")
-        IMAGE_HAPROXY = params["IMAGE_HAPROXY"] ?: getParam("IMAGE_HAPROXY")
-        IMAGE_BACKUP = params["IMAGE_BACKUP"] ?: getParam("IMAGE_BACKUP", "IMAGE_BACKUP${PILLAR_VERSION}")
-        IMAGE_LOGCOLLECTOR = params["IMAGE_LOGCOLLECTOR"] ?: getParam("IMAGE_LOGCOLLECTOR")
-        IMAGE_PMM_CLIENT = params["IMAGE_PMM_CLIENT"] ?: getParam("IMAGE_PMM_CLIENT")
-        IMAGE_PMM_SERVER = params["IMAGE_PMM_SERVER"] ?: getParam("IMAGE_PMM_SERVER")
+        IMAGE_OPERATOR = IMAGE_OPERATOR ?: getParam("IMAGE_OPERATOR")
+        IMAGE_PXC = IMAGE_PXC ?: getParam("IMAGE_PXC", "IMAGE_PXC${PILLAR_VERSION}")
+        IMAGE_PROXY = IMAGE_PROXY ?: getParam("IMAGE_PROXY")
+        IMAGE_HAPROXY = IMAGE_HAPROXY ?: getParam("IMAGE_HAPROXY")
+        IMAGE_BACKUP = IMAGE_BACKUP ?: getParam("IMAGE_BACKUP", "IMAGE_BACKUP${PILLAR_VERSION}")
+        IMAGE_LOGCOLLECTOR = IMAGE_LOGCOLLECTOR ?: getParam("IMAGE_LOGCOLLECTOR")
+        IMAGE_PMM_CLIENT = IMAGE_PMM_CLIENT ?: getParam("IMAGE_PMM_CLIENT")
+        IMAGE_PMM_SERVER = IMAGE_PMM_SERVER ?: getParam("IMAGE_PMM_SERVER")
         if ("$PLATFORM_VER" == "min".toLowerCase() || "$PLATFORM_VER" == "max".toLowerCase()) {
             PLATFORM_VER = getParam("PLATFORM_VER", "OPENSHIFT_${PLATFORM_VER}")
         }
@@ -81,16 +72,14 @@ void prepareNode() {
     """
 
     if ("$IMAGE_PXC") {
-        release = ("$RELEASE_RUN" == "YES") ? "RELEASE-" : ""
+        release = ("$PILLAR_VERSION" != "none") ? "RELEASE-" : ""
         cw = ("$CLUSTER_WIDE" == "YES") ? "CW" : "NON-CW"
         currentBuild.description = "$release$GIT_BRANCH-$PLATFORM_VER-$cw-" + "$IMAGE_PXC".split(":")[1]
     }
 
-    script {
-        GIT_SHORT_COMMIT = sh(script: 'git -C source rev-parse --short HEAD', , returnStdout: true).trim()
-        CLUSTER_NAME = sh(script: "echo jenkins-ver-pxc-$GIT_SHORT_COMMIT | tr '[:upper:]' '[:lower:]'", , returnStdout: true).trim()
-        PARAMS_HASH = sh(script: "echo $GIT_BRANCH-$GIT_SHORT_COMMIT-$PLATFORM_VER-$CLUSTER_WIDE-$IMAGE_OPERATOR-$IMAGE_PXC-$IMAGE_PROXY-$IMAGE_HAPROXY-$IMAGE_BACKUP-$IMAGE_LOGCOLLECTOR-$IMAGE_PMM_CLIENT-$IMAGE_PMM_SERVER | md5sum | cut -d' ' -f1", , returnStdout: true).trim()
-    }
+    GIT_SHORT_COMMIT = sh(script: 'git -C source rev-parse --short HEAD', , returnStdout: true).trim()
+    CLUSTER_NAME = sh(script: "echo jenkins-ver-pxc-$GIT_SHORT_COMMIT | tr '[:upper:]' '[:lower:]'", , returnStdout: true).trim()
+    PARAMS_HASH = sh(script: "echo $GIT_BRANCH-$GIT_SHORT_COMMIT-$PLATFORM_VER-$CLUSTER_WIDE-$IMAGE_OPERATOR-$IMAGE_PXC-$IMAGE_PROXY-$IMAGE_HAPROXY-$IMAGE_BACKUP-$IMAGE_LOGCOLLECTOR-$IMAGE_PMM_CLIENT-$IMAGE_PMM_SERVER | md5sum | cut -d' ' -f1", , returnStdout: true).trim()
 }
 
 void dockerBuildPush() {
@@ -386,13 +375,10 @@ pipeline {
             name: 'IGNORE_PREVIOUS_RUN'
         )
         choice(
-            choices: 'NO\nYES',
-            description: 'Release run?',
-            name: 'RELEASE_RUN'
         )
-        string(
-            defaultValue: '80',
-            description: 'For RELEASE_RUN only. Major version like 80, 57, etc',
+        choice(
+            choices: 'none\n80\n57',
+            description: 'Can be 08, 57, etc. or none. Implies release run.',
             name: 'PILLAR_VERSION'
         )
         string(
@@ -456,7 +442,6 @@ pipeline {
     stages {
         stage('Prepare node') {
             steps {
-                verifyParams()
                 prepareNode()
             }
         }

--- a/cloud/jenkins/pxc_operator_aws_openshift-4.groovy
+++ b/cloud/jenkins/pxc_operator_aws_openshift-4.groovy
@@ -372,15 +372,11 @@ pipeline {
         choice(
             choices: 'NO\nYES',
             description: 'Ignore passed tests in previous run (run all)',
-            name: 'IGNORE_PREVIOUS_RUN'
-        )
-        choice(
-        )
+            name: 'IGNORE_PREVIOUS_RUN')
         choice(
             choices: 'none\n80\n57',
             description: 'Can be 08, 57, etc. or none. Implies release run.',
-            name: 'PILLAR_VERSION'
-        )
+            name: 'PILLAR_VERSION')
         string(
             defaultValue: 'main',
             description: 'Tag/Branch for percona/percona-xtradb-cluster-operator repository',

--- a/cloud/jenkins/pxc_operator_aws_openshift_latest.groovy
+++ b/cloud/jenkins/pxc_operator_aws_openshift_latest.groovy
@@ -378,8 +378,8 @@ pipeline {
             description: 'Ignore passed tests in previous run (run all)',
             name: 'IGNORE_PREVIOUS_RUN')
         choice(
-            choices: 'none\n80\n57',
-            description: 'Can be 80, 57, etc. or none. Implies release run.',
+            choices: 'none\n84\n80\n57',
+            description: 'Implies release run.',
             name: 'PILLAR_VERSION')
         string(
             defaultValue: 'main',
@@ -391,7 +391,7 @@ pipeline {
             name: 'GIT_REPO')
         string(
             defaultValue: 'latest',
-            description: 'OpenShift kubernetes version',
+            description: 'OpenShift kubernetes version. If set to min or max, value will be automatically taken from release_versions file.',
             name: 'PLATFORM_VER')
         choice(
             choices: 'YES\nNO',

--- a/cloud/jenkins/pxc_operator_aws_openshift_latest.groovy
+++ b/cloud/jenkins/pxc_operator_aws_openshift_latest.groovy
@@ -375,7 +375,7 @@ pipeline {
             name: 'IGNORE_PREVIOUS_RUN')
         choice(
             choices: 'none\n80\n57',
-            description: 'Can be 08, 57, etc. or none. Implies release run.',
+            description: 'Can be 80, 57, etc. or none. Implies release run.',
             name: 'PILLAR_VERSION')
         string(
             defaultValue: 'main',

--- a/cloud/jenkins/pxc_operator_aws_openshift_latest.groovy
+++ b/cloud/jenkins/pxc_operator_aws_openshift_latest.groovy
@@ -145,7 +145,7 @@ void initTests() {
 
             for (int i=0; i<tests.size(); i++) {
                 def testName = tests[i]["name"]
-                def file="$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$PXC_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH"
+                def file="$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$DB_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH"
                 def retFileExists = sh(script: "aws s3api head-object --bucket percona-jenkins-artifactory --key $JOB_NAME/$GIT_SHORT_COMMIT/$file >/dev/null 2>&1", returnStatus: true)
 
                 if (retFileExists == 0) {
@@ -285,7 +285,7 @@ void runTest(Integer TEST_ID) {
                     e2e-tests/$testName/run
                 """
             }
-            pushArtifactFile("$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$PXC_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH")
+            pushArtifactFile("$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$DB_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH")
             tests[TEST_ID]["result"] = "passed"
             return true
         }
@@ -369,7 +369,7 @@ void shutdownCluster(String CLUSTER_SUFFIX) {
 pipeline {
     environment {
         CLEAN_NAMESPACE = 1
-        PXC_TAG = sh(script: "[[ \"$IMAGE_PXC\" ]] && echo $IMAGE_PXC | awk -F':' '{print \$2}' || echo main", , returnStdout: true).trim()
+        DB_TAG = sh(script: "[[ \"$IMAGE_PXC\" ]] && echo $IMAGE_PXC | awk -F':' '{print \$2}' || echo main", , returnStdout: true).trim()
     }
     parameters {
         choice(

--- a/cloud/jenkins/pxc_operator_aws_openshift_latest.groovy
+++ b/cloud/jenkins/pxc_operator_aws_openshift_latest.groovy
@@ -60,6 +60,18 @@ void prepareNode() {
         echo "=========================[ Not a release run. Using job params only! ]========================="
     }
 
+    if ("$PLATFORM_VER" == "latest") {
+        OC_VER = "4.15.25"
+        PLATFORM_VER = sh(script: "curl -s https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/$PLATFORM_VER/release.txt | sed -n 's/^\\s*Version:\\s\\+\\(\\S\\+\\)\\s*\$/\\1/p'", , returnStdout: true).trim()
+    } else {
+        if ("$PLATFORM_VER" <= "4.15.25") {
+            OC_VER="$PLATFORM_VER"
+        } else {
+            OC_VER="4.15.25"
+        }
+    }
+    echo "OC_VER=$OC_VER"
+
     echo "=========================[ Installing tools on the Jenkins executor ]========================="
     sh """
         sudo curl -s -L -o /usr/local/bin/kubectl https://dl.k8s.io/release/\$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl && sudo chmod +x /usr/local/bin/kubectl
@@ -73,18 +85,6 @@ void prepareNode() {
         sudo curl -fsSL https://github.com/mikefarah/yq/releases/download/v4.44.1/yq_linux_amd64 -o /usr/local/bin/yq && sudo chmod +x /usr/local/bin/yq
         sudo curl -fsSL https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux64 -o /usr/local/bin/jq && sudo chmod +x /usr/local/bin/jq
     """
-
-    if ("$PLATFORM_VER" == "latest") {
-        OC_VER = "4.15.25"
-        PLATFORM_VER = sh(script: "curl -s https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/$PLATFORM_VER/release.txt | sed -n 's/^\\s*Version:\\s\\+\\(\\S\\+\\)\\s*\$/\\1/p'", , returnStdout: true).trim()
-    } else {
-        if ("$PLATFORM_VER" <= "4.15.25") {
-            OC_VER="$PLATFORM_VER"
-        } else {
-            OC_VER="4.15.25"
-        }
-    }
-    echo "OC_VER=$OC_VER"
 
     if ("$IMAGE_PXC") {
         release = ("$RELEASE_RUN" == "YES") ? "RELEASE-" : ""

--- a/cloud/jenkins/pxc_operator_aws_openshift_latest.groovy
+++ b/cloud/jenkins/pxc_operator_aws_openshift_latest.groovy
@@ -263,7 +263,7 @@ void runTest(Integer TEST_ID) {
 
                     export DEBUG_TESTS=1
                     [[ "$CLUSTER_WIDE" == "YES" ]] && export OPERATOR_NS=pxc-operator
-                    export IMAGE=$IMAGE_OPERATOR
+                    [[ "$IMAGE_OPERATOR" ]] && export IMAGE=$IMAGE_OPERATOR || export IMAGE=perconalab/percona-xtradb-cluster-operator:$GIT_BRANCH
                     export IMAGE_PXC=$IMAGE_PXC
                     export IMAGE_PROXY=$IMAGE_PROXY
                     export IMAGE_HAPROXY=$IMAGE_HAPROXY

--- a/cloud/jenkins/pxc_operator_aws_openshift_latest.groovy
+++ b/cloud/jenkins/pxc_operator_aws_openshift_latest.groovy
@@ -1,9 +1,80 @@
 region='eu-west-2'
 tests=[]
 clusters=[]
+release_versions="source/e2e-tests/release_versions"
+
+void verifyParams() {
+    if ("$RELEASE_RUN" == "YES") {
+        echo "=========================[ RELEASE RUN ]========================="
+        if (!"$PILLAR_VERSION" && !"$IMAGE_PXC") {
+            error("Either PILLAR_VERSION or IMAGE_PXC should be provided for release run!")
+        }
+        USED_PLATFORM_VER="$PLATFORM_VER"
+    }
+}
+
+String getParam(String PARAM_NAME) {
+    def param = "${params[PARAM_NAME]}"
+
+    if ("$param" && "$param" != "null" && param != "") {
+        echo "$PARAM_NAME=$param (from job parameters)"
+        return param
+    } else {
+        param = sh(script: "grep -iE '^\\s*$PARAM_NAME=' $release_versions | cut -d = -f 2 | tr -d \'\"\'| tail -1", , returnStdout: true).trim()
+        if ("$param") {
+            echo "$PARAM_NAME=$param (from params file)"
+            return param
+        } else {
+            error("$PARAM_NAME not found in params file $release_versions")
+        }
+    }
+    return param
+}
 
 void prepareNode() {
+    echo "=========================[ Cloning the sources ]========================="
+    git branch: 'master', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
+    sh """
+        # sudo is needed for better node recovery after compilation failure
+        # if building failed on compilation stage directory will have files owned by docker user
+        sudo git config --global --add safe.directory '*'
+        sudo git reset --hard
+        sudo git clean -xdf
+        sudo rm -rf source
+        cloud/local/checkout $GIT_REPO $GIT_BRANCH
+    """
+
+    if ("$RELEASE_RUN" == "YES") {
+        echo "=========================[ Getting parameters for release test ]========================="
+        IMAGE_OPERATOR = getParam("IMAGE_OPERATOR")
+        IMAGE_PXC = getParam("IMAGE_PXC${PILLAR_VERSION}")
+        IMAGE_PROXY = getParam("IMAGE_PROXY")
+        IMAGE_HAPROXY = getParam("IMAGE_HAPROXY")
+        IMAGE_BACKUP = getParam("IMAGE_BACKUP${PILLAR_VERSION}")
+        IMAGE_LOGCOLLECTOR = getParam("IMAGE_LOGCOLLECTOR")
+        IMAGE_PMM_CLIENT = getParam("IMAGE_PMM_CLIENT")
+        IMAGE_PMM_SERVER = getParam("IMAGE_PMM_SERVER")
+        if ("$PLATFORM_VER" == "min".toLowerCase() || "$PLATFORM_VER" == "max".toLowerCase()) {
+            PLATFORM_VER = getParam("OPENSHIFT_${PLATFORM_VER}")
+        }
+    } else {
+        echo "=========================[ Not a release run. Using job params only! ]========================="
+    }
+
     echo "=========================[ Installing tools on the Jenkins executor ]========================="
+    sh """
+        sudo curl -s -L -o /usr/local/bin/kubectl https://dl.k8s.io/release/\$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl && sudo chmod +x /usr/local/bin/kubectl
+        kubectl version --client --output=yaml
+
+        curl -fsSL https://get.helm.sh/helm-v3.12.3-linux-amd64.tar.gz | sudo tar -C /usr/local/bin --strip-components 1 -xzf - linux-amd64/helm
+
+        curl -s -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/$OC_VER/openshift-client-linux.tar.gz | sudo tar -C /usr/local/bin -xzf - oc
+        curl -s -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/$USED_PLATFORM_VER/openshift-install-linux.tar.gz | sudo tar -C /usr/local/bin -xzf - openshift-install
+
+        sudo curl -fsSL https://github.com/mikefarah/yq/releases/download/v4.44.1/yq_linux_amd64 -o /usr/local/bin/yq && sudo chmod +x /usr/local/bin/yq
+        sudo curl -fsSL https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux64 -o /usr/local/bin/jq && sudo chmod +x /usr/local/bin/jq
+    """
+
     if ("$PLATFORM_VER" == "latest") {
         OC_VER = "4.15.25"
         USED_PLATFORM_VER = sh(script: "curl -s https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/$PLATFORM_VER/release.txt | sed -n 's/^\\s*Version:\\s\\+\\(\\S\\+\\)\\s*\$/\\1/p'", , returnStdout: true).trim()
@@ -18,46 +89,16 @@ void prepareNode() {
     echo "USED_PLATFORM_VER=$USED_PLATFORM_VER"
     echo "OC_VER=$OC_VER"
 
-    sh """
-        sudo curl -s -L -o /usr/local/bin/kubectl https://dl.k8s.io/release/\$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl && sudo chmod +x /usr/local/bin/kubectl
-        kubectl version --client --output=yaml
-
-        curl -fsSL https://get.helm.sh/helm-v3.12.3-linux-amd64.tar.gz | sudo tar -C /usr/local/bin --strip-components 1 -xzf - linux-amd64/helm
-
-        curl -s -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/$OC_VER/openshift-client-linux.tar.gz | sudo tar -C /usr/local/bin -xzf - oc
-        curl -s -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/$USED_PLATFORM_VER/openshift-install-linux.tar.gz | sudo tar -C /usr/local/bin -xzf - openshift-install
-
-        sudo curl -fsSL https://github.com/mikefarah/yq/releases/download/v4.44.1/yq_linux_amd64 -o /usr/local/bin/yq && sudo chmod +x /usr/local/bin/yq
-        sudo curl -fsSL https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux64 -o /usr/local/bin/jq && sudo chmod +x /usr/local/bin/jq
-
-        sudo yum install -y https://repo.percona.com/yum/percona-release-latest.noarch.rpm || true
-        sudo percona-release enable-only tools
-        sudo yum install -y percona-xtrabackup-80 | true
-
-        wget https://releases.hashicorp.com/terraform/0.11.14/terraform_0.11.14_linux_amd64.zip
-        unzip -o terraform_0.11.14_linux_amd64.zip
-        sudo mv terraform /usr/local/bin/ && rm terraform_0.11.14_linux_amd64.zip
-    """
-
     if ("$IMAGE_PXC") {
-        currentBuild.description = "$GIT_BRANCH-$USED_PLATFORM_VER-CW_$CLUSTER_WIDE-" + "$IMAGE_PXC".split(":")[1]
+        release = ("$RELEASE_RUN" == "YES") ? "RELEASE-" : ""
+        cw = ("$CLUSTER_WIDE" == "YES") ? "CW" : "NON-CW"
+        currentBuild.description = "$release$GIT_BRANCH-$PLATFORM_VER-$cw-" + "$IMAGE_PXC".split(":")[1]
     }
 
-    echo "=========================[ Cloning the sources ]========================="
-    git branch: 'master', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
-    sh """
-        # sudo is needed for better node recovery after compilation failure
-        # if building failed on compilation stage directory will have files owned by docker user
-        sudo git config --global --add safe.directory '*'
-        sudo git reset --hard
-        sudo git clean -xdf
-        sudo rm -rf source
-        cloud/local/checkout $GIT_REPO $GIT_BRANCH
-    """
     script {
         GIT_SHORT_COMMIT = sh(script: 'git -C source rev-parse --short HEAD', , returnStdout: true).trim()
         CLUSTER_NAME = sh(script: "echo jenkins-lat-pxc-$GIT_SHORT_COMMIT | tr '[:upper:]' '[:lower:]'", , returnStdout: true).trim()
-        PARAMS_HASH = sh(script: "echo $GIT_BRANCH-$GIT_SHORT_COMMIT-$USED_PLATFORM_VER-$CLUSTER_WIDE-$OPERATOR_IMAGE-$IMAGE_PXC-$IMAGE_PROXY-$IMAGE_HAPROXY-$IMAGE_BACKUP-$IMAGE_LOGCOLLECTOR-$IMAGE_PMM_CLIENT-$IMAGE_PMM_SERVER | md5sum | cut -d' ' -f1", , returnStdout: true).trim()
+        PARAMS_HASH = sh(script: "echo $GIT_BRANCH-$GIT_SHORT_COMMIT-$USED_PLATFORM_VER-$CLUSTER_WIDE-$IMAGE_OPERATOR-$IMAGE_PXC-$IMAGE_PROXY-$IMAGE_HAPROXY-$IMAGE_BACKUP-$IMAGE_LOGCOLLECTOR-$IMAGE_PMM_CLIENT-$IMAGE_PMM_SERVER | md5sum | cut -d' ' -f1", , returnStdout: true).trim()
     }
 }
 
@@ -65,7 +106,7 @@ void dockerBuildPush() {
     echo "=========================[ Building and Pushing the operator Docker image ]========================="
     withCredentials([usernamePassword(credentialsId: 'hub.docker.com', passwordVariable: 'PASS', usernameVariable: 'USER')]) {
         sh """
-            if [[ "$OPERATOR_IMAGE" ]]; then
+            if [[ "$IMAGE_OPERATOR" ]]; then
                 echo "SKIP: Build is not needed, operator image was set!"
             else
                 cd source
@@ -123,7 +164,7 @@ void initTests() {
         } else {
             sh """
                 aws s3 rm "s3://percona-jenkins-artifactory/$JOB_NAME/$GIT_SHORT_COMMIT/" --recursive --exclude "*" --include "*-$PARAMS_HASH" || :
-                """
+            """
         }
     }
 
@@ -154,7 +195,7 @@ void clusterRunner(String cluster) {
     }
 }
 
-void createCluster(String CLUSTER_SUFFIX){
+void createCluster(String CLUSTER_SUFFIX) {
     clusters.add("$CLUSTER_SUFFIX")
 
     withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'openshift-cicd'], file(credentialsId: 'aws-openshift-41-key-pub', variable: 'AWS_NODES_KEY_PUB'), file(credentialsId: 'openshift4-secrets', variable: 'OPENSHIFT_CONF_FILE')]) {
@@ -182,7 +223,7 @@ controlPlane:
   replicas: 1
 metadata:
   creationTimestamp: null
-  name: openshift-lat-pxc-jenkins-$CLUSTER_SUFFIX
+  name: $CLUSTER_NAME-$CLUSTER_SUFFIX
 networking:
   clusterNetwork:
   - cidr: 10.128.0.0/14
@@ -221,52 +262,6 @@ EOF
     }
 }
 
-void shutdownCluster(String CLUSTER_SUFFIX) {
-    withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'openshift-cicd'], file(credentialsId: 'aws-openshift-41-key-pub', variable: 'AWS_NODES_KEY_PUB'), file(credentialsId: 'openshift-secret-file', variable: 'OPENSHIFT-CONF-FILE')]) {
-        sshagent(['aws-openshift-41-key']) {
-            sh """
-                export KUBECONFIG=$WORKSPACE/openshift/$CLUSTER_SUFFIX/auth/kubeconfig
-                for namespace in \$(kubectl get namespaces --no-headers | awk '{print \$1}' | grep -vE "^kube-|^openshift" | sed '/-operator/ s/^/1-/' | sort | sed 's/^1-//'); do
-                    kubectl delete deployments --all -n \$namespace --force --grace-period=0 || true
-                    kubectl delete sts --all -n \$namespace --force --grace-period=0 || true
-                    kubectl delete replicasets --all -n \$namespace --force --grace-period=0 || true
-                    kubectl delete poddisruptionbudget --all -n \$namespace --force --grace-period=0 || true
-                    kubectl delete services --all -n \$namespace --force --grace-period=0 || true
-                    kubectl delete pods --all -n \$namespace --force --grace-period=0 || true
-                done
-                kubectl get svc --all-namespaces || true
-
-                /usr/local/bin/openshift-install destroy cluster --dir=openshift/$CLUSTER_SUFFIX || true
-            """
-        }
-    }
-}
-
-void pushArtifactFile(String FILE_NAME) {
-    echo "Push $FILE_NAME file to S3!"
-
-    withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AMI/OVF', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
-        sh """
-            touch $FILE_NAME
-            S3_PATH=s3://percona-jenkins-artifactory/\$JOB_NAME/$GIT_SHORT_COMMIT
-            aws s3 ls \$S3_PATH/$FILE_NAME || :
-            aws s3 cp --quiet $FILE_NAME \$S3_PATH/$FILE_NAME || :
-        """
-    }
-}
-
-TestsReport = '<testsuite name=\\"PXC-OpenShift-latest\\">\n'
-void makeReport() {
-    for (int i=0; i<tests.size(); i++) {
-        def testResult = tests[i]["result"]
-        def testTime = tests[i]["time"]
-        def testName = tests[i]["name"]
-
-        TestsReport = TestsReport + '<testcase name=\\"' + testName + '\\" time=\\"' + testTime + '\\"><'+ testResult +'/></testcase>\n'
-    }
-    TestsReport = TestsReport + '</testsuite>\n'
-}
-
 void runTest(Integer TEST_ID) {
     def retryCount = 0
     def testName = tests[TEST_ID]["name"]
@@ -284,7 +279,7 @@ void runTest(Integer TEST_ID) {
 
                     export DEBUG_TESTS=1
                     [[ "$CLUSTER_WIDE" == "YES" ]] && export OPERATOR_NS=pxc-operator
-                    [[ "$OPERATOR_IMAGE" ]] && export IMAGE=$OPERATOR_IMAGE || export IMAGE=perconalab/percona-xtradb-cluster-operator:$GIT_BRANCH
+                    export IMAGE=$IMAGE_OPERATOR
                     export IMAGE_PXC=$IMAGE_PXC
                     export IMAGE_PROXY=$IMAGE_PROXY
                     export IMAGE_HAPROXY=$IMAGE_HAPROXY
@@ -320,9 +315,68 @@ void runTest(Integer TEST_ID) {
     }
 }
 
+void pushArtifactFile(String FILE_NAME) {
+    echo "Push $FILE_NAME file to S3!"
+
+    withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AMI/OVF', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
+        sh """
+            touch $FILE_NAME
+            S3_PATH=s3://percona-jenkins-artifactory/\$JOB_NAME/$GIT_SHORT_COMMIT
+            aws s3 ls \$S3_PATH/$FILE_NAME || :
+            aws s3 cp --quiet $FILE_NAME \$S3_PATH/$FILE_NAME || :
+        """
+    }
+}
+
+void makeReport() {
+    echo "=========================[ Generating Test Report ]========================="
+    testsReport = '<testsuite name="PXC-OpenShift-latest">\n'
+    for (int i = 0; i < tests.size(); i ++) {
+        testsReport += '<testcase name="' + tests[i]["name"] + '" time="' + tests[i]["time"] + '"><'+ tests[i]["result"] +'/></testcase>\n'
+    }
+    testsReport += '</testsuite>\n'
+
+    echo "=========================[ Generating Parameters Report ]========================="
+    pipelineParameters = """
+        testsuite name=PXC-OpenShift-latest
+        IMAGE_OPERATOR=$IMAGE_OPERATOR
+        IMAGE_PXC=$IMAGE_PXC
+        IMAGE_PROXY=$IMAGE_PROXY
+        IMAGE_HAPROXY=$IMAGE_HAPROXY
+        IMAGE_BACKUP=$IMAGE_BACKUP
+        IMAGE_LOGCOLLECTOR=$IMAGE_LOGCOLLECTOR
+        IMAGE_PMM_CLIENT=$IMAGE_PMM_CLIENT
+        IMAGE_PMM_SERVER=$IMAGE_PMM_SERVER
+        USED_PLATFORM_VER=$USED_PLATFORM_VER
+    """
+
+    writeFile file: "TestsReport.xml", text: testsReport
+    writeFile file: 'PipelineParameters.txt', text: pipelineParameters
+}
+
+void shutdownCluster(String CLUSTER_SUFFIX) {
+    withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'openshift-cicd'], file(credentialsId: 'aws-openshift-41-key-pub', variable: 'AWS_NODES_KEY_PUB'), file(credentialsId: 'openshift-secret-file', variable: 'OPENSHIFT-CONF-FILE')]) {
+        sshagent(['aws-openshift-41-key']) {
+            sh """
+                export KUBECONFIG=$WORKSPACE/openshift/$CLUSTER_SUFFIX/auth/kubeconfig
+                for namespace in \$(kubectl get namespaces --no-headers | awk '{print \$1}' | grep -vE "^kube-|^openshift" | sed '/-operator/ s/^/1-/' | sort | sed 's/^1-//'); do
+                    kubectl delete deployments --all -n \$namespace --force --grace-period=0 || true
+                    kubectl delete sts --all -n \$namespace --force --grace-period=0 || true
+                    kubectl delete replicasets --all -n \$namespace --force --grace-period=0 || true
+                    kubectl delete poddisruptionbudget --all -n \$namespace --force --grace-period=0 || true
+                    kubectl delete services --all -n \$namespace --force --grace-period=0 || true
+                    kubectl delete pods --all -n \$namespace --force --grace-period=0 || true
+                done
+                kubectl get svc --all-namespaces || true
+
+                /usr/local/bin/openshift-install destroy cluster --dir=openshift/$CLUSTER_SUFFIX || true
+            """
+        }
+    }
+}
+
 pipeline {
     environment {
-        TF_IN_AUTOMATION = 'true'
         CLEAN_NAMESPACE = 1
         PXC_TAG = sh(script: "[[ \"$IMAGE_PXC\" ]] && echo $IMAGE_PXC | awk -F':' '{print \$2}' || echo main", , returnStdout: true).trim()
     }
@@ -340,10 +394,16 @@ pipeline {
             description: 'Ignore passed tests in previous run (run all)',
             name: 'IGNORE_PREVIOUS_RUN'
         )
+        choice(
+            choices: 'NO\nYES',
+            description: 'Release run?',
+            name: 'RELEASE_RUN'
+        )
         string(
-            defaultValue: 'latest',
-            description: 'OpenShift version to use',
-            name: 'PLATFORM_VER')
+            defaultValue: '80',
+            description: 'For RELEASE_RUN only. Major version like 80, 57, etc',
+            name: 'PILLAR_VERSION'
+        )
         string(
             defaultValue: 'main',
             description: 'Tag/Branch for percona/percona-xtradb-cluster-operator repository',
@@ -352,14 +412,18 @@ pipeline {
             defaultValue: 'https://github.com/percona/percona-xtradb-cluster-operator',
             description: 'percona-xtradb-cluster-operator repository',
             name: 'GIT_REPO')
+        string(
+            defaultValue: 'latest',
+            description: 'OpenShift kubernetes version',
+            name: 'PLATFORM_VER')
         choice(
             choices: 'YES\nNO',
-            description: 'Run tests with cluster wide',
+            description: 'Run tests in cluster wide mode',
             name: 'CLUSTER_WIDE')
         string(
             defaultValue: '',
             description: 'Operator image: perconalab/percona-xtradb-cluster-operator:main',
-            name: 'OPERATOR_IMAGE')
+            name: 'IMAGE_OPERATOR')
         string(
             defaultValue: '',
             description: 'PXC image: perconalab/percona-xtradb-cluster-operator:main-pxc8.0',
@@ -390,7 +454,7 @@ pipeline {
             name: 'IMAGE_PMM_SERVER')
     }
     agent {
-         label 'docker'
+        label 'docker'
     }
     options {
         buildDiscarder(logRotator(daysToKeepStr: '-1', artifactDaysToKeepStr: '-1', numToKeepStr: '30', artifactNumToKeepStr: '30'))
@@ -401,6 +465,7 @@ pipeline {
     stages {
         stage('Prepare node') {
             steps {
+                verifyParams()
                 prepareNode()
             }
         }
@@ -414,7 +479,7 @@ pipeline {
                 initTests()
             }
         }
-        stage('Run tests') {
+        stage('Run Tests') {
             parallel {
                 stage('cluster1') {
                     options {
@@ -479,11 +544,8 @@ pipeline {
         always {
             echo "CLUSTER ASSIGNMENTS\n" + tests.toString().replace("], ","]\n").replace("]]","]").replaceFirst("\\[","")
             makeReport()
-            sh """
-                echo "$TestsReport" > TestsReport.xml
-            """
             step([$class: 'JUnitResultArchiver', testResults: '*.xml', healthScaleFactor: 1.0])
-            archiveArtifacts '*.xml'
+            archiveArtifacts '*.xml,*.txt'
 
             script {
                 if (currentBuild.result != null && currentBuild.result != 'SUCCESS') {
@@ -495,7 +557,6 @@ pipeline {
 
             sh """
                 sudo docker system prune --volumes -af
-                sudo rm -rf *
             """
             deleteDir()
         }

--- a/cloud/jenkins/pxc_operator_aws_openshift_latest.groovy
+++ b/cloud/jenkins/pxc_operator_aws_openshift_latest.groovy
@@ -9,8 +9,8 @@ void verifyParams() {
         if (!"$PILLAR_VERSION" && !"$IMAGE_PXC") {
             error("Either PILLAR_VERSION or IMAGE_PXC should be provided for release run!")
         }
-        USED_PLATFORM_VER="$PLATFORM_VER"
     }
+    USED_PLATFORM_VER="$PLATFORM_VER"
 }
 
 String getParam(String PARAM_NAME) {

--- a/cloud/jenkins/pxc_operator_aws_openshift_latest.groovy
+++ b/cloud/jenkins/pxc_operator_aws_openshift_latest.groovy
@@ -436,7 +436,7 @@ pipeline {
         copyArtifactPermission('pxc-operator-latest-scheduler');
     }
     stages {
-        stage('Prepare node') {
+        stage('Prepare Node') {
             steps {
                 prepareNode()
             }
@@ -446,7 +446,7 @@ pipeline {
                 dockerBuildPush()
             }
         }
-        stage('Init tests') {
+        stage('Init Tests') {
             steps {
                 initTests()
             }

--- a/cloud/jenkins/pxc_operator_aws_openshift_latest.groovy
+++ b/cloud/jenkins/pxc_operator_aws_openshift_latest.groovy
@@ -69,6 +69,10 @@ void prepareNode() {
 
         sudo curl -fsSL https://github.com/mikefarah/yq/releases/download/v4.44.1/yq_linux_amd64 -o /usr/local/bin/yq && sudo chmod +x /usr/local/bin/yq
         sudo curl -fsSL https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux64 -o /usr/local/bin/jq && sudo chmod +x /usr/local/bin/jq
+
+        sudo yum install -y https://repo.percona.com/yum/percona-release-latest.noarch.rpm || true
+        sudo percona-release enable-only tools
+        sudo yum install -y percona-xtrabackup-80 | true
     """
 
     if ("$IMAGE_PXC") {

--- a/cloud/jenkins/pxc_operator_aws_openshift_latest.groovy
+++ b/cloud/jenkins/pxc_operator_aws_openshift_latest.groovy
@@ -12,20 +12,14 @@ void verifyParams() {
     }
 }
 
-String getParam(String PARAM_NAME) {
-    def param = "${params[PARAM_NAME]}"
+String getParam(String paramName, String keyName = null) {
+    keyName = keyName ?: paramName
 
-    if ("$param" && "$param" != "null" && param != "") {
-        echo "$PARAM_NAME=$param (from job parameters)"
-        return param
+    param = sh(script: "grep -iE '^\\s*$keyName=' $release_versions | cut -d = -f 2 | tr -d \'\"\'| tail -1", , returnStdout: true).trim()
+    if ("$param") {
+        echo "$paramName=$param (from params file)"
     } else {
-        param = sh(script: "grep -iE '^\\s*$PARAM_NAME=' $release_versions | cut -d = -f 2 | tr -d \'\"\'| tail -1", , returnStdout: true).trim()
-        if ("$param") {
-            echo "$PARAM_NAME=$param (from params file)"
-            return param
-        } else {
-            error("$PARAM_NAME not found in params file $release_versions")
-        }
+        error("$keyName not found in params file $release_versions")
     }
     return param
 }
@@ -45,16 +39,16 @@ void prepareNode() {
 
     if ("$RELEASE_RUN" == "YES") {
         echo "=========================[ Getting parameters for release test ]========================="
-        IMAGE_OPERATOR = getParam("IMAGE_OPERATOR")
-        IMAGE_PXC = getParam("IMAGE_PXC${PILLAR_VERSION}")
-        IMAGE_PROXY = getParam("IMAGE_PROXY")
-        IMAGE_HAPROXY = getParam("IMAGE_HAPROXY")
-        IMAGE_BACKUP = getParam("IMAGE_BACKUP${PILLAR_VERSION}")
-        IMAGE_LOGCOLLECTOR = getParam("IMAGE_LOGCOLLECTOR")
-        IMAGE_PMM_CLIENT = getParam("IMAGE_PMM_CLIENT")
-        IMAGE_PMM_SERVER = getParam("IMAGE_PMM_SERVER")
+        IMAGE_OPERATOR = params["IMAGE_OPERATOR"] ?: getParam("IMAGE_OPERATOR")
+        IMAGE_PXC = params["IMAGE_PXC"] ?: getParam("IMAGE_PXC", "IMAGE_PXC${PILLAR_VERSION}")
+        IMAGE_PROXY = params["IMAGE_PROXY"] ?: getParam("IMAGE_PROXY")
+        IMAGE_HAPROXY = params["IMAGE_HAPROXY"] ?: getParam("IMAGE_HAPROXY")
+        IMAGE_BACKUP = params["IMAGE_BACKUP"] ?: getParam("IMAGE_BACKUP", "IMAGE_BACKUP${PILLAR_VERSION}")
+        IMAGE_LOGCOLLECTOR = params["IMAGE_LOGCOLLECTOR"] ?: getParam("IMAGE_LOGCOLLECTOR")
+        IMAGE_PMM_CLIENT = params["IMAGE_PMM_CLIENT"] ?: getParam("IMAGE_PMM_CLIENT")
+        IMAGE_PMM_SERVER = params["IMAGE_PMM_SERVER"] ?: getParam("IMAGE_PMM_SERVER")
         if ("$PLATFORM_VER" == "min".toLowerCase() || "$PLATFORM_VER" == "max".toLowerCase()) {
-            PLATFORM_VER = getParam("OPENSHIFT_${PLATFORM_VER}")
+            PLATFORM_VER = getParam("PLATFORM_VER", "OPENSHIFT_${PLATFORM_VER}")
         }
     } else {
         echo "=========================[ Not a release run. Using job params only! ]========================="

--- a/cloud/jenkins/pxc_operator_aws_openshift_latest.groovy
+++ b/cloud/jenkins/pxc_operator_aws_openshift_latest.groovy
@@ -3,15 +3,6 @@ tests=[]
 clusters=[]
 release_versions="source/e2e-tests/release_versions"
 
-void verifyParams() {
-    if ("$RELEASE_RUN" == "YES") {
-        echo "=========================[ RELEASE RUN ]========================="
-        if (!"$PILLAR_VERSION" && !"$IMAGE_PXC") {
-            error("Either PILLAR_VERSION or IMAGE_PXC should be provided for release run!")
-        }
-    }
-}
-
 String getParam(String paramName, String keyName = null) {
     keyName = keyName ?: paramName
 
@@ -37,16 +28,16 @@ void prepareNode() {
         cloud/local/checkout $GIT_REPO $GIT_BRANCH
     """
 
-    if ("$RELEASE_RUN" == "YES") {
+    if ("$PILLAR_VERSION" != "none") {
         echo "=========================[ Getting parameters for release test ]========================="
-        IMAGE_OPERATOR = params["IMAGE_OPERATOR"] ?: getParam("IMAGE_OPERATOR")
-        IMAGE_PXC = params["IMAGE_PXC"] ?: getParam("IMAGE_PXC", "IMAGE_PXC${PILLAR_VERSION}")
-        IMAGE_PROXY = params["IMAGE_PROXY"] ?: getParam("IMAGE_PROXY")
-        IMAGE_HAPROXY = params["IMAGE_HAPROXY"] ?: getParam("IMAGE_HAPROXY")
-        IMAGE_BACKUP = params["IMAGE_BACKUP"] ?: getParam("IMAGE_BACKUP", "IMAGE_BACKUP${PILLAR_VERSION}")
-        IMAGE_LOGCOLLECTOR = params["IMAGE_LOGCOLLECTOR"] ?: getParam("IMAGE_LOGCOLLECTOR")
-        IMAGE_PMM_CLIENT = params["IMAGE_PMM_CLIENT"] ?: getParam("IMAGE_PMM_CLIENT")
-        IMAGE_PMM_SERVER = params["IMAGE_PMM_SERVER"] ?: getParam("IMAGE_PMM_SERVER")
+        IMAGE_OPERATOR = IMAGE_OPERATOR ?: getParam("IMAGE_OPERATOR")
+        IMAGE_PXC = IMAGE_PXC ?: getParam("IMAGE_PXC", "IMAGE_PXC${PILLAR_VERSION}")
+        IMAGE_PROXY = IMAGE_PROXY ?: getParam("IMAGE_PROXY")
+        IMAGE_HAPROXY = IMAGE_HAPROXY ?: getParam("IMAGE_HAPROXY")
+        IMAGE_BACKUP = IMAGE_BACKUP ?: getParam("IMAGE_BACKUP", "IMAGE_BACKUP${PILLAR_VERSION}")
+        IMAGE_LOGCOLLECTOR = IMAGE_LOGCOLLECTOR ?: getParam("IMAGE_LOGCOLLECTOR")
+        IMAGE_PMM_CLIENT = IMAGE_PMM_CLIENT ?: getParam("IMAGE_PMM_CLIENT")
+        IMAGE_PMM_SERVER = IMAGE_PMM_SERVER ?: getParam("IMAGE_PMM_SERVER")
         if ("$PLATFORM_VER" == "min".toLowerCase() || "$PLATFORM_VER" == "max".toLowerCase()) {
             PLATFORM_VER = getParam("PLATFORM_VER", "OPENSHIFT_${PLATFORM_VER}")
         }
@@ -81,16 +72,14 @@ void prepareNode() {
     """
 
     if ("$IMAGE_PXC") {
-        release = ("$RELEASE_RUN" == "YES") ? "RELEASE-" : ""
+        release = ("$PILLAR_VERSION" != "none") ? "RELEASE-" : ""
         cw = ("$CLUSTER_WIDE" == "YES") ? "CW" : "NON-CW"
         currentBuild.description = "$release$GIT_BRANCH-$PLATFORM_VER-$cw-" + "$IMAGE_PXC".split(":")[1]
     }
 
-    script {
-        GIT_SHORT_COMMIT = sh(script: 'git -C source rev-parse --short HEAD', , returnStdout: true).trim()
-        CLUSTER_NAME = sh(script: "echo jenkins-lat-pxc-$GIT_SHORT_COMMIT | tr '[:upper:]' '[:lower:]'", , returnStdout: true).trim()
-        PARAMS_HASH = sh(script: "echo $GIT_BRANCH-$GIT_SHORT_COMMIT-$PLATFORM_VER-$CLUSTER_WIDE-$IMAGE_OPERATOR-$IMAGE_PXC-$IMAGE_PROXY-$IMAGE_HAPROXY-$IMAGE_BACKUP-$IMAGE_LOGCOLLECTOR-$IMAGE_PMM_CLIENT-$IMAGE_PMM_SERVER | md5sum | cut -d' ' -f1", , returnStdout: true).trim()
-    }
+    GIT_SHORT_COMMIT = sh(script: 'git -C source rev-parse --short HEAD', , returnStdout: true).trim()
+    CLUSTER_NAME = sh(script: "echo jenkins-lat-pxc-$GIT_SHORT_COMMIT | tr '[:upper:]' '[:lower:]'", , returnStdout: true).trim()
+    PARAMS_HASH = sh(script: "echo $GIT_BRANCH-$GIT_SHORT_COMMIT-$PLATFORM_VER-$CLUSTER_WIDE-$IMAGE_OPERATOR-$IMAGE_PXC-$IMAGE_PROXY-$IMAGE_HAPROXY-$IMAGE_BACKUP-$IMAGE_LOGCOLLECTOR-$IMAGE_PMM_CLIENT-$IMAGE_PMM_SERVER | md5sum | cut -d' ' -f1", , returnStdout: true).trim()
 }
 
 void dockerBuildPush() {
@@ -386,13 +375,10 @@ pipeline {
             name: 'IGNORE_PREVIOUS_RUN'
         )
         choice(
-            choices: 'NO\nYES',
-            description: 'Release run?',
-            name: 'RELEASE_RUN'
         )
-        string(
-            defaultValue: '80',
-            description: 'For RELEASE_RUN only. Major version like 80, 57, etc',
+        choice(
+            choices: 'none\n80\n57',
+            description: 'Can be 08, 57, etc. or none. Implies release run.',
             name: 'PILLAR_VERSION'
         )
         string(
@@ -456,7 +442,6 @@ pipeline {
     stages {
         stage('Prepare node') {
             steps {
-                verifyParams()
                 prepareNode()
             }
         }

--- a/cloud/jenkins/pxc_operator_aws_openshift_latest.groovy
+++ b/cloud/jenkins/pxc_operator_aws_openshift_latest.groovy
@@ -372,15 +372,11 @@ pipeline {
         choice(
             choices: 'NO\nYES',
             description: 'Ignore passed tests in previous run (run all)',
-            name: 'IGNORE_PREVIOUS_RUN'
-        )
-        choice(
-        )
+            name: 'IGNORE_PREVIOUS_RUN')
         choice(
             choices: 'none\n80\n57',
             description: 'Can be 08, 57, etc. or none. Implies release run.',
-            name: 'PILLAR_VERSION'
-        )
+            name: 'PILLAR_VERSION')
         string(
             defaultValue: 'main',
             description: 'Tag/Branch for percona/percona-xtradb-cluster-operator repository',

--- a/cloud/jenkins/pxc_operator_eks_latest.groovy
+++ b/cloud/jenkins/pxc_operator_eks_latest.groovy
@@ -445,7 +445,7 @@ pipeline {
         copyArtifactPermission('pxc-operator-latest-scheduler');
     }
     stages {
-        stage('Prepare node') {
+        stage('Prepare Node') {
             steps {
                 prepareNode()
             }
@@ -455,7 +455,7 @@ pipeline {
                 dockerBuildPush()
             }
         }
-        stage('Init tests') {
+        stage('Init Tests') {
             steps {
                 initTests()
             }

--- a/cloud/jenkins/pxc_operator_eks_latest.groovy
+++ b/cloud/jenkins/pxc_operator_eks_latest.groovy
@@ -384,7 +384,7 @@ pipeline {
             name: 'IGNORE_PREVIOUS_RUN')
         choice(
             choices: 'none\n80\n57',
-            description: 'Can be 08, 57, etc. or none. Implies release run.',
+            description: 'Can be 80, 57, etc. or none. Implies release run.',
             name: 'PILLAR_VERSION')
         string(
             defaultValue: 'main',

--- a/cloud/jenkins/pxc_operator_eks_latest.groovy
+++ b/cloud/jenkins/pxc_operator_eks_latest.groovy
@@ -9,8 +9,8 @@ void verifyParams() {
         if (!"$PILLAR_VERSION" && !"$IMAGE_PXC") {
             error("Either PILLAR_VERSION or IMAGE_PXC should be provided for release run!")
         }
-        USED_PLATFORM_VER="$PLATFORM_VER"
     }
+    USED_PLATFORM_VER="$PLATFORM_VER"
 }
 
 String getParam(String PARAM_NAME) {

--- a/cloud/jenkins/pxc_operator_eks_latest.groovy
+++ b/cloud/jenkins/pxc_operator_eks_latest.groovy
@@ -56,6 +56,10 @@ void prepareNode() {
         sudo curl -fsSL https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux64 -o /usr/local/bin/jq && sudo chmod +x /usr/local/bin/jq
 
         curl -sL https://github.com/eksctl-io/eksctl/releases/latest/download/eksctl_\$(uname -s)_amd64.tar.gz | sudo tar -C /usr/local/bin -xzf - && sudo chmod +x /usr/local/bin/eksctl
+
+        sudo yum install -y https://repo.percona.com/yum/percona-release-latest.noarch.rpm || true
+        sudo percona-release enable-only tools
+        sudo yum install -y percona-xtrabackup-80 | true
     """
 
     if ("$PLATFORM_VER" == "latest") {

--- a/cloud/jenkins/pxc_operator_eks_latest.groovy
+++ b/cloud/jenkins/pxc_operator_eks_latest.groovy
@@ -380,15 +380,11 @@ pipeline {
         choice(
             choices: 'NO\nYES',
             description: 'Ignore passed tests in previous run (run all)',
-            name: 'IGNORE_PREVIOUS_RUN'
-        )
-        choice(
-        )
+            name: 'IGNORE_PREVIOUS_RUN')
         choice(
             choices: 'none\n80\n57',
             description: 'Can be 08, 57, etc. or none. Implies release run.',
-            name: 'PILLAR_VERSION'
-        )
+            name: 'PILLAR_VERSION')
         string(
             defaultValue: 'main',
             description: 'Tag/Branch for percona/percona-xtradb-cluster-operator repository',

--- a/cloud/jenkins/pxc_operator_eks_latest.groovy
+++ b/cloud/jenkins/pxc_operator_eks_latest.groovy
@@ -3,15 +3,6 @@ tests=[]
 clusters=[]
 release_versions="source/e2e-tests/release_versions"
 
-void verifyParams() {
-    if ("$RELEASE_RUN" == "YES") {
-        echo "=========================[ RELEASE RUN ]========================="
-        if (!"$PILLAR_VERSION" && !"$IMAGE_PXC") {
-            error("Either PILLAR_VERSION or IMAGE_PXC should be provided for release run!")
-        }
-    }
-}
-
 String getParam(String paramName, String keyName = null) {
     keyName = keyName ?: paramName
 
@@ -37,16 +28,16 @@ void prepareNode() {
         cloud/local/checkout $GIT_REPO $GIT_BRANCH
     """
 
-    if ("$RELEASE_RUN" == "YES") {
+    if ("$PILLAR_VERSION" != "none") {
         echo "=========================[ Getting parameters for release test ]========================="
-        IMAGE_OPERATOR = params["IMAGE_OPERATOR"] ?: getParam("IMAGE_OPERATOR")
-        IMAGE_PXC = params["IMAGE_PXC"] ?: getParam("IMAGE_PXC", "IMAGE_PXC${PILLAR_VERSION}")
-        IMAGE_PROXY = params["IMAGE_PROXY"] ?: getParam("IMAGE_PROXY")
-        IMAGE_HAPROXY = params["IMAGE_HAPROXY"] ?: getParam("IMAGE_HAPROXY")
-        IMAGE_BACKUP = params["IMAGE_BACKUP"] ?: getParam("IMAGE_BACKUP", "IMAGE_BACKUP${PILLAR_VERSION}")
-        IMAGE_LOGCOLLECTOR = params["IMAGE_LOGCOLLECTOR"] ?: getParam("IMAGE_LOGCOLLECTOR")
-        IMAGE_PMM_CLIENT = params["IMAGE_PMM_CLIENT"] ?: getParam("IMAGE_PMM_CLIENT")
-        IMAGE_PMM_SERVER = params["IMAGE_PMM_SERVER"] ?: getParam("IMAGE_PMM_SERVER")
+        IMAGE_OPERATOR = IMAGE_OPERATOR ?: getParam("IMAGE_OPERATOR")
+        IMAGE_PXC = IMAGE_PXC ?: getParam("IMAGE_PXC", "IMAGE_PXC${PILLAR_VERSION}")
+        IMAGE_PROXY = IMAGE_PROXY ?: getParam("IMAGE_PROXY")
+        IMAGE_HAPROXY = IMAGE_HAPROXY ?: getParam("IMAGE_HAPROXY")
+        IMAGE_BACKUP = IMAGE_BACKUP ?: getParam("IMAGE_BACKUP", "IMAGE_BACKUP${PILLAR_VERSION}")
+        IMAGE_LOGCOLLECTOR = IMAGE_LOGCOLLECTOR ?: getParam("IMAGE_LOGCOLLECTOR")
+        IMAGE_PMM_CLIENT = IMAGE_PMM_CLIENT ?: getParam("IMAGE_PMM_CLIENT")
+        IMAGE_PMM_SERVER = IMAGE_PMM_SERVER ?: getParam("IMAGE_PMM_SERVER")
         if ("$PLATFORM_VER" == "min".toLowerCase() || "$PLATFORM_VER" == "max".toLowerCase()) {
             PLATFORM_VER = getParam("PLATFORM_VER", "EKS_${PLATFORM_VER}")
         }
@@ -72,16 +63,14 @@ void prepareNode() {
     }
 
     if ("$IMAGE_PXC") {
-        release = ("$RELEASE_RUN" == "YES") ? "RELEASE-" : ""
+        release = ("$PILLAR_VERSION" != "none") ? "RELEASE-" : ""
         cw = ("$CLUSTER_WIDE" == "YES") ? "CW" : "NON-CW"
         currentBuild.description = "$release$GIT_BRANCH-$PLATFORM_VER-$cw-" + "$IMAGE_PXC".split(":")[1]
     }
 
-    script {
-        GIT_SHORT_COMMIT = sh(script: 'git -C source rev-parse --short HEAD', , returnStdout: true).trim()
-        CLUSTER_NAME = sh(script: "echo jenkins-lat-pxc-$GIT_SHORT_COMMIT | tr '[:upper:]' '[:lower:]'", , returnStdout: true).trim()
-        PARAMS_HASH = sh(script: "echo $GIT_BRANCH-$GIT_SHORT_COMMIT-$PLATFORM_VER-$CLUSTER_WIDE-$IMAGE_OPERATOR-$IMAGE_PXC-$IMAGE_PROXY-$IMAGE_HAPROXY-$IMAGE_BACKUP-$IMAGE_LOGCOLLECTOR-$IMAGE_PMM_CLIENT-$IMAGE_PMM_SERVER | md5sum | cut -d' ' -f1", , returnStdout: true).trim()
-    }
+    GIT_SHORT_COMMIT = sh(script: 'git -C source rev-parse --short HEAD', , returnStdout: true).trim()
+    CLUSTER_NAME = sh(script: "echo jenkins-lat-pxc-$GIT_SHORT_COMMIT | tr '[:upper:]' '[:lower:]'", , returnStdout: true).trim()
+    PARAMS_HASH = sh(script: "echo $GIT_BRANCH-$GIT_SHORT_COMMIT-$PLATFORM_VER-$CLUSTER_WIDE-$IMAGE_OPERATOR-$IMAGE_PXC-$IMAGE_PROXY-$IMAGE_HAPROXY-$IMAGE_BACKUP-$IMAGE_LOGCOLLECTOR-$IMAGE_PMM_CLIENT-$IMAGE_PMM_SERVER | md5sum | cut -d' ' -f1", , returnStdout: true).trim()
 }
 
 void dockerBuildPush() {
@@ -394,13 +383,10 @@ pipeline {
             name: 'IGNORE_PREVIOUS_RUN'
         )
         choice(
-            choices: 'NO\nYES',
-            description: 'Release run?',
-            name: 'RELEASE_RUN'
         )
-        string(
-            defaultValue: '80',
-            description: 'For RELEASE_RUN only. Major version like 80, 57, etc',
+        choice(
+            choices: 'none\n80\n57',
+            description: 'Can be 08, 57, etc. or none. Implies release run.',
             name: 'PILLAR_VERSION'
         )
         string(
@@ -464,7 +450,6 @@ pipeline {
     stages {
         stage('Prepare node') {
             steps {
-                verifyParams()
                 prepareNode()
             }
         }

--- a/cloud/jenkins/pxc_operator_eks_latest.groovy
+++ b/cloud/jenkins/pxc_operator_eks_latest.groovy
@@ -387,8 +387,8 @@ pipeline {
             description: 'Ignore passed tests in previous run (run all)',
             name: 'IGNORE_PREVIOUS_RUN')
         choice(
-            choices: 'none\n80\n57',
-            description: 'Can be 80, 57, etc. or none. Implies release run.',
+            choices: 'none\n84\n80\n57',
+            description: 'Implies release run.',
             name: 'PILLAR_VERSION')
         string(
             defaultValue: 'main',
@@ -400,7 +400,7 @@ pipeline {
             name: 'GIT_REPO')
         string(
             defaultValue: 'latest',
-            description: 'EKS kubernetes version',
+            description: 'EKS kubernetes version. If set to min or max, value will be automatically taken from release_versions file.',
             name: 'PLATFORM_VER')
         choice(
             choices: 'YES\nNO',

--- a/cloud/jenkins/pxc_operator_eks_latest.groovy
+++ b/cloud/jenkins/pxc_operator_eks_latest.groovy
@@ -12,18 +12,14 @@ void verifyParams() {
     }
 }
 
-String getParam(String PARAM_NAME) {
-    def param = "${params[PARAM_NAME]}"
+String getParam(String paramName, String keyName = null) {
+    keyName = keyName ?: paramName
 
-    if ("$param" && "$param" != "null" && param != "") {
-        echo "$PARAM_NAME=$param (from job parameters)"
+    param = sh(script: "grep -iE '^\\s*$keyName=' $release_versions | cut -d = -f 2 | tr -d \'\"\'| tail -1", , returnStdout: true).trim()
+    if ("$param") {
+        echo "$paramName=$param (from params file)"
     } else {
-        param = sh(script: "grep -iE '^\\s*$PARAM_NAME=' $release_versions | cut -d = -f 2 | tr -d \'\"\'| tail -1", , returnStdout: true).trim()
-        if ("$param") {
-            echo "$PARAM_NAME=$param (from params file)"
-        } else {
-            error("$PARAM_NAME not found in params file $release_versions")
-        }
+        error("$keyName not found in params file $release_versions")
     }
     return param
 }
@@ -43,16 +39,16 @@ void prepareNode() {
 
     if ("$RELEASE_RUN" == "YES") {
         echo "=========================[ Getting parameters for release test ]========================="
-        IMAGE_OPERATOR = getParam("IMAGE_OPERATOR")
-        IMAGE_PXC = getParam("IMAGE_PXC${PILLAR_VERSION}")
-        IMAGE_PROXY = getParam("IMAGE_PROXY")
-        IMAGE_HAPROXY = getParam("IMAGE_HAPROXY")
-        IMAGE_BACKUP = getParam("IMAGE_BACKUP${PILLAR_VERSION}")
-        IMAGE_LOGCOLLECTOR = getParam("IMAGE_LOGCOLLECTOR")
-        IMAGE_PMM_CLIENT = getParam("IMAGE_PMM_CLIENT")
-        IMAGE_PMM_SERVER = getParam("IMAGE_PMM_SERVER")
+        IMAGE_OPERATOR = params["IMAGE_OPERATOR"] ?: getParam("IMAGE_OPERATOR")
+        IMAGE_PXC = params["IMAGE_PXC"] ?: getParam("IMAGE_PXC", "IMAGE_PXC${PILLAR_VERSION}")
+        IMAGE_PROXY = params["IMAGE_PROXY"] ?: getParam("IMAGE_PROXY")
+        IMAGE_HAPROXY = params["IMAGE_HAPROXY"] ?: getParam("IMAGE_HAPROXY")
+        IMAGE_BACKUP = params["IMAGE_BACKUP"] ?: getParam("IMAGE_BACKUP", "IMAGE_BACKUP${PILLAR_VERSION}")
+        IMAGE_LOGCOLLECTOR = params["IMAGE_LOGCOLLECTOR"] ?: getParam("IMAGE_LOGCOLLECTOR")
+        IMAGE_PMM_CLIENT = params["IMAGE_PMM_CLIENT"] ?: getParam("IMAGE_PMM_CLIENT")
+        IMAGE_PMM_SERVER = params["IMAGE_PMM_SERVER"] ?: getParam("IMAGE_PMM_SERVER")
         if ("$PLATFORM_VER" == "min".toLowerCase() || "$PLATFORM_VER" == "max".toLowerCase()) {
-            PLATFORM_VER = getParam("EKS_${PLATFORM_VER}")
+            PLATFORM_VER = getParam("PLATFORM_VER", "EKS_${PLATFORM_VER}")
         }
     } else {
         echo "=========================[ Not a release run. Using job params only! ]========================="

--- a/cloud/jenkins/pxc_operator_eks_latest.groovy
+++ b/cloud/jenkins/pxc_operator_eks_latest.groovy
@@ -250,23 +250,25 @@ void runTest(Integer TEST_ID) {
             tests[TEST_ID]["result"] = "failure"
 
             timeout(time: 90, unit: 'MINUTES') {
-                sh """
-                    cd source
+                withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'eks-cicd'], file(credentialsId: 'eks-conf-file', variable: 'EKS_CONF_FILE')]) {
+                    sh """
+                        cd source
 
-                    export DEBUG_TESTS=1
-                    [[ "$CLUSTER_WIDE" == "YES" ]] && export OPERATOR_NS=pxc-operator
-                    export IMAGE=$IMAGE_OPERATOR
-                    export IMAGE_PXC=$IMAGE_PXC
-                    export IMAGE_PROXY=$IMAGE_PROXY
-                    export IMAGE_HAPROXY=$IMAGE_HAPROXY
-                    export IMAGE_BACKUP=$IMAGE_BACKUP
-                    export IMAGE_LOGCOLLECTOR=$IMAGE_LOGCOLLECTOR
-                    export IMAGE_PMM_CLIENT=$IMAGE_PMM_CLIENT
-                    export IMAGE_PMM_SERVER=$IMAGE_PMM_SERVER
-                    export KUBECONFIG=/tmp/$CLUSTER_NAME-$clusterSuffix
+                        export DEBUG_TESTS=1
+                        [[ "$CLUSTER_WIDE" == "YES" ]] && export OPERATOR_NS=pxc-operator
+                        export IMAGE=$IMAGE_OPERATOR
+                        export IMAGE_PXC=$IMAGE_PXC
+                        export IMAGE_PROXY=$IMAGE_PROXY
+                        export IMAGE_HAPROXY=$IMAGE_HAPROXY
+                        export IMAGE_BACKUP=$IMAGE_BACKUP
+                        export IMAGE_LOGCOLLECTOR=$IMAGE_LOGCOLLECTOR
+                        export IMAGE_PMM_CLIENT=$IMAGE_PMM_CLIENT
+                        export IMAGE_PMM_SERVER=$IMAGE_PMM_SERVER
+                        export KUBECONFIG=/tmp/$CLUSTER_NAME-$clusterSuffix
 
-                    e2e-tests/$testName/run
-                """
+                        e2e-tests/$testName/run
+                    """
+                }
             }
             pushArtifactFile("$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$PXC_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH")
             tests[TEST_ID]["result"] = "passed"

--- a/cloud/jenkins/pxc_operator_eks_latest.groovy
+++ b/cloud/jenkins/pxc_operator_eks_latest.groovy
@@ -250,7 +250,7 @@ void runTest(Integer TEST_ID) {
 
                         export DEBUG_TESTS=1
                         [[ "$CLUSTER_WIDE" == "YES" ]] && export OPERATOR_NS=pxc-operator
-                        export IMAGE=$IMAGE_OPERATOR
+                        [[ "$IMAGE_OPERATOR" ]] && export IMAGE=$IMAGE_OPERATOR || export IMAGE=perconalab/percona-xtradb-cluster-operator:$GIT_BRANCH
                         export IMAGE_PXC=$IMAGE_PXC
                         export IMAGE_PROXY=$IMAGE_PROXY
                         export IMAGE_HAPROXY=$IMAGE_HAPROXY

--- a/cloud/jenkins/pxc_operator_eks_latest.groovy
+++ b/cloud/jenkins/pxc_operator_eks_latest.groovy
@@ -203,6 +203,7 @@ nodeGroups:
         - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
         - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
         - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+        - arn:aws:iam::aws:policy/AmazonS3FullAccess
       instancesDistribution:
         maxPrice: 0.15
         instanceTypes: ["m5.xlarge", "m5.2xlarge"] # At least two instance types should be specified

--- a/cloud/jenkins/pxc_operator_eks_latest.groovy
+++ b/cloud/jenkins/pxc_operator_eks_latest.groovy
@@ -136,7 +136,7 @@ void initTests() {
 
             for (int i=0; i<tests.size(); i++) {
                 def testName = tests[i]["name"]
-                def file="$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$PXC_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH"
+                def file="$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$DB_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH"
                 def retFileExists = sh(script: "aws s3api head-object --bucket percona-jenkins-artifactory --key $JOB_NAME/$GIT_SHORT_COMMIT/$file >/dev/null 2>&1", returnStatus: true)
 
                 if (retFileExists == 0) {
@@ -270,7 +270,7 @@ void runTest(Integer TEST_ID) {
                     """
                 }
             }
-            pushArtifactFile("$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$PXC_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH")
+            pushArtifactFile("$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$DB_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH")
             tests[TEST_ID]["result"] = "passed"
             return true
         }
@@ -377,7 +377,7 @@ void shutdownCluster(String CLUSTER_SUFFIX) {
 pipeline {
     environment {
         CLEAN_NAMESPACE = 1
-        PXC_TAG = sh(script: "[[ \"$IMAGE_PXC\" ]] && echo $IMAGE_PXC | awk -F':' '{print \$2}' || echo main", , returnStdout: true).trim()
+        DB_TAG = sh(script: "[[ \"$IMAGE_PXC\" ]] && echo $IMAGE_PXC | awk -F':' '{print \$2}' || echo main", , returnStdout: true).trim()
     }
     parameters {
         choice(

--- a/cloud/jenkins/pxc_operator_eks_version.groovy
+++ b/cloud/jenkins/pxc_operator_eks_version.groovy
@@ -445,7 +445,7 @@ pipeline {
         copyArtifactPermission('pxc-operator-latest-scheduler');
     }
     stages {
-        stage('Prepare node') {
+        stage('Prepare Node') {
             steps {
                 prepareNode()
             }
@@ -455,7 +455,7 @@ pipeline {
                 dockerBuildPush()
             }
         }
-        stage('Init tests') {
+        stage('Init Tests') {
             steps {
                 initTests()
             }

--- a/cloud/jenkins/pxc_operator_eks_version.groovy
+++ b/cloud/jenkins/pxc_operator_eks_version.groovy
@@ -384,7 +384,7 @@ pipeline {
             name: 'IGNORE_PREVIOUS_RUN')
         choice(
             choices: 'none\n80\n57',
-            description: 'Can be 08, 57, etc. or none. Implies release run.',
+            description: 'Can be 80, 57, etc. or none. Implies release run.',
             name: 'PILLAR_VERSION')
         string(
             defaultValue: 'main',

--- a/cloud/jenkins/pxc_operator_eks_version.groovy
+++ b/cloud/jenkins/pxc_operator_eks_version.groovy
@@ -9,8 +9,8 @@ void verifyParams() {
         if (!"$PILLAR_VERSION" && !"$IMAGE_PXC") {
             error("Either PILLAR_VERSION or IMAGE_PXC should be provided for release run!")
         }
-        USED_PLATFORM_VER="$PLATFORM_VER"
     }
+    USED_PLATFORM_VER="$PLATFORM_VER"
 }
 
 String getParam(String PARAM_NAME) {

--- a/cloud/jenkins/pxc_operator_eks_version.groovy
+++ b/cloud/jenkins/pxc_operator_eks_version.groovy
@@ -56,6 +56,10 @@ void prepareNode() {
         sudo curl -fsSL https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux64 -o /usr/local/bin/jq && sudo chmod +x /usr/local/bin/jq
 
         curl -sL https://github.com/eksctl-io/eksctl/releases/latest/download/eksctl_\$(uname -s)_amd64.tar.gz | sudo tar -C /usr/local/bin -xzf - && sudo chmod +x /usr/local/bin/eksctl
+
+        sudo yum install -y https://repo.percona.com/yum/percona-release-latest.noarch.rpm || true
+        sudo percona-release enable-only tools
+        sudo yum install -y percona-xtrabackup-80 | true
     """
 
     if ("$PLATFORM_VER" == "latest") {

--- a/cloud/jenkins/pxc_operator_eks_version.groovy
+++ b/cloud/jenkins/pxc_operator_eks_version.groovy
@@ -380,15 +380,11 @@ pipeline {
         choice(
             choices: 'NO\nYES',
             description: 'Ignore passed tests in previous run (run all)',
-            name: 'IGNORE_PREVIOUS_RUN'
-        )
-        choice(
-        )
+            name: 'IGNORE_PREVIOUS_RUN')
         choice(
             choices: 'none\n80\n57',
             description: 'Can be 08, 57, etc. or none. Implies release run.',
-            name: 'PILLAR_VERSION'
-        )
+            name: 'PILLAR_VERSION')
         string(
             defaultValue: 'main',
             description: 'Tag/Branch for percona/percona-xtradb-cluster-operator repository',

--- a/cloud/jenkins/pxc_operator_eks_version.groovy
+++ b/cloud/jenkins/pxc_operator_eks_version.groovy
@@ -387,8 +387,8 @@ pipeline {
             description: 'Ignore passed tests in previous run (run all)',
             name: 'IGNORE_PREVIOUS_RUN')
         choice(
-            choices: 'none\n80\n57',
-            description: 'Can be 80, 57, etc. or none. Implies release run.',
+            choices: 'none\n84\n80\n57',
+            description: 'Implies release run.',
             name: 'PILLAR_VERSION')
         string(
             defaultValue: 'main',
@@ -400,7 +400,7 @@ pipeline {
             name: 'GIT_REPO')
         string(
             defaultValue: 'latest',
-            description: 'EKS kubernetes version',
+            description: 'EKS kubernetes version. If set to min or max, value will be automatically taken from release_versions file.',
             name: 'PLATFORM_VER')
         choice(
             choices: 'YES\nNO',

--- a/cloud/jenkins/pxc_operator_eks_version.groovy
+++ b/cloud/jenkins/pxc_operator_eks_version.groovy
@@ -12,18 +12,14 @@ void verifyParams() {
     }
 }
 
-String getParam(String PARAM_NAME) {
-    def param = "${params[PARAM_NAME]}"
+String getParam(String paramName, String keyName = null) {
+    keyName = keyName ?: paramName
 
-    if ("$param" && "$param" != "null" && param != "") {
-        echo "$PARAM_NAME=$param (from job parameters)"
+    param = sh(script: "grep -iE '^\\s*$keyName=' $release_versions | cut -d = -f 2 | tr -d \'\"\'| tail -1", , returnStdout: true).trim()
+    if ("$param") {
+        echo "$paramName=$param (from params file)"
     } else {
-        param = sh(script: "grep -iE '^\\s*$PARAM_NAME=' $release_versions | cut -d = -f 2 | tr -d \'\"\'| tail -1", , returnStdout: true).trim()
-        if ("$param") {
-            echo "$PARAM_NAME=$param (from params file)"
-        } else {
-            error("$PARAM_NAME not found in params file $release_versions")
-        }
+        error("$keyName not found in params file $release_versions")
     }
     return param
 }
@@ -43,16 +39,16 @@ void prepareNode() {
 
     if ("$RELEASE_RUN" == "YES") {
         echo "=========================[ Getting parameters for release test ]========================="
-        IMAGE_OPERATOR = getParam("IMAGE_OPERATOR")
-        IMAGE_PXC = getParam("IMAGE_PXC${PILLAR_VERSION}")
-        IMAGE_PROXY = getParam("IMAGE_PROXY")
-        IMAGE_HAPROXY = getParam("IMAGE_HAPROXY")
-        IMAGE_BACKUP = getParam("IMAGE_BACKUP${PILLAR_VERSION}")
-        IMAGE_LOGCOLLECTOR = getParam("IMAGE_LOGCOLLECTOR")
-        IMAGE_PMM_CLIENT = getParam("IMAGE_PMM_CLIENT")
-        IMAGE_PMM_SERVER = getParam("IMAGE_PMM_SERVER")
+        IMAGE_OPERATOR = params["IMAGE_OPERATOR"] ?: getParam("IMAGE_OPERATOR")
+        IMAGE_PXC = params["IMAGE_PXC"] ?: getParam("IMAGE_PXC", "IMAGE_PXC${PILLAR_VERSION}")
+        IMAGE_PROXY = params["IMAGE_PROXY"] ?: getParam("IMAGE_PROXY")
+        IMAGE_HAPROXY = params["IMAGE_HAPROXY"] ?: getParam("IMAGE_HAPROXY")
+        IMAGE_BACKUP = params["IMAGE_BACKUP"] ?: getParam("IMAGE_BACKUP", "IMAGE_BACKUP${PILLAR_VERSION}")
+        IMAGE_LOGCOLLECTOR = params["IMAGE_LOGCOLLECTOR"] ?: getParam("IMAGE_LOGCOLLECTOR")
+        IMAGE_PMM_CLIENT = params["IMAGE_PMM_CLIENT"] ?: getParam("IMAGE_PMM_CLIENT")
+        IMAGE_PMM_SERVER = params["IMAGE_PMM_SERVER"] ?: getParam("IMAGE_PMM_SERVER")
         if ("$PLATFORM_VER" == "min".toLowerCase() || "$PLATFORM_VER" == "max".toLowerCase()) {
-            PLATFORM_VER = getParam("EKS_${PLATFORM_VER}")
+            PLATFORM_VER = getParam("PLATFORM_VER", "EKS_${PLATFORM_VER}")
         }
     } else {
         echo "=========================[ Not a release run. Using job params only! ]========================="

--- a/cloud/jenkins/pxc_operator_eks_version.groovy
+++ b/cloud/jenkins/pxc_operator_eks_version.groovy
@@ -10,7 +10,6 @@ void verifyParams() {
             error("Either PILLAR_VERSION or IMAGE_PXC should be provided for release run!")
         }
     }
-    USED_PLATFORM_VER="$PLATFORM_VER"
 }
 
 String getParam(String PARAM_NAME) {
@@ -73,7 +72,7 @@ void prepareNode() {
     """
 
     if ("$PLATFORM_VER" == "latest") {
-        USED_PLATFORM_VER = sh(script: "eksctl version -ojson | jq -r '.EKSServerSupportedVersions | max'", , returnStdout: true).trim()
+        PLATFORM_VER = sh(script: "eksctl version -ojson | jq -r '.EKSServerSupportedVersions | max'", , returnStdout: true).trim()
     }
 
     if ("$IMAGE_PXC") {
@@ -85,7 +84,7 @@ void prepareNode() {
     script {
         GIT_SHORT_COMMIT = sh(script: 'git -C source rev-parse --short HEAD', , returnStdout: true).trim()
         CLUSTER_NAME = sh(script: "echo jenkins-ver-pxc-$GIT_SHORT_COMMIT | tr '[:upper:]' '[:lower:]'", , returnStdout: true).trim()
-        PARAMS_HASH = sh(script: "echo $GIT_BRANCH-$GIT_SHORT_COMMIT-$USED_PLATFORM_VER-$CLUSTER_WIDE-$IMAGE_OPERATOR-$IMAGE_PXC-$IMAGE_PROXY-$IMAGE_HAPROXY-$IMAGE_BACKUP-$IMAGE_LOGCOLLECTOR-$IMAGE_PMM_CLIENT-$IMAGE_PMM_SERVER | md5sum | cut -d' ' -f1", , returnStdout: true).trim()
+        PARAMS_HASH = sh(script: "echo $GIT_BRANCH-$GIT_SHORT_COMMIT-$PLATFORM_VER-$CLUSTER_WIDE-$IMAGE_OPERATOR-$IMAGE_PXC-$IMAGE_PROXY-$IMAGE_HAPROXY-$IMAGE_BACKUP-$IMAGE_LOGCOLLECTOR-$IMAGE_PMM_CLIENT-$IMAGE_PMM_SERVER | md5sum | cut -d' ' -f1", , returnStdout: true).trim()
     }
 }
 
@@ -141,7 +140,7 @@ void initTests() {
 
             for (int i=0; i<tests.size(); i++) {
                 def testName = tests[i]["name"]
-                def file="$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$USED_PLATFORM_VER-$PXC_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH"
+                def file="$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$PXC_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH"
                 def retFileExists = sh(script: "aws s3api head-object --bucket percona-jenkins-artifactory --key $JOB_NAME/$GIT_SHORT_COMMIT/$file >/dev/null 2>&1", returnStatus: true)
 
                 if (retFileExists == 0) {
@@ -196,7 +195,7 @@ kind: ClusterConfig
 metadata:
     name: $CLUSTER_NAME-$CLUSTER_SUFFIX
     region: $region
-    version: "$USED_PLATFORM_VER"
+    version: "$PLATFORM_VER"
     tags:
         'delete-cluster-after-hours': '10'
         'creation-time': '\$timestamp'
@@ -273,7 +272,7 @@ void runTest(Integer TEST_ID) {
                     e2e-tests/$testName/run
                 """
             }
-            pushArtifactFile("$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$USED_PLATFORM_VER-$PXC_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH")
+            pushArtifactFile("$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$PXC_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH")
             tests[TEST_ID]["result"] = "passed"
             return true
         }
@@ -326,7 +325,7 @@ void makeReport() {
         IMAGE_LOGCOLLECTOR=$IMAGE_LOGCOLLECTOR
         IMAGE_PMM_CLIENT=$IMAGE_PMM_CLIENT
         IMAGE_PMM_SERVER=$IMAGE_PMM_SERVER
-        USED_PLATFORM_VER=$USED_PLATFORM_VER
+        PLATFORM_VER=$PLATFORM_VER
     """
 
     writeFile file: "TestsReport.xml", text: testsReport

--- a/cloud/jenkins/pxc_operator_eks_version.groovy
+++ b/cloud/jenkins/pxc_operator_eks_version.groovy
@@ -250,23 +250,25 @@ void runTest(Integer TEST_ID) {
             tests[TEST_ID]["result"] = "failure"
 
             timeout(time: 90, unit: 'MINUTES') {
-                sh """
-                    cd source
+                withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'eks-cicd'], file(credentialsId: 'eks-conf-file', variable: 'EKS_CONF_FILE')]) {
+                    sh """
+                        cd source
 
-                    export DEBUG_TESTS=1
-                    [[ "$CLUSTER_WIDE" == "YES" ]] && export OPERATOR_NS=pxc-operator
-                    export IMAGE=$IMAGE_OPERATOR
-                    export IMAGE_PXC=$IMAGE_PXC
-                    export IMAGE_PROXY=$IMAGE_PROXY
-                    export IMAGE_HAPROXY=$IMAGE_HAPROXY
-                    export IMAGE_BACKUP=$IMAGE_BACKUP
-                    export IMAGE_LOGCOLLECTOR=$IMAGE_LOGCOLLECTOR
-                    export IMAGE_PMM_CLIENT=$IMAGE_PMM_CLIENT
-                    export IMAGE_PMM_SERVER=$IMAGE_PMM_SERVER
-                    export KUBECONFIG=/tmp/$CLUSTER_NAME-$clusterSuffix
+                        export DEBUG_TESTS=1
+                        [[ "$CLUSTER_WIDE" == "YES" ]] && export OPERATOR_NS=pxc-operator
+                        export IMAGE=$IMAGE_OPERATOR
+                        export IMAGE_PXC=$IMAGE_PXC
+                        export IMAGE_PROXY=$IMAGE_PROXY
+                        export IMAGE_HAPROXY=$IMAGE_HAPROXY
+                        export IMAGE_BACKUP=$IMAGE_BACKUP
+                        export IMAGE_LOGCOLLECTOR=$IMAGE_LOGCOLLECTOR
+                        export IMAGE_PMM_CLIENT=$IMAGE_PMM_CLIENT
+                        export IMAGE_PMM_SERVER=$IMAGE_PMM_SERVER
+                        export KUBECONFIG=/tmp/$CLUSTER_NAME-$clusterSuffix
 
-                    e2e-tests/$testName/run
-                """
+                        e2e-tests/$testName/run
+                    """
+                }
             }
             pushArtifactFile("$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$PXC_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH")
             tests[TEST_ID]["result"] = "passed"

--- a/cloud/jenkins/pxc_operator_eks_version.groovy
+++ b/cloud/jenkins/pxc_operator_eks_version.groovy
@@ -3,15 +3,6 @@ tests=[]
 clusters=[]
 release_versions="source/e2e-tests/release_versions"
 
-void verifyParams() {
-    if ("$RELEASE_RUN" == "YES") {
-        echo "=========================[ RELEASE RUN ]========================="
-        if (!"$PILLAR_VERSION" && !"$IMAGE_PXC") {
-            error("Either PILLAR_VERSION or IMAGE_PXC should be provided for release run!")
-        }
-    }
-}
-
 String getParam(String paramName, String keyName = null) {
     keyName = keyName ?: paramName
 
@@ -37,16 +28,16 @@ void prepareNode() {
         cloud/local/checkout $GIT_REPO $GIT_BRANCH
     """
 
-    if ("$RELEASE_RUN" == "YES") {
+    if ("$PILLAR_VERSION" != "none") {
         echo "=========================[ Getting parameters for release test ]========================="
-        IMAGE_OPERATOR = params["IMAGE_OPERATOR"] ?: getParam("IMAGE_OPERATOR")
-        IMAGE_PXC = params["IMAGE_PXC"] ?: getParam("IMAGE_PXC", "IMAGE_PXC${PILLAR_VERSION}")
-        IMAGE_PROXY = params["IMAGE_PROXY"] ?: getParam("IMAGE_PROXY")
-        IMAGE_HAPROXY = params["IMAGE_HAPROXY"] ?: getParam("IMAGE_HAPROXY")
-        IMAGE_BACKUP = params["IMAGE_BACKUP"] ?: getParam("IMAGE_BACKUP", "IMAGE_BACKUP${PILLAR_VERSION}")
-        IMAGE_LOGCOLLECTOR = params["IMAGE_LOGCOLLECTOR"] ?: getParam("IMAGE_LOGCOLLECTOR")
-        IMAGE_PMM_CLIENT = params["IMAGE_PMM_CLIENT"] ?: getParam("IMAGE_PMM_CLIENT")
-        IMAGE_PMM_SERVER = params["IMAGE_PMM_SERVER"] ?: getParam("IMAGE_PMM_SERVER")
+        IMAGE_OPERATOR = IMAGE_OPERATOR ?: getParam("IMAGE_OPERATOR")
+        IMAGE_PXC = IMAGE_PXC ?: getParam("IMAGE_PXC", "IMAGE_PXC${PILLAR_VERSION}")
+        IMAGE_PROXY = IMAGE_PROXY ?: getParam("IMAGE_PROXY")
+        IMAGE_HAPROXY = IMAGE_HAPROXY ?: getParam("IMAGE_HAPROXY")
+        IMAGE_BACKUP = IMAGE_BACKUP ?: getParam("IMAGE_BACKUP", "IMAGE_BACKUP${PILLAR_VERSION}")
+        IMAGE_LOGCOLLECTOR = IMAGE_LOGCOLLECTOR ?: getParam("IMAGE_LOGCOLLECTOR")
+        IMAGE_PMM_CLIENT = IMAGE_PMM_CLIENT ?: getParam("IMAGE_PMM_CLIENT")
+        IMAGE_PMM_SERVER = IMAGE_PMM_SERVER ?: getParam("IMAGE_PMM_SERVER")
         if ("$PLATFORM_VER" == "min".toLowerCase() || "$PLATFORM_VER" == "max".toLowerCase()) {
             PLATFORM_VER = getParam("PLATFORM_VER", "EKS_${PLATFORM_VER}")
         }
@@ -72,16 +63,14 @@ void prepareNode() {
     }
 
     if ("$IMAGE_PXC") {
-        release = ("$RELEASE_RUN" == "YES") ? "RELEASE-" : ""
+        release = ("$PILLAR_VERSION" != "none") ? "RELEASE-" : ""
         cw = ("$CLUSTER_WIDE" == "YES") ? "CW" : "NON-CW"
         currentBuild.description = "$release$GIT_BRANCH-$PLATFORM_VER-$cw-" + "$IMAGE_PXC".split(":")[1]
     }
 
-    script {
-        GIT_SHORT_COMMIT = sh(script: 'git -C source rev-parse --short HEAD', , returnStdout: true).trim()
-        CLUSTER_NAME = sh(script: "echo jenkins-ver-pxc-$GIT_SHORT_COMMIT | tr '[:upper:]' '[:lower:]'", , returnStdout: true).trim()
-        PARAMS_HASH = sh(script: "echo $GIT_BRANCH-$GIT_SHORT_COMMIT-$PLATFORM_VER-$CLUSTER_WIDE-$IMAGE_OPERATOR-$IMAGE_PXC-$IMAGE_PROXY-$IMAGE_HAPROXY-$IMAGE_BACKUP-$IMAGE_LOGCOLLECTOR-$IMAGE_PMM_CLIENT-$IMAGE_PMM_SERVER | md5sum | cut -d' ' -f1", , returnStdout: true).trim()
-    }
+    GIT_SHORT_COMMIT = sh(script: 'git -C source rev-parse --short HEAD', , returnStdout: true).trim()
+    CLUSTER_NAME = sh(script: "echo jenkins-ver-pxc-$GIT_SHORT_COMMIT | tr '[:upper:]' '[:lower:]'", , returnStdout: true).trim()
+    PARAMS_HASH = sh(script: "echo $GIT_BRANCH-$GIT_SHORT_COMMIT-$PLATFORM_VER-$CLUSTER_WIDE-$IMAGE_OPERATOR-$IMAGE_PXC-$IMAGE_PROXY-$IMAGE_HAPROXY-$IMAGE_BACKUP-$IMAGE_LOGCOLLECTOR-$IMAGE_PMM_CLIENT-$IMAGE_PMM_SERVER | md5sum | cut -d' ' -f1", , returnStdout: true).trim()
 }
 
 void dockerBuildPush() {
@@ -394,13 +383,10 @@ pipeline {
             name: 'IGNORE_PREVIOUS_RUN'
         )
         choice(
-            choices: 'NO\nYES',
-            description: 'Release run?',
-            name: 'RELEASE_RUN'
         )
-        string(
-            defaultValue: '80',
-            description: 'For RELEASE_RUN only. Major version like 80, 57, etc',
+        choice(
+            choices: 'none\n80\n57',
+            description: 'Can be 08, 57, etc. or none. Implies release run.',
             name: 'PILLAR_VERSION'
         )
         string(
@@ -464,7 +450,6 @@ pipeline {
     stages {
         stage('Prepare node') {
             steps {
-                verifyParams()
                 prepareNode()
             }
         }

--- a/cloud/jenkins/pxc_operator_eks_version.groovy
+++ b/cloud/jenkins/pxc_operator_eks_version.groovy
@@ -1,36 +1,35 @@
 region='eu-west-3'
 tests=[]
 clusters=[]
+release_versions="source/e2e-tests/release_versions"
 
-void prepareNode() {
-    echo "=========================[ Installing tools on the Jenkins executor ]========================="
-    sh """
-        sudo curl -s -L -o /usr/local/bin/kubectl https://dl.k8s.io/release/\$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl && sudo chmod +x /usr/local/bin/kubectl
-        kubectl version --client --output=yaml
-
-        curl -fsSL https://get.helm.sh/helm-v3.12.3-linux-amd64.tar.gz | sudo tar -C /usr/local/bin --strip-components 1 -xzf - linux-amd64/helm
-
-        sudo curl -fsSL https://github.com/mikefarah/yq/releases/download/v4.44.1/yq_linux_amd64 -o /usr/local/bin/yq && sudo chmod +x /usr/local/bin/yq
-        sudo curl -fsSL https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux64 -o /usr/local/bin/jq && sudo chmod +x /usr/local/bin/jq
-
-        curl -sL https://github.com/eksctl-io/eksctl/releases/latest/download/eksctl_\$(uname -s)_amd64.tar.gz | sudo tar -C /usr/local/bin -xzf - && sudo chmod +x /usr/local/bin/eksctl
-
-        sudo yum install -y https://repo.percona.com/yum/percona-release-latest.noarch.rpm || true
-        sudo percona-release enable-only tools
-        sudo yum install -y percona-xtrabackup-80 | true
-    """
-
-    if ("$PLATFORM_VER" == "latest") {
-        USED_PLATFORM_VER = sh(script: "eksctl version -ojson | jq -r '.EKSServerSupportedVersions | max'", , returnStdout: true).trim()
-    } else {
+void verifyParams() {
+    if ("$RELEASE_RUN" == "YES") {
+        echo "=========================[ RELEASE RUN ]========================="
+        if (!"$PILLAR_VERSION" && !"$IMAGE_PXC") {
+            error("Either PILLAR_VERSION or IMAGE_PXC should be provided for release run!")
+        }
         USED_PLATFORM_VER="$PLATFORM_VER"
     }
-    echo "USED_PLATFORM_VER=$USED_PLATFORM_VER"
+}
 
-    if ("$IMAGE_PXC") {
-        currentBuild.description = "$GIT_BRANCH-$USED_PLATFORM_VER-CW_$CLUSTER_WIDE-" + "$IMAGE_PXC".split(":")[1]
+String getParam(String PARAM_NAME) {
+    def param = "${params[PARAM_NAME]}"
+
+    if ("$param" && "$param" != "null" && param != "") {
+        echo "$PARAM_NAME=$param (from job parameters)"
+    } else {
+        param = sh(script: "grep -iE '^\\s*$PARAM_NAME=' $release_versions | cut -d = -f 2 | tr -d \'\"\'| tail -1", , returnStdout: true).trim()
+        if ("$param") {
+            echo "$PARAM_NAME=$param (from params file)"
+        } else {
+            error("$PARAM_NAME not found in params file $release_versions")
+        }
     }
+    return param
+}
 
+void prepareNode() {
     echo "=========================[ Cloning the sources ]========================="
     git branch: 'master', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
     sh """
@@ -43,18 +42,58 @@ void prepareNode() {
         cloud/local/checkout $GIT_REPO $GIT_BRANCH
     """
 
+    if ("$RELEASE_RUN" == "YES") {
+        echo "=========================[ Getting parameters for release test ]========================="
+        IMAGE_OPERATOR = getParam("IMAGE_OPERATOR")
+        IMAGE_PXC = getParam("IMAGE_PXC${PILLAR_VERSION}")
+        IMAGE_PROXY = getParam("IMAGE_PROXY")
+        IMAGE_HAPROXY = getParam("IMAGE_HAPROXY")
+        IMAGE_BACKUP = getParam("IMAGE_BACKUP${PILLAR_VERSION}")
+        IMAGE_LOGCOLLECTOR = getParam("IMAGE_LOGCOLLECTOR")
+        IMAGE_PMM_CLIENT = getParam("IMAGE_PMM_CLIENT")
+        IMAGE_PMM_SERVER = getParam("IMAGE_PMM_SERVER")
+        if ("$PLATFORM_VER" == "min".toLowerCase() || "$PLATFORM_VER" == "max".toLowerCase()) {
+            PLATFORM_VER = getParam("EKS_${PLATFORM_VER}")
+        }
+    } else {
+        echo "=========================[ Not a release run. Using job params only! ]========================="
+    }
+
+    echo "=========================[ Installing tools on the Jenkins executor ]========================="
+    sh """
+        sudo curl -s -L -o /usr/local/bin/kubectl https://dl.k8s.io/release/\$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl && sudo chmod +x /usr/local/bin/kubectl
+        kubectl version --client --output=yaml
+
+        curl -fsSL https://get.helm.sh/helm-v3.12.3-linux-amd64.tar.gz | sudo tar -C /usr/local/bin --strip-components 1 -xzf - linux-amd64/helm
+
+        sudo curl -fsSL https://github.com/mikefarah/yq/releases/download/v4.44.1/yq_linux_amd64 -o /usr/local/bin/yq && sudo chmod +x /usr/local/bin/yq
+        sudo curl -fsSL https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux64 -o /usr/local/bin/jq && sudo chmod +x /usr/local/bin/jq
+
+        curl -sL https://github.com/eksctl-io/eksctl/releases/latest/download/eksctl_\$(uname -s)_amd64.tar.gz | sudo tar -C /usr/local/bin -xzf - && sudo chmod +x /usr/local/bin/eksctl
+    """
+
+    if ("$PLATFORM_VER" == "latest") {
+        USED_PLATFORM_VER = sh(script: "eksctl version -ojson | jq -r '.EKSServerSupportedVersions | max'", , returnStdout: true).trim()
+    }
+
+    if ("$IMAGE_PXC") {
+        release = ("$RELEASE_RUN" == "YES") ? "RELEASE-" : ""
+        cw = ("$CLUSTER_WIDE" == "YES") ? "CW" : "NON-CW"
+        currentBuild.description = "$release$GIT_BRANCH-$PLATFORM_VER-$cw-" + "$IMAGE_PXC".split(":")[1]
+    }
+
     script {
         GIT_SHORT_COMMIT = sh(script: 'git -C source rev-parse --short HEAD', , returnStdout: true).trim()
         CLUSTER_NAME = sh(script: "echo jenkins-ver-pxc-$GIT_SHORT_COMMIT | tr '[:upper:]' '[:lower:]'", , returnStdout: true).trim()
-        PARAMS_HASH = sh(script: "echo $GIT_BRANCH-$GIT_SHORT_COMMIT-$USED_PLATFORM_VER-$CLUSTER_WIDE-$OPERATOR_IMAGE-$IMAGE_PXC-$IMAGE_PROXY-$IMAGE_HAPROXY-$IMAGE_BACKUP-$IMAGE_LOGCOLLECTOR-$IMAGE_PMM_CLIENT-$IMAGE_PMM_SERVER | md5sum | cut -d' ' -f1", , returnStdout: true).trim()
+        PARAMS_HASH = sh(script: "echo $GIT_BRANCH-$GIT_SHORT_COMMIT-$USED_PLATFORM_VER-$CLUSTER_WIDE-$IMAGE_OPERATOR-$IMAGE_PXC-$IMAGE_PROXY-$IMAGE_HAPROXY-$IMAGE_BACKUP-$IMAGE_LOGCOLLECTOR-$IMAGE_PMM_CLIENT-$IMAGE_PMM_SERVER | md5sum | cut -d' ' -f1", , returnStdout: true).trim()
     }
 }
 
 void dockerBuildPush() {
-    echo "=========================[ Building and Pushing the Docker image ]========================="
+    echo "=========================[ Building and Pushing the operator Docker image ]========================="
     withCredentials([usernamePassword(credentialsId: 'hub.docker.com', passwordVariable: 'PASS', usernameVariable: 'USER')]) {
         sh """
-            if [[ "$OPERATOR_IMAGE" ]]; then
+            if [[ "$IMAGE_OPERATOR" ]]; then
                 echo "SKIP: Build is not needed, operator image was set!"
             else
                 cd source
@@ -94,8 +133,8 @@ void initTests() {
     }
 
     echo "Marking passed tests in the tests map!"
-    if ("$IGNORE_PREVIOUS_RUN" == "NO") {
-        withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AMI/OVF', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
+    withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AMI/OVF', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
+        if ("$IGNORE_PREVIOUS_RUN" == "NO") {
             sh """
                 aws s3 ls s3://percona-jenkins-artifactory/$JOB_NAME/$GIT_SHORT_COMMIT/ || :
             """
@@ -109,9 +148,7 @@ void initTests() {
                     tests[i]["result"] = "passed"
                 }
             }
-        }
-    } else {
-        withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AMI/OVF', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
+        } else {
             sh """
                 aws s3 rm "s3://percona-jenkins-artifactory/$JOB_NAME/$GIT_SHORT_COMMIT/" --recursive --exclude "*" --include "*-$PARAMS_HASH" || :
             """
@@ -182,7 +219,6 @@ nodeGroups:
         - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
         - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
         - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
-        - arn:aws:iam::aws:policy/AmazonS3FullAccess
       instancesDistribution:
         maxPrice: 0.15
         instanceTypes: ["m5.xlarge", "m5.2xlarge"] # At least two instance types should be specified
@@ -200,7 +236,6 @@ EOF
     withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'eks-cicd', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
         sh """
             export KUBECONFIG=/tmp/$CLUSTER_NAME-$CLUSTER_SUFFIX
-            export PATH=/home/ec2-user/.local/bin:$PATH
             eksctl create cluster -f cluster-${CLUSTER_SUFFIX}.yaml
             kubectl annotate storageclass gp2 storageclass.kubernetes.io/is-default-class=true
             kubectl create clusterrolebinding cluster-admin-binding1 --clusterrole=cluster-admin --user="\$(aws sts get-caller-identity|jq -r '.Arn')"
@@ -220,25 +255,23 @@ void runTest(Integer TEST_ID) {
             tests[TEST_ID]["result"] = "failure"
 
             timeout(time: 90, unit: 'MINUTES') {
-                withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'eks-cicd'], file(credentialsId: 'eks-conf-file', variable: 'EKS_CONF_FILE')]) {
-                    sh """
-                        cd source
+                sh """
+                    cd source
 
-                        export DEBUG_TESTS=1
-                        [[ "$CLUSTER_WIDE" == "YES" ]] && export OPERATOR_NS=pxc-operator
-                        [[ "$OPERATOR_IMAGE" ]] && export IMAGE=$OPERATOR_IMAGE || export IMAGE=perconalab/percona-xtradb-cluster-operator:$GIT_BRANCH
-                        export IMAGE_PXC=$IMAGE_PXC
-                        export IMAGE_PROXY=$IMAGE_PROXY
-                        export IMAGE_HAPROXY=$IMAGE_HAPROXY
-                        export IMAGE_BACKUP=$IMAGE_BACKUP
-                        export IMAGE_LOGCOLLECTOR=$IMAGE_LOGCOLLECTOR
-                        export IMAGE_PMM_CLIENT=$IMAGE_PMM_CLIENT
-                        export IMAGE_PMM_SERVER=$IMAGE_PMM_SERVER
-                        export KUBECONFIG=/tmp/$CLUSTER_NAME-$clusterSuffix
+                    export DEBUG_TESTS=1
+                    [[ "$CLUSTER_WIDE" == "YES" ]] && export OPERATOR_NS=pxc-operator
+                    export IMAGE=$IMAGE_OPERATOR
+                    export IMAGE_PXC=$IMAGE_PXC
+                    export IMAGE_PROXY=$IMAGE_PROXY
+                    export IMAGE_HAPROXY=$IMAGE_HAPROXY
+                    export IMAGE_BACKUP=$IMAGE_BACKUP
+                    export IMAGE_LOGCOLLECTOR=$IMAGE_LOGCOLLECTOR
+                    export IMAGE_PMM_CLIENT=$IMAGE_PMM_CLIENT
+                    export IMAGE_PMM_SERVER=$IMAGE_PMM_SERVER
+                    export KUBECONFIG=/tmp/$CLUSTER_NAME-$clusterSuffix
 
-                        e2e-tests/$testName/run
-                    """
-                }
+                    e2e-tests/$testName/run
+                """
             }
             pushArtifactFile("$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$USED_PLATFORM_VER-$PXC_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH")
             tests[TEST_ID]["result"] = "passed"
@@ -274,24 +307,36 @@ void pushArtifactFile(String FILE_NAME) {
     }
 }
 
-TestsReport = '<testsuite name=\\"PXC-EKS-version\\">\n'
 void makeReport() {
     echo "=========================[ Generating Test Report ]========================="
-    for (int i=0; i<tests.size(); i++) {
-        def testResult = tests[i]["result"]
-        def testTime = tests[i]["time"]
-        def testName = tests[i]["name"]
-
-        TestsReport = TestsReport + '<testcase name=\\"' + testName + '\\" time=\\"' + testTime + '\\"><'+ testResult +'/></testcase>\n'
+    testsReport = '<testsuite name="PXC-EKS-version">\n'
+    for (int i = 0; i < tests.size(); i ++) {
+        testsReport += '<testcase name="' + tests[i]["name"] + '" time="' + tests[i]["time"] + '"><'+ tests[i]["result"] +'/></testcase>\n'
     }
-    TestsReport = TestsReport + '</testsuite>\n'
+    testsReport += '</testsuite>\n'
+
+    echo "=========================[ Generating Parameters Report ]========================="
+    pipelineParameters = """
+        testsuite name=PXC-EKS-version
+        IMAGE_OPERATOR=$IMAGE_OPERATOR
+        IMAGE_PXC=$IMAGE_PXC
+        IMAGE_PROXY=$IMAGE_PROXY
+        IMAGE_HAPROXY=$IMAGE_HAPROXY
+        IMAGE_BACKUP=$IMAGE_BACKUP
+        IMAGE_LOGCOLLECTOR=$IMAGE_LOGCOLLECTOR
+        IMAGE_PMM_CLIENT=$IMAGE_PMM_CLIENT
+        IMAGE_PMM_SERVER=$IMAGE_PMM_SERVER
+        USED_PLATFORM_VER=$USED_PLATFORM_VER
+    """
+
+    writeFile file: "TestsReport.xml", text: testsReport
+    writeFile file: 'PipelineParameters.txt', text: pipelineParameters
 }
 
 void shutdownCluster(String CLUSTER_SUFFIX) {
     withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'eks-cicd', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
         sh """
             export KUBECONFIG=/tmp/$CLUSTER_NAME-$CLUSTER_SUFFIX
-            eksctl delete addon --name aws-ebs-csi-driver --cluster $CLUSTER_NAME-$CLUSTER_SUFFIX --region $region || true
             for namespace in \$(kubectl get namespaces --no-headers | awk '{print \$1}' | grep -vE "^kube-|^openshift" | sed '/-operator/ s/^/1-/' | sort | sed 's/^1-//'); do
                 kubectl delete deployments --all -n \$namespace --force --grace-period=0 || true
                 kubectl delete sts --all -n \$namespace --force --grace-period=0 || true
@@ -351,6 +396,16 @@ pipeline {
             description: 'Ignore passed tests in previous run (run all)',
             name: 'IGNORE_PREVIOUS_RUN'
         )
+        choice(
+            choices: 'NO\nYES',
+            description: 'Release run?',
+            name: 'RELEASE_RUN'
+        )
+        string(
+            defaultValue: '80',
+            description: 'For RELEASE_RUN only. Major version like 80, 57, etc',
+            name: 'PILLAR_VERSION'
+        )
         string(
             defaultValue: 'main',
             description: 'Tag/Branch for percona/percona-xtradb-cluster-operator repository',
@@ -370,7 +425,7 @@ pipeline {
         string(
             defaultValue: '',
             description: 'Operator image: perconalab/percona-xtradb-cluster-operator:main',
-            name: 'OPERATOR_IMAGE')
+            name: 'IMAGE_OPERATOR')
         string(
             defaultValue: '',
             description: 'PXC image: perconalab/percona-xtradb-cluster-operator:main-pxc8.0',
@@ -412,6 +467,7 @@ pipeline {
     stages {
         stage('Prepare node') {
             steps {
+                verifyParams()
                 prepareNode()
             }
         }
@@ -482,19 +538,19 @@ pipeline {
         always {
             echo "CLUSTER ASSIGNMENTS\n" + tests.toString().replace("], ","]\n").replace("]]","]").replaceFirst("\\[","")
             makeReport()
-            sh """
-                echo "$TestsReport" > TestsReport.xml
-            """
             step([$class: 'JUnitResultArchiver', testResults: '*.xml', healthScaleFactor: 1.0])
-            archiveArtifacts '*.xml'
+            archiveArtifacts '*.xml,*.txt'
 
             script {
+                if (currentBuild.result != null && currentBuild.result != 'SUCCESS') {
+                    slackSend channel: '#cloud-dev-ci', color: '#FF0000', message: "[$JOB_NAME]: build $currentBuild.result, $BUILD_URL"
+                }
+
                 clusters.each { shutdownCluster(it) }
             }
 
             sh """
                 sudo docker system prune --volumes -af
-                sudo rm -rf *
             """
             deleteDir()
         }

--- a/cloud/jenkins/pxc_operator_eks_version.groovy
+++ b/cloud/jenkins/pxc_operator_eks_version.groovy
@@ -250,7 +250,7 @@ void runTest(Integer TEST_ID) {
 
                         export DEBUG_TESTS=1
                         [[ "$CLUSTER_WIDE" == "YES" ]] && export OPERATOR_NS=pxc-operator
-                        export IMAGE=$IMAGE_OPERATOR
+                        [[ "$IMAGE_OPERATOR" ]] && export IMAGE=$IMAGE_OPERATOR || export IMAGE=perconalab/percona-xtradb-cluster-operator:$GIT_BRANCH
                         export IMAGE_PXC=$IMAGE_PXC
                         export IMAGE_PROXY=$IMAGE_PROXY
                         export IMAGE_HAPROXY=$IMAGE_HAPROXY

--- a/cloud/jenkins/pxc_operator_eks_version.groovy
+++ b/cloud/jenkins/pxc_operator_eks_version.groovy
@@ -203,6 +203,7 @@ nodeGroups:
         - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
         - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
         - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+        - arn:aws:iam::aws:policy/AmazonS3FullAccess
       instancesDistribution:
         maxPrice: 0.15
         instanceTypes: ["m5.xlarge", "m5.2xlarge"] # At least two instance types should be specified

--- a/cloud/jenkins/pxc_operator_eks_version.groovy
+++ b/cloud/jenkins/pxc_operator_eks_version.groovy
@@ -136,7 +136,7 @@ void initTests() {
 
             for (int i=0; i<tests.size(); i++) {
                 def testName = tests[i]["name"]
-                def file="$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$PXC_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH"
+                def file="$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$DB_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH"
                 def retFileExists = sh(script: "aws s3api head-object --bucket percona-jenkins-artifactory --key $JOB_NAME/$GIT_SHORT_COMMIT/$file >/dev/null 2>&1", returnStatus: true)
 
                 if (retFileExists == 0) {
@@ -270,7 +270,7 @@ void runTest(Integer TEST_ID) {
                     """
                 }
             }
-            pushArtifactFile("$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$PXC_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH")
+            pushArtifactFile("$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$DB_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH")
             tests[TEST_ID]["result"] = "passed"
             return true
         }
@@ -377,7 +377,7 @@ void shutdownCluster(String CLUSTER_SUFFIX) {
 pipeline {
     environment {
         CLEAN_NAMESPACE = 1
-        PXC_TAG = sh(script: "[[ \"$IMAGE_PXC\" ]] && echo $IMAGE_PXC | awk -F':' '{print \$2}' || echo main", , returnStdout: true).trim()
+        DB_TAG = sh(script: "[[ \"$IMAGE_PXC\" ]] && echo $IMAGE_PXC | awk -F':' '{print \$2}' || echo main", , returnStdout: true).trim()
     }
     parameters {
         choice(

--- a/cloud/jenkins/pxc_operator_gke_latest.groovy
+++ b/cloud/jenkins/pxc_operator_gke_latest.groovy
@@ -13,7 +13,6 @@ void verifyParams() {
         GKE_RELEASE_CHANNEL = "stable"
         echo "Forcing GKE_RELEASE_CHANNEL=stable, because it's a release run!"
     }
-    USED_PLATFORM_VER="$PLATFORM_VER"
 }
 
 String getParam(String PARAM_NAME) {
@@ -61,6 +60,8 @@ void prepareNode() {
     } else {
         echo "=========================[ Not a release run. Using job params only! ]========================="
     }
+
+    USED_PLATFORM_VER="$PLATFORM_VER"
 
     echo "=========================[ Installing tools on the Jenkins executor ]========================="
     sh """

--- a/cloud/jenkins/pxc_operator_gke_latest.groovy
+++ b/cloud/jenkins/pxc_operator_gke_latest.groovy
@@ -374,7 +374,7 @@ pipeline {
             name: 'ARCH')
         choice(
             choices: 'none\n80\n57',
-            description: 'Can be 08, 57, etc. or none. Implies release run.',
+            description: 'Can be 80, 57, etc. or none. Implies release run.',
             name: 'PILLAR_VERSION')
         string(
             defaultValue: 'main',

--- a/cloud/jenkins/pxc_operator_gke_latest.groovy
+++ b/cloud/jenkins/pxc_operator_gke_latest.groovy
@@ -212,7 +212,7 @@ void createCluster(String CLUSTER_SUFFIX) {
                     --subnetwork=jenkins-$CLUSTER_SUFFIX \
                     --cluster-ipv4-cidr=/21 \
                     --labels delete-cluster-after-hours=6 \
-                    --enable-ip-alias \
+                    --enable-ip-alias &&\
                 kubectl create clusterrolebinding cluster-admin-binding1 --clusterrole=cluster-admin --user=\$(gcloud config get-value core/account)
                 exitCode=\$?
                 if [[ \$exitCode == 0 ]]; then break; fi

--- a/cloud/jenkins/pxc_operator_gke_latest.groovy
+++ b/cloud/jenkins/pxc_operator_gke_latest.groovy
@@ -255,7 +255,7 @@ void runTest(Integer TEST_ID) {
 
                     export DEBUG_TESTS=1
                     [[ "$CLUSTER_WIDE" == "YES" ]] && export OPERATOR_NS=pxc-operator
-                    export IMAGE=$IMAGE_OPERATOR
+                    [[ "$IMAGE_OPERATOR" ]] && export IMAGE=$IMAGE_OPERATOR || export IMAGE=perconalab/percona-xtradb-cluster-operator:$GIT_BRANCH
                     export IMAGE_PXC=$IMAGE_PXC
                     export IMAGE_PROXY=$IMAGE_PROXY
                     export IMAGE_HAPROXY=$IMAGE_HAPROXY

--- a/cloud/jenkins/pxc_operator_gke_latest.groovy
+++ b/cloud/jenkins/pxc_operator_gke_latest.groovy
@@ -15,18 +15,14 @@ void verifyParams() {
     }
 }
 
-String getParam(String PARAM_NAME) {
-    def param = "${params[PARAM_NAME]}"
+String getParam(String paramName, String keyName = null) {
+    keyName = keyName ?: paramName
 
-    if ("$param" && "$param" != "null" && param != "") {
-        echo "$PARAM_NAME=$param (from job parameters)"
+    param = sh(script: "grep -iE '^\\s*$keyName=' $release_versions | cut -d = -f 2 | tr -d \'\"\'| tail -1", , returnStdout: true).trim()
+    if ("$param") {
+        echo "$paramName=$param (from params file)"
     } else {
-        param = sh(script: "grep -iE '^\\s*$PARAM_NAME=' $release_versions | cut -d = -f 2 | tr -d \'\"\'| tail -1", , returnStdout: true).trim()
-        if ("$param") {
-            echo "$PARAM_NAME=$param (from params file)"
-        } else {
-            error("$PARAM_NAME not found in params file $release_versions")
-        }
+        error("$keyName not found in params file $release_versions")
     }
     return param
 }
@@ -46,16 +42,16 @@ void prepareNode() {
 
     if ("$RELEASE_RUN" == "YES") {
         echo "=========================[ Getting parameters for release test ]========================="
-        IMAGE_OPERATOR = getParam("IMAGE_OPERATOR")
-        IMAGE_PXC = getParam("IMAGE_PXC${PILLAR_VERSION}")
-        IMAGE_PROXY = getParam("IMAGE_PROXY")
-        IMAGE_HAPROXY = getParam("IMAGE_HAPROXY")
-        IMAGE_BACKUP = getParam("IMAGE_BACKUP${PILLAR_VERSION}")
-        IMAGE_LOGCOLLECTOR = getParam("IMAGE_LOGCOLLECTOR")
-        IMAGE_PMM_CLIENT = getParam("IMAGE_PMM_CLIENT")
-        IMAGE_PMM_SERVER = getParam("IMAGE_PMM_SERVER")
+        IMAGE_OPERATOR = params["IMAGE_OPERATOR"] ?: getParam("IMAGE_OPERATOR")
+        IMAGE_PXC = params["IMAGE_PXC"] ?: getParam("IMAGE_PXC", "IMAGE_PXC${PILLAR_VERSION}")
+        IMAGE_PROXY = params["IMAGE_PROXY"] ?: getParam("IMAGE_PROXY")
+        IMAGE_HAPROXY = params["IMAGE_HAPROXY"] ?: getParam("IMAGE_HAPROXY")
+        IMAGE_BACKUP = params["IMAGE_BACKUP"] ?: getParam("IMAGE_BACKUP", "IMAGE_BACKUP${PILLAR_VERSION}")
+        IMAGE_LOGCOLLECTOR = params["IMAGE_LOGCOLLECTOR"] ?: getParam("IMAGE_LOGCOLLECTOR")
+        IMAGE_PMM_CLIENT = params["IMAGE_PMM_CLIENT"] ?: getParam("IMAGE_PMM_CLIENT")
+        IMAGE_PMM_SERVER = params["IMAGE_PMM_SERVER"] ?: getParam("IMAGE_PMM_SERVER")
         if ("$PLATFORM_VER" == "min".toLowerCase() || "$PLATFORM_VER" == "max".toLowerCase()) {
-            PLATFORM_VER = getParam("GKE_${PLATFORM_VER}")
+            PLATFORM_VER = getParam("PLATFORM_VER", "GKE_${PLATFORM_VER}")
         }
     } else {
         echo "=========================[ Not a release run. Using job params only! ]========================="

--- a/cloud/jenkins/pxc_operator_gke_latest.groovy
+++ b/cloud/jenkins/pxc_operator_gke_latest.groovy
@@ -47,7 +47,7 @@ void prepareNode() {
     """
 
     if ("$RELEASE_RUN" == "YES") {
-        OPERATOR_IMAGE = getParam("OPERATOR_IMAGE")
+        IMAGE_OPERATOR = getParam("IMAGE_OPERATOR")
         IMAGE_PXC = getParam("IMAGE_PXC${PILLAR_VERSION}")
         IMAGE_PROXY = getParam("IMAGE_PROXY")
         IMAGE_HAPROXY = getParam("IMAGE_HAPROXY")
@@ -120,7 +120,7 @@ EOF
     script {
         GIT_SHORT_COMMIT = sh(script: 'git -C source rev-parse --short HEAD', , returnStdout: true).trim()
         CLUSTER_NAME = sh(script: "echo jenkins-lat-pxc-$GIT_SHORT_COMMIT | tr '[:upper:]' '[:lower:]'", , returnStdout: true).trim()
-        PARAMS_HASH = sh(script: "echo $GIT_BRANCH-$GIT_SHORT_COMMIT-$GKE_RELEASE_CHANNEL-$ARCH-$USED_PLATFORM_VER-$CLUSTER_WIDE-$OPERATOR_IMAGE-$IMAGE_PXC-$IMAGE_PROXY-$IMAGE_HAPROXY-$IMAGE_BACKUP-$IMAGE_LOGCOLLECTOR-$IMAGE_PMM_CLIENT-$IMAGE_PMM_SERVER | md5sum | cut -d' ' -f1", , returnStdout: true).trim()
+        PARAMS_HASH = sh(script: "echo $GIT_BRANCH-$GIT_SHORT_COMMIT-$GKE_RELEASE_CHANNEL-$ARCH-$USED_PLATFORM_VER-$CLUSTER_WIDE-$IMAGE_OPERATOR-$IMAGE_PXC-$IMAGE_PROXY-$IMAGE_HAPROXY-$IMAGE_BACKUP-$IMAGE_LOGCOLLECTOR-$IMAGE_PMM_CLIENT-$IMAGE_PMM_SERVER | md5sum | cut -d' ' -f1", , returnStdout: true).trim()
     }
 }
 
@@ -128,7 +128,7 @@ void dockerBuildPush() {
     echo "=========================[ Building and Pushing the operator Docker image ]========================="
     withCredentials([usernamePassword(credentialsId: 'hub.docker.com', passwordVariable: 'PASS', usernameVariable: 'USER')]) {
         sh """
-            if [[ "$OPERATOR_IMAGE" ]]; then
+            if [[ "$IMAGE_OPERATOR" ]]; then
                 echo "SKIP: Build is not needed, operator image was set!"
             else
                 cd source
@@ -281,7 +281,7 @@ void runTest(Integer TEST_ID) {
 
                     export DEBUG_TESTS=1
                     [[ "$CLUSTER_WIDE" == "YES" ]] && export OPERATOR_NS=pxc-operator
-                    [[ "$OPERATOR_IMAGE" ]] && export IMAGE=$OPERATOR_IMAGE || export IMAGE=perconalab/percona-xtradb-cluster-operator:$GIT_BRANCH
+                    [[ "$IMAGE_OPERATOR" ]] && export IMAGE=$IMAGE_OPERATOR || export IMAGE=perconalab/percona-xtradb-cluster-operator:$GIT_BRANCH
                     export IMAGE_PXC=$IMAGE_PXC
                     export IMAGE_PROXY=$IMAGE_PROXY
                     export IMAGE_HAPROXY=$IMAGE_HAPROXY
@@ -342,7 +342,7 @@ void makeReport() {
 
     echo "=========================[ Generating Images Report ]========================="
     TestsImages = "testsuite name='PSMDB-GKE-latest'\n" +\
-                    "OPERATOR_IMAGE=$OPERATOR_IMAGE\n" +\
+                    "IMAGE_OPERATOR=$IMAGE_OPERATOR\n" +\
                     "IMAGE_PXC=$IMAGE_PXC\n" +\
                     "IMAGE_PROXY=$IMAGE_PROXY\n" +\
                     "IMAGE_HAPROXY=$IMAGE_HAPROXY\n" +\
@@ -428,7 +428,7 @@ pipeline {
         string(
             defaultValue: '',
             description: 'Operator image: perconalab/percona-xtradb-cluster-operator:main',
-            name: 'OPERATOR_IMAGE')
+            name: 'IMAGE_OPERATOR')
         string(
             defaultValue: '',
             description: 'PXC image: perconalab/percona-xtradb-cluster-operator:main-pxc8.0',

--- a/cloud/jenkins/pxc_operator_gke_latest.groovy
+++ b/cloud/jenkins/pxc_operator_gke_latest.groovy
@@ -51,7 +51,7 @@ void prepareNode() {
         IMAGE_PXC = getParam("IMAGE_PXC${PILLAR_VERSION}")
         IMAGE_PROXY = getParam("IMAGE_PROXY")
         IMAGE_HAPROXY = getParam("IMAGE_HAPROXY")
-        IMAGE_BACKUP = getParam("IMAGE_BACKUP"${PILLAR_VERSION})
+        IMAGE_BACKUP = getParam("IMAGE_BACKUP${PILLAR_VERSION}")
         IMAGE_LOGCOLLECTOR = getParam("IMAGE_LOGCOLLECTOR")
         IMAGE_PMM_CLIENT = getParam("IMAGE_PMM_CLIENT")
         IMAGE_PMM_SERVER = getParam("IMAGE_PMM_SERVER")

--- a/cloud/jenkins/pxc_operator_gke_latest.groovy
+++ b/cloud/jenkins/pxc_operator_gke_latest.groovy
@@ -68,6 +68,10 @@ repo_gpgcheck=0
 gpgkey=https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
 EOF
         sudo yum install -y google-cloud-cli google-cloud-cli-gke-gcloud-auth-plugin
+
+        sudo yum install -y https://repo.percona.com/yum/percona-release-latest.noarch.rpm || true
+        sudo percona-release enable-only tools
+        sudo yum install -y percona-xtrabackup-80 | true
     """
 
     echo "=========================[ Logging in the Kubernetes provider ]========================="

--- a/cloud/jenkins/pxc_operator_gke_latest.groovy
+++ b/cloud/jenkins/pxc_operator_gke_latest.groovy
@@ -368,18 +368,15 @@ pipeline {
         choice(
             choices: 'NO\nYES',
             description: 'Ignore passed tests in previous run (run all)',
-            name: 'IGNORE_PREVIOUS_RUN'
-        )
+            name: 'IGNORE_PREVIOUS_RUN')
         choice(
             choices: 'amd64\narm64',
             description: 'Architecture',
-            name: 'ARCH'
-        )
+            name: 'ARCH')
         choice(
             choices: 'none\n80\n57',
             description: 'Can be 08, 57, etc. or none. Implies release run.',
-            name: 'PILLAR_VERSION'
-        )
+            name: 'PILLAR_VERSION')
         string(
             defaultValue: 'main',
             description: 'Tag/Branch for percona/percona-xtradb-cluster-operator repository',

--- a/cloud/jenkins/pxc_operator_gke_latest.groovy
+++ b/cloud/jenkins/pxc_operator_gke_latest.groovy
@@ -365,8 +365,8 @@ pipeline {
             description: 'Ignore passed tests in previous run (run all)',
             name: 'IGNORE_PREVIOUS_RUN')
         choice(
-            choices: 'none\n80\n57',
-            description: 'Can be 80, 57, etc. or none. Implies release run.',
+            choices: 'none\n84\n80\n57',
+            description: 'Implies release run.',
             name: 'PILLAR_VERSION')
         string(
             defaultValue: 'main',
@@ -378,7 +378,7 @@ pipeline {
             name: 'GIT_REPO')
         string(
             defaultValue: 'latest',
-            description: 'GKE kubernetes version',
+            description: 'GKE kubernetes version. If set to min or max, value will be automatically taken from release_versions file.',
             name: 'PLATFORM_VER')
         choice(
             choices: 'rapid\nstable\nregular\nNone',

--- a/cloud/jenkins/pxc_operator_gke_latest.groovy
+++ b/cloud/jenkins/pxc_operator_gke_latest.groovy
@@ -23,7 +23,7 @@ String getParam(String PARAM_NAME) {
         echo "$PARAM_NAME=$param (from job parameters)"
         return param
     } else {
-        param = sh(script: "grep -E '^\\s*$PARAM_NAME=' ~/work/percona-xtradb-cluster-operator/e2e-tests/release_versions | awk -F '=' '{print $2}' | head -1", , returnStdout: true).trim()
+        param = sh(script: "grep -E '^\\s*$PARAM_NAME=' ~/work/percona-xtradb-cluster-operator/e2e-tests/release_versions | cut -d = -f 2 | tr -d \'\"\'| head -1", , returnStdout: true).trim()
         if ("$param") {
             echo "$PARAM_NAME=$param (from params file)"
             return param

--- a/cloud/jenkins/pxc_operator_gke_latest.groovy
+++ b/cloud/jenkins/pxc_operator_gke_latest.groovy
@@ -12,9 +12,8 @@ void verifyParams() {
 
         GKE_RELEASE_CHANNEL = "stable"
         echo "Forcing GKE_RELEASE_CHANNEL=stable, because it's a release run!"
-
-        USED_PLATFORM_VER="$PLATFORM_VER"
     }
+    USED_PLATFORM_VER="$PLATFORM_VER"
 }
 
 String getParam(String PARAM_NAME) {

--- a/cloud/jenkins/pxc_operator_gke_latest.groovy
+++ b/cloud/jenkins/pxc_operator_gke_latest.groovy
@@ -342,6 +342,7 @@ void makeReport() {
         IMAGE_PMM_CLIENT=$IMAGE_PMM_CLIENT
         IMAGE_PMM_SERVER=$IMAGE_PMM_SERVER
         USED_PLATFORM_VER=$USED_PLATFORM_VER
+        PLATFORM_VER=$PLATFORM_VER
     """
 
     writeFile file: "TestsReport.xml", text: testsReport

--- a/cloud/jenkins/pxc_operator_gke_latest.groovy
+++ b/cloud/jenkins/pxc_operator_gke_latest.groovy
@@ -402,8 +402,8 @@ pipeline {
             name: 'ARCH'
         )
         string(
-            defaultValue: '70',
-            description: 'For RELEASE_RUN only. Major version like 70,60, etc',
+            defaultValue: '80',
+            description: 'For RELEASE_RUN only. Major version like 80, 57, etc',
             name: 'PILLAR_VERSION'
         )
         string(

--- a/cloud/jenkins/pxc_operator_gke_latest.groovy
+++ b/cloud/jenkins/pxc_operator_gke_latest.groovy
@@ -3,18 +3,6 @@ tests=[]
 clusters=[]
 release_versions="source/e2e-tests/release_versions"
 
-void verifyParams() {
-    if ("$RELEASE_RUN" == "YES") {
-        echo "=========================[ RELEASE RUN ]========================="
-        if (!"$PILLAR_VERSION" && !"$IMAGE_PXC") {
-            error("Either PILLAR_VERSION or IMAGE_PXC should be provided for release run!")
-        }
-
-        GKE_RELEASE_CHANNEL = "stable"
-        echo "Forcing GKE_RELEASE_CHANNEL=stable, because it's a release run!"
-    }
-}
-
 String getParam(String paramName, String keyName = null) {
     keyName = keyName ?: paramName
 
@@ -40,16 +28,19 @@ void prepareNode() {
         cloud/local/checkout $GIT_REPO $GIT_BRANCH
     """
 
-    if ("$RELEASE_RUN" == "YES") {
+    if ("$PILLAR_VERSION" != "none") {
         echo "=========================[ Getting parameters for release test ]========================="
-        IMAGE_OPERATOR = params["IMAGE_OPERATOR"] ?: getParam("IMAGE_OPERATOR")
-        IMAGE_PXC = params["IMAGE_PXC"] ?: getParam("IMAGE_PXC", "IMAGE_PXC${PILLAR_VERSION}")
-        IMAGE_PROXY = params["IMAGE_PROXY"] ?: getParam("IMAGE_PROXY")
-        IMAGE_HAPROXY = params["IMAGE_HAPROXY"] ?: getParam("IMAGE_HAPROXY")
-        IMAGE_BACKUP = params["IMAGE_BACKUP"] ?: getParam("IMAGE_BACKUP", "IMAGE_BACKUP${PILLAR_VERSION}")
-        IMAGE_LOGCOLLECTOR = params["IMAGE_LOGCOLLECTOR"] ?: getParam("IMAGE_LOGCOLLECTOR")
-        IMAGE_PMM_CLIENT = params["IMAGE_PMM_CLIENT"] ?: getParam("IMAGE_PMM_CLIENT")
-        IMAGE_PMM_SERVER = params["IMAGE_PMM_SERVER"] ?: getParam("IMAGE_PMM_SERVER")
+        GKE_RELEASE_CHANNEL = "stable"
+        echo "Forcing GKE_RELEASE_CHANNEL=stable, because it's a release run!"
+
+        IMAGE_OPERATOR = IMAGE_OPERATOR ?: getParam("IMAGE_OPERATOR")
+        IMAGE_PXC = IMAGE_PXC ?: getParam("IMAGE_PXC", "IMAGE_PXC${PILLAR_VERSION}")
+        IMAGE_PROXY = IMAGE_PROXY ?: getParam("IMAGE_PROXY")
+        IMAGE_HAPROXY = IMAGE_HAPROXY ?: getParam("IMAGE_HAPROXY")
+        IMAGE_BACKUP = IMAGE_BACKUP ?: getParam("IMAGE_BACKUP", "IMAGE_BACKUP${PILLAR_VERSION}")
+        IMAGE_LOGCOLLECTOR = IMAGE_LOGCOLLECTOR ?: getParam("IMAGE_LOGCOLLECTOR")
+        IMAGE_PMM_CLIENT = IMAGE_PMM_CLIENT ?: getParam("IMAGE_PMM_CLIENT")
+        IMAGE_PMM_SERVER = IMAGE_PMM_SERVER ?: getParam("IMAGE_PMM_SERVER")
         if ("$PLATFORM_VER" == "min".toLowerCase() || "$PLATFORM_VER" == "max".toLowerCase()) {
             PLATFORM_VER = getParam("PLATFORM_VER", "GKE_${PLATFORM_VER}")
         }
@@ -100,16 +91,16 @@ EOF
     }
 
     if ("$IMAGE_PXC") {
-        release = ("$RELEASE_RUN" == "YES") ? "RELEASE-" : ""
+        release = ("$PILLAR_VERSION" != "none") ? "RELEASE-" : ""
         cw = ("$CLUSTER_WIDE" == "YES") ? "CW" : "NON-CW"
-        currentBuild.description = "${release}$GIT_BRANCH-$ARCH-$PLATFORM_VER-$GKE_RELEASE_CHANNEL-$cw-" + "$IMAGE_PXC".split(":")[1]
+        currentBuild.description = "$release$GIT_BRANCH-$ARCH-$PLATFORM_VER-$GKE_RELEASE_CHANNEL-$cw-" + "$IMAGE_PXC".split(":")[1]
     }
 
-    script {
-        GIT_SHORT_COMMIT = sh(script: 'git -C source rev-parse --short HEAD', , returnStdout: true).trim()
-        CLUSTER_NAME = sh(script: "echo jenkins-lat-pxc-$GIT_SHORT_COMMIT | tr '[:upper:]' '[:lower:]'", , returnStdout: true).trim()
-        PARAMS_HASH = sh(script: "echo $GIT_BRANCH-$GIT_SHORT_COMMIT-$GKE_RELEASE_CHANNEL-$ARCH-$PLATFORM_VER-$CLUSTER_WIDE-$IMAGE_OPERATOR-$IMAGE_PXC-$IMAGE_PROXY-$IMAGE_HAPROXY-$IMAGE_BACKUP-$IMAGE_LOGCOLLECTOR-$IMAGE_PMM_CLIENT-$IMAGE_PMM_SERVER | md5sum | cut -d' ' -f1", , returnStdout: true).trim()
-    }
+
+    GIT_SHORT_COMMIT = sh(script: 'git -C source rev-parse --short HEAD', , returnStdout: true).trim()
+    CLUSTER_NAME = sh(script: "echo jenkins-lat-pxc-$GIT_SHORT_COMMIT | tr '[:upper:]' '[:lower:]'", , returnStdout: true).trim()
+    PARAMS_HASH = sh(script: "echo $GIT_BRANCH-$GIT_SHORT_COMMIT-$GKE_RELEASE_CHANNEL-$ARCH-$PLATFORM_VER-$CLUSTER_WIDE-$IMAGE_OPERATOR-$IMAGE_PXC-$IMAGE_PROXY-$IMAGE_HAPROXY-$IMAGE_BACKUP-$IMAGE_LOGCOLLECTOR-$IMAGE_PMM_CLIENT-$IMAGE_PMM_SERVER | md5sum | cut -d' ' -f1", , returnStdout: true).trim()
+
 }
 
 void dockerBuildPush() {
@@ -380,18 +371,13 @@ pipeline {
             name: 'IGNORE_PREVIOUS_RUN'
         )
         choice(
-            choices: 'NO\nYES',
-            description: 'Release run?',
-            name: 'RELEASE_RUN'
-        )
-        choice(
             choices: 'amd64\narm64',
             description: 'Architecture',
             name: 'ARCH'
         )
-        string(
-            defaultValue: '80',
-            description: 'For RELEASE_RUN only. Major version like 80, 57, etc',
+        choice(
+            choices: 'none\n80\n57',
+            description: 'Can be 08, 57, etc. or none. Implies release run.',
             name: 'PILLAR_VERSION'
         )
         string(
@@ -459,7 +445,6 @@ pipeline {
     stages {
         stage('Prepare node') {
             steps {
-                verifyParams()
                 prepareNode()
             }
         }

--- a/cloud/jenkins/pxc_operator_gke_latest.groovy
+++ b/cloud/jenkins/pxc_operator_gke_latest.groovy
@@ -440,7 +440,7 @@ pipeline {
         copyArtifactPermission('pxc-operator-latest-scheduler');
     }
     stages {
-        stage('Prepare node') {
+        stage('Prepare Node') {
             steps {
                 prepareNode()
             }
@@ -450,7 +450,7 @@ pipeline {
                 dockerBuildPush()
             }
         }
-        stage('Init tests') {
+        stage('Init Tests') {
             steps {
                 initTests()
             }

--- a/cloud/jenkins/pxc_operator_gke_latest.groovy
+++ b/cloud/jenkins/pxc_operator_gke_latest.groovy
@@ -55,7 +55,6 @@ void prepareNode() {
         IMAGE_LOGCOLLECTOR = getParam("IMAGE_LOGCOLLECTOR")
         IMAGE_PMM_CLIENT = getParam("IMAGE_PMM_CLIENT")
         IMAGE_PMM_SERVER = getParam("IMAGE_PMM_SERVER")
-        USED_PLATFORM_VER = getParam("USED_PLATFORM_VER")
         if ("$PLATFORM_VER" == "min".toLowerCase() || "$PLATFORM_VER" == "max".toLowerCase()) {
             PLATFORM_VER = getParam("GKE_${PLATFORM_VER}")
         }

--- a/cloud/jenkins/pxc_operator_gke_latest.groovy
+++ b/cloud/jenkins/pxc_operator_gke_latest.groovy
@@ -23,7 +23,7 @@ String getParam(String PARAM_NAME) {
         echo "$PARAM_NAME=$param (from job parameters)"
         return param
     } else {
-        param = sh(script: "grep -E '^\\s*$PARAM_NAME=' ~/work/percona-xtradb-cluster-operator/e2e-tests/release_versions | cut -d = -f 2 | tr -d \'\"\'| head -1", , returnStdout: true).trim()
+        param = sh(script: "grep -E '^\\s*$PARAM_NAME=' $release_version | cut -d = -f 2 | tr -d \'\"\'| head -1", , returnStdout: true).trim()
         if ("$param") {
             echo "$PARAM_NAME=$param (from params file)"
             return param

--- a/cloud/jenkins/pxc_operator_gke_latest.groovy
+++ b/cloud/jenkins/pxc_operator_gke_latest.groovy
@@ -164,7 +164,7 @@ void initTests() {
 
             for (int i=0; i<tests.size(); i++) {
                 def testName = tests[i]["name"]
-                def file="$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$PXC_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH"
+                def file="$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$DB_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH"
                 def retFileExists = sh(script: "aws s3api head-object --bucket percona-jenkins-artifactory --key $JOB_NAME/$GIT_SHORT_COMMIT/$file >/dev/null 2>&1", returnStatus: true)
 
                 if (retFileExists == 0) {
@@ -282,7 +282,7 @@ void runTest(Integer TEST_ID) {
                     e2e-tests/$testName/run
                 """
             }
-            pushArtifactFile("$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$PXC_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH")
+            pushArtifactFile("$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$DB_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH")
             tests[TEST_ID]["result"] = "passed"
             return true
         }
@@ -363,7 +363,7 @@ void shutdownCluster(String CLUSTER_SUFFIX) {
 pipeline {
     environment {
         CLEAN_NAMESPACE = 1
-        PXC_TAG = sh(script: "[[ \"$IMAGE_PXC\" ]] && echo $IMAGE_PXC | awk -F':' '{print \$2}' || echo main", , returnStdout: true).trim()
+        DB_TAG = sh(script: "[[ \"$IMAGE_PXC\" ]] && echo $IMAGE_PXC | awk -F':' '{print \$2}' || echo main", , returnStdout: true).trim()
     }
     parameters {
         choice(

--- a/cloud/jenkins/pxc_operator_gke_latest.groovy
+++ b/cloud/jenkins/pxc_operator_gke_latest.groovy
@@ -23,7 +23,7 @@ String getParam(String PARAM_NAME) {
         echo "$PARAM_NAME=$param (from job parameters)"
         return param
     } else {
-        param = sh(script: "grep -E '^\s*$PARAM_NAME=' ~/work/percona-xtradb-cluster-operator/e2e-tests/release_versions | awk -F '=' '{print $2}' | head -1", , returnStdout: true).trim()
+        param = sh(script: "grep -E '^\\s*$PARAM_NAME=' ~/work/percona-xtradb-cluster-operator/e2e-tests/release_versions | awk -F '=' '{print $2}' | head -1", , returnStdout: true).trim()
         if ("$param") {
             echo "$PARAM_NAME=$param (from params file)"
             return param

--- a/cloud/jenkins/pxc_operator_gke_latest.groovy
+++ b/cloud/jenkins/pxc_operator_gke_latest.groovy
@@ -23,7 +23,7 @@ String getParam(String PARAM_NAME) {
         echo "$PARAM_NAME=$param (from job parameters)"
         return param
     } else {
-        param = sh(script: "grep -E '^\\s*$PARAM_NAME=' $release_version | cut -d = -f 2 | tr -d \'\"\'| head -1", , returnStdout: true).trim()
+        param = sh(script: "grep -E '^\\s*$PARAM_NAME=' $release_versions | cut -d = -f 2 | tr -d \'\"\'| head -1", , returnStdout: true).trim()
         if ("$param") {
             echo "$PARAM_NAME=$param (from params file)"
             return param

--- a/cloud/jenkins/pxc_operator_gke_latest.groovy
+++ b/cloud/jenkins/pxc_operator_gke_latest.groovy
@@ -61,8 +61,6 @@ void prepareNode() {
         echo "=========================[ Not a release run. Using job params only! ]========================="
     }
 
-    USED_PLATFORM_VER="$PLATFORM_VER"
-
     echo "=========================[ Installing tools on the Jenkins executor ]========================="
     sh """
         sudo curl -s -L -o /usr/local/bin/kubectl https://dl.k8s.io/release/\$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl && sudo chmod +x /usr/local/bin/kubectl
@@ -94,7 +92,7 @@ EOF
     }
 
     if ("$PLATFORM_VER" == "latest") {
-        USED_PLATFORM_VER = sh(script: "gcloud container get-server-config --region=$region --flatten=channels --filter='channels.channel=RAPID' --format='value(channels.defaultVersion)' | cut -d- -f1", , returnStdout: true).trim()
+        PLATFORM_VER = sh(script: "gcloud container get-server-config --region=$region --flatten=channels --filter='channels.channel=RAPID' --format='value(channels.defaultVersion)' | cut -d- -f1", , returnStdout: true).trim()
     }
 
     if ("$ARCH" == "amd64") {
@@ -114,7 +112,7 @@ EOF
     script {
         GIT_SHORT_COMMIT = sh(script: 'git -C source rev-parse --short HEAD', , returnStdout: true).trim()
         CLUSTER_NAME = sh(script: "echo jenkins-lat-pxc-$GIT_SHORT_COMMIT | tr '[:upper:]' '[:lower:]'", , returnStdout: true).trim()
-        PARAMS_HASH = sh(script: "echo $GIT_BRANCH-$GIT_SHORT_COMMIT-$GKE_RELEASE_CHANNEL-$ARCH-$USED_PLATFORM_VER-$CLUSTER_WIDE-$IMAGE_OPERATOR-$IMAGE_PXC-$IMAGE_PROXY-$IMAGE_HAPROXY-$IMAGE_BACKUP-$IMAGE_LOGCOLLECTOR-$IMAGE_PMM_CLIENT-$IMAGE_PMM_SERVER | md5sum | cut -d' ' -f1", , returnStdout: true).trim()
+        PARAMS_HASH = sh(script: "echo $GIT_BRANCH-$GIT_SHORT_COMMIT-$GKE_RELEASE_CHANNEL-$ARCH-$PLATFORM_VER-$CLUSTER_WIDE-$IMAGE_OPERATOR-$IMAGE_PXC-$IMAGE_PROXY-$IMAGE_HAPROXY-$IMAGE_BACKUP-$IMAGE_LOGCOLLECTOR-$IMAGE_PMM_CLIENT-$IMAGE_PMM_SERVER | md5sum | cut -d' ' -f1", , returnStdout: true).trim()
     }
 }
 
@@ -170,7 +168,7 @@ void initTests() {
 
             for (int i=0; i<tests.size(); i++) {
                 def testName = tests[i]["name"]
-                def file="$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$USED_PLATFORM_VER-$PXC_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH"
+                def file="$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$PXC_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH"
                 def retFileExists = sh(script: "aws s3api head-object --bucket percona-jenkins-artifactory --key $JOB_NAME/$GIT_SHORT_COMMIT/$file >/dev/null 2>&1", returnStatus: true)
 
                 if (retFileExists == 0) {
@@ -224,7 +222,7 @@ void createCluster(String CLUSTER_SUFFIX) {
                 gcloud container clusters create $CLUSTER_NAME-$CLUSTER_SUFFIX \
                     --release-channel $GKE_RELEASE_CHANNEL \
                     --zone $region \
-                    --cluster-version $USED_PLATFORM_VER \
+                    --cluster-version $PLATFORM_VER \
                     --preemptible \
                     --disk-size 30 \
                     --machine-type $MACHINE_TYPE \
@@ -288,7 +286,7 @@ void runTest(Integer TEST_ID) {
                     e2e-tests/$testName/run
                 """
             }
-            pushArtifactFile("$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$USED_PLATFORM_VER-$PXC_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH")
+            pushArtifactFile("$GIT_BRANCH-$GIT_SHORT_COMMIT-$testName-$PLATFORM_VER-$PXC_TAG-CW_$CLUSTER_WIDE-$PARAMS_HASH")
             tests[TEST_ID]["result"] = "passed"
             return true
         }
@@ -341,7 +339,6 @@ void makeReport() {
         IMAGE_LOGCOLLECTOR=$IMAGE_LOGCOLLECTOR
         IMAGE_PMM_CLIENT=$IMAGE_PMM_CLIENT
         IMAGE_PMM_SERVER=$IMAGE_PMM_SERVER
-        USED_PLATFORM_VER=$USED_PLATFORM_VER
         PLATFORM_VER=$PLATFORM_VER
     """
 

--- a/cloud/jenkins/pxc_operator_gke_latest.groovy
+++ b/cloud/jenkins/pxc_operator_gke_latest.groovy
@@ -221,7 +221,6 @@ void createCluster(String CLUSTER_SUFFIX) {
                     --cluster-ipv4-cidr=/21 \
                     --labels delete-cluster-after-hours=6 \
                     --enable-ip-alias \
-                    --workload-pool=cloud-dev-112233.svc.id.goog &&\
                 kubectl create clusterrolebinding cluster-admin-binding1 --clusterrole=cluster-admin --user=\$(gcloud config get-value core/account)
                 exitCode=\$?
                 if [[ \$exitCode == 0 ]]; then break; fi

--- a/cloud/jenkins/pxc_operator_gke_latest.groovy
+++ b/cloud/jenkins/pxc_operator_gke_latest.groovy
@@ -82,24 +82,16 @@ EOF
         PLATFORM_VER = sh(script: "gcloud container get-server-config --region=$region --flatten=channels --filter='channels.channel=RAPID' --format='value(channels.defaultVersion)' | cut -d- -f1", , returnStdout: true).trim()
     }
 
-    if ("$ARCH" == "amd64") {
-        MACHINE_TYPE="n1-standard-4"
-    } else if ("$ARCH" == "arm64") {
-        MACHINE_TYPE="t2a-standard-4"
-    } else {
-        error("Unknown architecture $ARCH")
-    }
-
     if ("$IMAGE_PXC") {
         release = ("$PILLAR_VERSION" != "none") ? "RELEASE-" : ""
         cw = ("$CLUSTER_WIDE" == "YES") ? "CW" : "NON-CW"
-        currentBuild.description = "$release$GIT_BRANCH-$ARCH-$PLATFORM_VER-$GKE_RELEASE_CHANNEL-$cw-" + "$IMAGE_PXC".split(":")[1]
+        currentBuild.description = "$release$GIT_BRANCH-$PLATFORM_VER-$GKE_RELEASE_CHANNEL-$cw-" + "$IMAGE_PXC".split(":")[1]
     }
 
 
     GIT_SHORT_COMMIT = sh(script: 'git -C source rev-parse --short HEAD', , returnStdout: true).trim()
     CLUSTER_NAME = sh(script: "echo jenkins-lat-pxc-$GIT_SHORT_COMMIT | tr '[:upper:]' '[:lower:]'", , returnStdout: true).trim()
-    PARAMS_HASH = sh(script: "echo $GIT_BRANCH-$GIT_SHORT_COMMIT-$GKE_RELEASE_CHANNEL-$ARCH-$PLATFORM_VER-$CLUSTER_WIDE-$IMAGE_OPERATOR-$IMAGE_PXC-$IMAGE_PROXY-$IMAGE_HAPROXY-$IMAGE_BACKUP-$IMAGE_LOGCOLLECTOR-$IMAGE_PMM_CLIENT-$IMAGE_PMM_SERVER | md5sum | cut -d' ' -f1", , returnStdout: true).trim()
+    PARAMS_HASH = sh(script: "echo $GIT_BRANCH-$GIT_SHORT_COMMIT-$GKE_RELEASE_CHANNEL-$PLATFORM_VER-$CLUSTER_WIDE-$IMAGE_OPERATOR-$IMAGE_PXC-$IMAGE_PROXY-$IMAGE_HAPROXY-$IMAGE_BACKUP-$IMAGE_LOGCOLLECTOR-$IMAGE_PMM_CLIENT-$IMAGE_PMM_SERVER | md5sum | cut -d' ' -f1", , returnStdout: true).trim()
 
 }
 
@@ -212,7 +204,7 @@ void createCluster(String CLUSTER_SUFFIX) {
                     --cluster-version $PLATFORM_VER \
                     --preemptible \
                     --disk-size 30 \
-                    --machine-type $MACHINE_TYPE \
+                    --machine-type n1-standard-4 \
                     --num-nodes=4 \
                     --min-nodes=4 \
                     --max-nodes=6 \
@@ -368,10 +360,6 @@ pipeline {
             choices: 'NO\nYES',
             description: 'Ignore passed tests in previous run (run all)',
             name: 'IGNORE_PREVIOUS_RUN')
-        choice(
-            choices: 'amd64\narm64',
-            description: 'Architecture',
-            name: 'ARCH')
         choice(
             choices: 'none\n80\n57',
             description: 'Can be 80, 57, etc. or none. Implies release run.',

--- a/cloud/jenkins/pxc_operator_gke_version.groovy
+++ b/cloud/jenkins/pxc_operator_gke_version.groovy
@@ -374,7 +374,7 @@ pipeline {
             name: 'ARCH')
         choice(
             choices: 'none\n80\n57',
-            description: 'Can be 08, 57, etc. or none. Implies release run.',
+            description: 'Can be 80, 57, etc. or none. Implies release run.',
             name: 'PILLAR_VERSION')
         string(
             defaultValue: 'main',

--- a/cloud/jenkins/pxc_operator_gke_version.groovy
+++ b/cloud/jenkins/pxc_operator_gke_version.groovy
@@ -212,7 +212,7 @@ void createCluster(String CLUSTER_SUFFIX) {
                     --subnetwork=jenkins-$CLUSTER_SUFFIX \
                     --cluster-ipv4-cidr=/21 \
                     --labels delete-cluster-after-hours=6 \
-                    --enable-ip-alias \
+                    --enable-ip-alias &&\
                 kubectl create clusterrolebinding cluster-admin-binding1 --clusterrole=cluster-admin --user=\$(gcloud config get-value core/account)
                 exitCode=\$?
                 if [[ \$exitCode == 0 ]]; then break; fi

--- a/cloud/jenkins/pxc_operator_gke_version.groovy
+++ b/cloud/jenkins/pxc_operator_gke_version.groovy
@@ -255,7 +255,7 @@ void runTest(Integer TEST_ID) {
 
                     export DEBUG_TESTS=1
                     [[ "$CLUSTER_WIDE" == "YES" ]] && export OPERATOR_NS=pxc-operator
-                    export IMAGE=$IMAGE_OPERATOR
+                    [[ "$IMAGE_OPERATOR" ]] && export IMAGE=$IMAGE_OPERATOR || export IMAGE=perconalab/percona-xtradb-cluster-operator:$GIT_BRANCH
                     export IMAGE_PXC=$IMAGE_PXC
                     export IMAGE_PROXY=$IMAGE_PROXY
                     export IMAGE_HAPROXY=$IMAGE_HAPROXY

--- a/cloud/jenkins/pxc_operator_gke_version.groovy
+++ b/cloud/jenkins/pxc_operator_gke_version.groovy
@@ -15,18 +15,14 @@ void verifyParams() {
     }
 }
 
-String getParam(String PARAM_NAME) {
-    def param = "${params[PARAM_NAME]}"
+String getParam(String paramName, String keyName = null) {
+    keyName = keyName ?: paramName
 
-    if ("$param" && "$param" != "null" && param != "") {
-        echo "$PARAM_NAME=$param (from job parameters)"
+    param = sh(script: "grep -iE '^\\s*$keyName=' $release_versions | cut -d = -f 2 | tr -d \'\"\'| tail -1", , returnStdout: true).trim()
+    if ("$param") {
+        echo "$paramName=$param (from params file)"
     } else {
-        param = sh(script: "grep -iE '^\\s*$PARAM_NAME=' $release_versions | cut -d = -f 2 | tr -d \'\"\'| tail -1", , returnStdout: true).trim()
-        if ("$param") {
-            echo "$PARAM_NAME=$param (from params file)"
-        } else {
-            error("$PARAM_NAME not found in params file $release_versions")
-        }
+        error("$keyName not found in params file $release_versions")
     }
     return param
 }
@@ -46,16 +42,16 @@ void prepareNode() {
 
     if ("$RELEASE_RUN" == "YES") {
         echo "=========================[ Getting parameters for release test ]========================="
-        IMAGE_OPERATOR = getParam("IMAGE_OPERATOR")
-        IMAGE_PXC = getParam("IMAGE_PXC${PILLAR_VERSION}")
-        IMAGE_PROXY = getParam("IMAGE_PROXY")
-        IMAGE_HAPROXY = getParam("IMAGE_HAPROXY")
-        IMAGE_BACKUP = getParam("IMAGE_BACKUP${PILLAR_VERSION}")
-        IMAGE_LOGCOLLECTOR = getParam("IMAGE_LOGCOLLECTOR")
-        IMAGE_PMM_CLIENT = getParam("IMAGE_PMM_CLIENT")
-        IMAGE_PMM_SERVER = getParam("IMAGE_PMM_SERVER")
+        IMAGE_OPERATOR = params["IMAGE_OPERATOR"] ?: getParam("IMAGE_OPERATOR")
+        IMAGE_PXC = params["IMAGE_PXC"] ?: getParam("IMAGE_PXC", "IMAGE_PXC${PILLAR_VERSION}")
+        IMAGE_PROXY = params["IMAGE_PROXY"] ?: getParam("IMAGE_PROXY")
+        IMAGE_HAPROXY = params["IMAGE_HAPROXY"] ?: getParam("IMAGE_HAPROXY")
+        IMAGE_BACKUP = params["IMAGE_BACKUP"] ?: getParam("IMAGE_BACKUP", "IMAGE_BACKUP${PILLAR_VERSION}")
+        IMAGE_LOGCOLLECTOR = params["IMAGE_LOGCOLLECTOR"] ?: getParam("IMAGE_LOGCOLLECTOR")
+        IMAGE_PMM_CLIENT = params["IMAGE_PMM_CLIENT"] ?: getParam("IMAGE_PMM_CLIENT")
+        IMAGE_PMM_SERVER = params["IMAGE_PMM_SERVER"] ?: getParam("IMAGE_PMM_SERVER")
         if ("$PLATFORM_VER" == "min".toLowerCase() || "$PLATFORM_VER" == "max".toLowerCase()) {
-            PLATFORM_VER = getParam("GKE_${PLATFORM_VER}")
+            PLATFORM_VER = getParam("PLATFORM_VER", "GKE_${PLATFORM_VER}")
         }
     } else {
         echo "=========================[ Not a release run. Using job params only! ]========================="

--- a/cloud/jenkins/pxc_operator_gke_version.groovy
+++ b/cloud/jenkins/pxc_operator_gke_version.groovy
@@ -68,6 +68,10 @@ repo_gpgcheck=0
 gpgkey=https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
 EOF
         sudo yum install -y google-cloud-cli google-cloud-cli-gke-gcloud-auth-plugin
+
+        sudo yum install -y https://repo.percona.com/yum/percona-release-latest.noarch.rpm || true
+        sudo percona-release enable-only tools
+        sudo yum install -y percona-xtrabackup-80 | true
     """
 
     echo "=========================[ Logging in the Kubernetes provider ]========================="

--- a/cloud/jenkins/pxc_operator_gke_version.groovy
+++ b/cloud/jenkins/pxc_operator_gke_version.groovy
@@ -368,18 +368,15 @@ pipeline {
         choice(
             choices: 'NO\nYES',
             description: 'Ignore passed tests in previous run (run all)',
-            name: 'IGNORE_PREVIOUS_RUN'
-        )
+            name: 'IGNORE_PREVIOUS_RUN')
         choice(
             choices: 'amd64\narm64',
             description: 'Architecture',
-            name: 'ARCH'
-        )
+            name: 'ARCH')
         choice(
             choices: 'none\n80\n57',
             description: 'Can be 08, 57, etc. or none. Implies release run.',
-            name: 'PILLAR_VERSION'
-        )
+            name: 'PILLAR_VERSION')
         string(
             defaultValue: 'main',
             description: 'Tag/Branch for percona/percona-xtradb-cluster-operator repository',

--- a/cloud/jenkins/pxc_operator_gke_version.groovy
+++ b/cloud/jenkins/pxc_operator_gke_version.groovy
@@ -365,8 +365,8 @@ pipeline {
             description: 'Ignore passed tests in previous run (run all)',
             name: 'IGNORE_PREVIOUS_RUN')
         choice(
-            choices: 'none\n80\n57',
-            description: 'Can be 80, 57, etc. or none. Implies release run.',
+            choices: 'none\n84\n80\n57',
+            description: 'Implies release run.',
             name: 'PILLAR_VERSION')
         string(
             defaultValue: 'main',
@@ -378,7 +378,7 @@ pipeline {
             name: 'GIT_REPO')
         string(
             defaultValue: 'latest',
-            description: 'GKE kubernetes version',
+            description: 'GKE kubernetes version. If set to min or max, value will be automatically taken from release_versions file.',
             name: 'PLATFORM_VER')
         choice(
             choices: 'rapid\nstable\nregular\nNone',

--- a/cloud/jenkins/pxc_operator_gke_version.groovy
+++ b/cloud/jenkins/pxc_operator_gke_version.groovy
@@ -12,9 +12,8 @@ void verifyParams() {
 
         GKE_RELEASE_CHANNEL = "stable"
         echo "Forcing GKE_RELEASE_CHANNEL=stable, because it's a release run!"
-
-        USED_PLATFORM_VER="$PLATFORM_VER"
     }
+    USED_PLATFORM_VER="$PLATFORM_VER"
 }
 
 String getParam(String PARAM_NAME) {

--- a/cloud/jenkins/pxc_operator_gke_version.groovy
+++ b/cloud/jenkins/pxc_operator_gke_version.groovy
@@ -377,7 +377,7 @@ pipeline {
         )
         choice(
             choices: 'none\n80\n57',
-            description: 'Can be 08, 57, etc. Implies release run.',
+            description: 'Can be 08, 57, etc. or none. Implies release run.',
             name: 'PILLAR_VERSION'
         )
         string(

--- a/cloud/jenkins/pxc_operator_gke_version.groovy
+++ b/cloud/jenkins/pxc_operator_gke_version.groovy
@@ -440,7 +440,7 @@ pipeline {
         copyArtifactPermission('pxc-operator-latest-scheduler');
     }
     stages {
-        stage('Prepare node') {
+        stage('Prepare Node') {
             steps {
                 prepareNode()
             }
@@ -450,7 +450,7 @@ pipeline {
                 dockerBuildPush()
             }
         }
-        stage('Init tests') {
+        stage('Init Tests') {
             steps {
                 initTests()
             }

--- a/cloud/jenkins/pxc_operator_gke_version.groovy
+++ b/cloud/jenkins/pxc_operator_gke_version.groovy
@@ -221,7 +221,6 @@ void createCluster(String CLUSTER_SUFFIX) {
                     --cluster-ipv4-cidr=/21 \
                     --labels delete-cluster-after-hours=6 \
                     --enable-ip-alias \
-                    --workload-pool=cloud-dev-112233.svc.id.goog &&\
                 kubectl create clusterrolebinding cluster-admin-binding1 --clusterrole=cluster-admin --user=\$(gcloud config get-value core/account)
                 exitCode=\$?
                 if [[ \$exitCode == 0 ]]; then break; fi

--- a/cloud/jenkins/pxc_operator_minikube.groovy
+++ b/cloud/jenkins/pxc_operator_minikube.groovy
@@ -258,13 +258,11 @@ pipeline {
         choice(
             choices: 'NO\nYES',
             description: 'Ignore passed tests in previous run (run all)',
-            name: 'IGNORE_PREVIOUS_RUN'
-        )
+            name: 'IGNORE_PREVIOUS_RUN')
         choice(
             choices: 'none\n80\n57',
             description: 'Can be 08, 57, etc. or none. Implies release run.',
-            name: 'PILLAR_VERSION'
-        )
+            name: 'PILLAR_VERSION')
         string(
             defaultValue: 'main',
             description: 'Tag/Branch for percona/percona-xtradb-cluster-operator repository',

--- a/cloud/jenkins/pxc_operator_minikube.groovy
+++ b/cloud/jenkins/pxc_operator_minikube.groovy
@@ -8,7 +8,6 @@ void verifyParams() {
             error("Either PILLAR_VERSION or IMAGE_PXC should be provided for release run!")
         }
     }
-    USED_PLATFORM_VER="$PLATFORM_VER"
 }
 
 String getParam(String PARAM_NAME) {
@@ -81,7 +80,7 @@ void prepareNode() {
     }
 
     GIT_SHORT_COMMIT = sh(script: 'git -C source rev-parse --short HEAD', , returnStdout: true).trim()
-    PARAMS_HASH = sh(script: "echo $GIT_BRANCH-$GIT_SHORT_COMMIT-$USED_PLATFORM_VER-$CLUSTER_WIDE-$IMAGE_OPERATOR-$IMAGE_PXC-$IMAGE_PROXY-$IMAGE_HAPROXY-$IMAGE_BACKUP-$IMAGE_LOGCOLLECTOR-$IMAGE_PMM_CLIENT-$IMAGE_PMM_SERVER | md5sum | cut -d' ' -f1", , returnStdout: true).trim()
+    PARAMS_HASH = sh(script: "echo $GIT_BRANCH-$GIT_SHORT_COMMIT-$PLATFORM_VER-$CLUSTER_WIDE-$IMAGE_OPERATOR-$IMAGE_PXC-$IMAGE_PROXY-$IMAGE_HAPROXY-$IMAGE_BACKUP-$IMAGE_LOGCOLLECTOR-$IMAGE_PMM_CLIENT-$IMAGE_PMM_SERVER | md5sum | cut -d' ' -f1", , returnStdout: true).trim()
 }
 
 void dockerBuildPush() {
@@ -252,7 +251,7 @@ void makeReport() {
         IMAGE_LOGCOLLECTOR=$IMAGE_LOGCOLLECTOR
         IMAGE_PMM_CLIENT=$IMAGE_PMM_CLIENT
         IMAGE_PMM_SERVER=$IMAGE_PMM_SERVER
-        USED_PLATFORM_VER=$USED_PLATFORM_VER
+        PLATFORM_VER=$PLATFORM_VER
     """
 
     writeFile file: "TestsReport.xml", text: testsReport

--- a/cloud/jenkins/pxc_operator_minikube.groovy
+++ b/cloud/jenkins/pxc_operator_minikube.groovy
@@ -61,7 +61,7 @@ void prepareNode() {
     }
 
     if ("$IMAGE_PXC") {
-        release = ("$PILLAR_VERSION" == "YES") ? "RELEASE-" : ""
+        release = ("$PILLAR_VERSION" != "none") ? "RELEASE-" : ""
         cw = ("$CLUSTER_WIDE" == "YES") ? "CW" : "NON-CW"
         currentBuild.description = "$release$GIT_BRANCH-$PLATFORM_VER-$cw-" + "$IMAGE_PXC".split(":")[1]
     }

--- a/cloud/jenkins/pxc_operator_minikube.groovy
+++ b/cloud/jenkins/pxc_operator_minikube.groovy
@@ -260,8 +260,8 @@ pipeline {
             description: 'Ignore passed tests in previous run (run all)',
             name: 'IGNORE_PREVIOUS_RUN')
         choice(
-            choices: 'none\n80\n57',
-            description: 'Can be 80, 57, etc. or none. Implies release run.',
+            choices: 'none\n84\n80\n57',
+            description: 'Implies release run.',
             name: 'PILLAR_VERSION')
         string(
             defaultValue: 'main',
@@ -273,7 +273,7 @@ pipeline {
             name: 'GIT_REPO')
         string(
             defaultValue: 'latest',
-            description: 'Minikube kubernetes version',
+            description: 'Minikube kubernetes version. If set to rel, value will be automatically taken from release_versions file.',
             name: 'PLATFORM_VER')
         choice(
             choices: 'YES\nNO',

--- a/cloud/jenkins/pxc_operator_minikube.groovy
+++ b/cloud/jenkins/pxc_operator_minikube.groovy
@@ -262,7 +262,7 @@ pipeline {
         )
         choice(
             choices: 'none\n80\n57',
-            description: 'Can be 08, 57, etc. Implies release run.',
+            description: 'Can be 08, 57, etc. or none. Implies release run.',
             name: 'PILLAR_VERSION'
         )
         string(

--- a/cloud/jenkins/pxc_operator_minikube.groovy
+++ b/cloud/jenkins/pxc_operator_minikube.groovy
@@ -57,10 +57,6 @@ void prepareNode() {
     """
 
     if ("$IMAGE_PXC") {
-        currentBuild.description = "$GIT_BRANCH-$PLATFORM_VER-CW_$CLUSTER_WIDE-" + "$IMAGE_PXC".split(":")[1]
-    }
-
-    if ("$IMAGE_PXC") {
         release = ("$PILLAR_VERSION" != "none") ? "RELEASE-" : ""
         cw = ("$CLUSTER_WIDE" == "YES") ? "CW" : "NON-CW"
         currentBuild.description = "$release$GIT_BRANCH-$PLATFORM_VER-$cw-" + "$IMAGE_PXC".split(":")[1]

--- a/cloud/jenkins/pxc_operator_minikube.groovy
+++ b/cloud/jenkins/pxc_operator_minikube.groovy
@@ -254,6 +254,9 @@ void makeReport() {
         IMAGE_PMM_SERVER=$IMAGE_PMM_SERVER
         USED_PLATFORM_VER=$USED_PLATFORM_VER
     """
+
+    writeFile file: "TestsReport.xml", text: testsReport
+    writeFile file: 'PipelineParameters.txt', text: pipelineParameters
 }
 
 pipeline {

--- a/cloud/jenkins/pxc_operator_minikube.groovy
+++ b/cloud/jenkins/pxc_operator_minikube.groovy
@@ -169,7 +169,7 @@ void runTest(Integer TEST_ID) {
 
                 export DEBUG_TESTS=1
                 [[ "$CLUSTER_WIDE" == "YES" ]] && export OPERATOR_NS=pxc-operator
-                export IMAGE=$IMAGE_OPERATOR
+                [[ "$IMAGE_OPERATOR" ]] && export IMAGE=$IMAGE_OPERATOR || export IMAGE=perconalab/percona-xtradb-cluster-operator:$GIT_BRANCH
                 export IMAGE_PXC=$IMAGE_PXC
                 export IMAGE_PROXY=$IMAGE_PROXY
                 export IMAGE_HAPROXY=$IMAGE_HAPROXY

--- a/cloud/jenkins/pxc_operator_minikube.groovy
+++ b/cloud/jenkins/pxc_operator_minikube.groovy
@@ -1,15 +1,6 @@
 tests=[]
 release_versions="source/e2e-tests/release_versions"
 
-void verifyParams() {
-    if ("$RELEASE_RUN" == "YES") {
-        echo "=========================[ RELEASE RUN ]========================="
-        if (!"$PILLAR_VERSION" && !"$IMAGE_PXC") {
-            error("Either PILLAR_VERSION or IMAGE_PXC should be provided for release run!")
-        }
-    }
-}
-
 String getParam(String paramName, String keyName = null) {
     keyName = keyName ?: paramName
 
@@ -37,14 +28,18 @@ void prepareNode() {
 
     if ("$RELEASE_RUN" == "YES") {
         echo "=========================[ Getting parameters for release test ]========================="
-        IMAGE_OPERATOR = params["IMAGE_OPERATOR"] ?: getParam("IMAGE_OPERATOR")
-        IMAGE_PXC = params["IMAGE_PXC"] ?: getParam("IMAGE_PXC", "IMAGE_PXC${PILLAR_VERSION}")
-        IMAGE_PROXY = params["IMAGE_PROXY"] ?: getParam("IMAGE_PROXY")
-        IMAGE_HAPROXY = params["IMAGE_HAPROXY"] ?: getParam("IMAGE_HAPROXY")
-        IMAGE_BACKUP = params["IMAGE_BACKUP"] ?: getParam("IMAGE_BACKUP", "IMAGE_BACKUP${PILLAR_VERSION}")
-        IMAGE_LOGCOLLECTOR = params["IMAGE_LOGCOLLECTOR"] ?: getParam("IMAGE_LOGCOLLECTOR")
-        IMAGE_PMM_CLIENT = params["IMAGE_PMM_CLIENT"] ?: getParam("IMAGE_PMM_CLIENT")
-        IMAGE_PMM_SERVER = params["IMAGE_PMM_SERVER"] ?: getParam("IMAGE_PMM_SERVER")
+        IMAGE_OPERATOR = IMAGE_OPERATOR ?: getParam("IMAGE_OPERATOR")
+        if ("$IMAGE_PXC" ==~ /^\d+$/) {
+            IMAGE_PXC = getParam("IMAGE_PXC", "IMAGE_PXC${IMAGE_PXC}")
+        }
+        IMAGE_PROXY = IMAGE_PROXY ?: getParam("IMAGE_PROXY")
+        IMAGE_HAPROXY = IMAGE_HAPROXY ?: getParam("IMAGE_HAPROXY")
+        if ("$IMAGE_BACKUP" ==~ /^\d+$/) {
+            IMAGE_BACKUP = getParam("IMAGE_BACKUP", "IMAGE_BACKUP${IMAGE_BACKUP}")
+        }
+        IMAGE_LOGCOLLECTOR = IMAGE_LOGCOLLECTOR ?: getParam("IMAGE_LOGCOLLECTOR")
+        IMAGE_PMM_CLIENT = IMAGE_PMM_CLIENT ?: getParam("IMAGE_PMM_CLIENT")
+        IMAGE_PMM_SERVER = IMAGE_PMM_SERVER ?: getParam("IMAGE_PMM_SERVER")
         if ("$PLATFORM_VER" == "rel".toLowerCase()) {
             PLATFORM_VER = getParam("PLATFORM_VER", "MINIKUBE_${PLATFORM_VER}")
         }
@@ -279,11 +274,6 @@ pipeline {
             name: 'RELEASE_RUN'
         )
         string(
-            defaultValue: '80',
-            description: 'For RELEASE_RUN only. Major version like 80, 57, etc',
-            name: 'PILLAR_VERSION'
-        )
-        string(
             defaultValue: 'main',
             description: 'Tag/Branch for percona/percona-xtradb-cluster-operator repository',
             name: 'GIT_BRANCH')
@@ -342,7 +332,6 @@ pipeline {
     stages {
         stage('Prepare node') {
             steps {
-                verifyParams()
                 prepareNode()
             }
         }

--- a/cloud/jenkins/pxc_operator_minikube.groovy
+++ b/cloud/jenkins/pxc_operator_minikube.groovy
@@ -320,7 +320,7 @@ pipeline {
         skipDefaultCheckout()
     }
     stages {
-        stage('Prepare node') {
+        stage('Prepare Node') {
             steps {
                 prepareNode()
             }
@@ -330,7 +330,7 @@ pipeline {
                 dockerBuildPush()
             }
         }
-        stage('Init tests') {
+        stage('Init Tests') {
             steps {
                 initTests()
             }

--- a/cloud/jenkins/pxc_operator_minikube.groovy
+++ b/cloud/jenkins/pxc_operator_minikube.groovy
@@ -363,7 +363,6 @@ pipeline {
                 timeout(time: 3, unit: 'HOURS')
             }
             steps {
-                installToolsOnNode()
                 clusterRunner('cluster1')
             }
         }

--- a/cloud/jenkins/pxc_operator_minikube.groovy
+++ b/cloud/jenkins/pxc_operator_minikube.groovy
@@ -385,7 +385,6 @@ pipeline {
 
             sh """
                 minikube delete || true
-                sudo docker system prune --volumes -af
             """
             deleteDir()
         }

--- a/cloud/jenkins/pxc_operator_minikube.groovy
+++ b/cloud/jenkins/pxc_operator_minikube.groovy
@@ -261,7 +261,7 @@ pipeline {
             name: 'IGNORE_PREVIOUS_RUN')
         choice(
             choices: 'none\n80\n57',
-            description: 'Can be 08, 57, etc. or none. Implies release run.',
+            description: 'Can be 80, 57, etc. or none. Implies release run.',
             name: 'PILLAR_VERSION')
         string(
             defaultValue: 'main',

--- a/cloud/jenkins/pxc_operator_minikube.groovy
+++ b/cloud/jenkins/pxc_operator_minikube.groovy
@@ -10,18 +10,14 @@ void verifyParams() {
     }
 }
 
-String getParam(String PARAM_NAME) {
-    def param = "${params[PARAM_NAME]}"
+String getParam(String paramName, String keyName = null) {
+    keyName = keyName ?: paramName
 
-    if ("$param" && "$param" != "null" && param != "") {
-        echo "$PARAM_NAME=$param (from job parameters)"
+    param = sh(script: "grep -iE '^\\s*$keyName=' $release_versions | cut -d = -f 2 | tr -d \'\"\'| tail -1", , returnStdout: true).trim()
+    if ("$param") {
+        echo "$paramName=$param (from params file)"
     } else {
-        param = sh(script: "grep -iE '^\\s*$PARAM_NAME=' $release_versions | cut -d = -f 2 | tr -d \'\"\'| tail -1", , returnStdout: true).trim()
-        if ("$param") {
-            echo "$PARAM_NAME=$param (from params file)"
-        } else {
-            error("$PARAM_NAME not found in params file $release_versions")
-        }
+        error("$keyName not found in params file $release_versions")
     }
     return param
 }
@@ -41,16 +37,16 @@ void prepareNode() {
 
     if ("$RELEASE_RUN" == "YES") {
         echo "=========================[ Getting parameters for release test ]========================="
-        IMAGE_OPERATOR = getParam("IMAGE_OPERATOR")
-        IMAGE_PXC = getParam("IMAGE_PXC${PILLAR_VERSION}")
-        IMAGE_PROXY = getParam("IMAGE_PROXY")
-        IMAGE_HAPROXY = getParam("IMAGE_HAPROXY")
-        IMAGE_BACKUP = getParam("IMAGE_BACKUP${PILLAR_VERSION}")
-        IMAGE_LOGCOLLECTOR = getParam("IMAGE_LOGCOLLECTOR")
-        IMAGE_PMM_CLIENT = getParam("IMAGE_PMM_CLIENT")
-        IMAGE_PMM_SERVER = getParam("IMAGE_PMM_SERVER")
+        IMAGE_OPERATOR = params["IMAGE_OPERATOR"] ?: getParam("IMAGE_OPERATOR")
+        IMAGE_PXC = params["IMAGE_PXC"] ?: getParam("IMAGE_PXC", "IMAGE_PXC${PILLAR_VERSION}")
+        IMAGE_PROXY = params["IMAGE_PROXY"] ?: getParam("IMAGE_PROXY")
+        IMAGE_HAPROXY = params["IMAGE_HAPROXY"] ?: getParam("IMAGE_HAPROXY")
+        IMAGE_BACKUP = params["IMAGE_BACKUP"] ?: getParam("IMAGE_BACKUP", "IMAGE_BACKUP${PILLAR_VERSION}")
+        IMAGE_LOGCOLLECTOR = params["IMAGE_LOGCOLLECTOR"] ?: getParam("IMAGE_LOGCOLLECTOR")
+        IMAGE_PMM_CLIENT = params["IMAGE_PMM_CLIENT"] ?: getParam("IMAGE_PMM_CLIENT")
+        IMAGE_PMM_SERVER = params["IMAGE_PMM_SERVER"] ?: getParam("IMAGE_PMM_SERVER")
         if ("$PLATFORM_VER" == "rel".toLowerCase()) {
-            PLATFORM_VER = getParam("MINIKUBE_${PLATFORM_VER}")
+            PLATFORM_VER = getParam("PLATFORM_VER", "MINIKUBE_${PLATFORM_VER}")
         }
     } else {
         echo "=========================[ Not a release run. Using job params only! ]========================="

--- a/cloud/jenkins/pxc_operator_minikube.groovy
+++ b/cloud/jenkins/pxc_operator_minikube.groovy
@@ -1,12 +1,33 @@
 tests=[]
+release_versions="source/e2e-tests/release_versions"
 
-void checkoutSources() {
-    if ("$IMAGE_PXC") {
-        currentBuild.description = "$GIT_BRANCH-$PLATFORM_VER-CW_$CLUSTER_WIDE-" + "$IMAGE_PXC".split(":")[1]
+void verifyParams() {
+    if ("$RELEASE_RUN" == "YES") {
+        echo "=========================[ RELEASE RUN ]========================="
+        if (!"$PILLAR_VERSION" && !"$IMAGE_PXC") {
+            error("Either PILLAR_VERSION or IMAGE_PXC should be provided for release run!")
+        }
+        USED_PLATFORM_VER="$PLATFORM_VER"
     }
+}
 
-    echo "USED_PLATFORM_VER=$PLATFORM_VER"
+String getParam(String PARAM_NAME) {
+    def param = "${params[PARAM_NAME]}"
 
+    if ("$param" && "$param" != "null" && param != "") {
+        echo "$PARAM_NAME=$param (from job parameters)"
+    } else {
+        param = sh(script: "grep -iE '^\\s*$PARAM_NAME=' $release_versions | cut -d = -f 2 | tr -d \'\"\'| tail -1", , returnStdout: true).trim()
+        if ("$param") {
+            echo "$PARAM_NAME=$param (from params file)"
+        } else {
+            error("$PARAM_NAME not found in params file $release_versions")
+        }
+    }
+    return param
+}
+
+void prepareNode() {
     echo "=========================[ Cloning the sources ]========================="
     git branch: 'master', url: 'https://github.com/Percona-Lab/jenkins-pipelines'
     sh """
@@ -19,15 +40,55 @@ void checkoutSources() {
         cloud/local/checkout $GIT_REPO $GIT_BRANCH
     """
 
+    if ("$RELEASE_RUN" == "YES") {
+        echo "=========================[ Getting parameters for release test ]========================="
+        IMAGE_OPERATOR = getParam("IMAGE_OPERATOR")
+        IMAGE_PXC = getParam("IMAGE_PXC${PILLAR_VERSION}")
+        IMAGE_PROXY = getParam("IMAGE_PROXY")
+        IMAGE_HAPROXY = getParam("IMAGE_HAPROXY")
+        IMAGE_BACKUP = getParam("IMAGE_BACKUP${PILLAR_VERSION}")
+        IMAGE_LOGCOLLECTOR = getParam("IMAGE_LOGCOLLECTOR")
+        IMAGE_PMM_CLIENT = getParam("IMAGE_PMM_CLIENT")
+        IMAGE_PMM_SERVER = getParam("IMAGE_PMM_SERVER")
+        if ("$PLATFORM_VER" == "rel".toLowerCase()) {
+            PLATFORM_VER = getParam("MINIKUBE_${PLATFORM_VER}")
+        }
+    } else {
+        echo "=========================[ Not a release run. Using job params only! ]========================="
+    }
+
+    echo "=========================[ Installing tools on the Jenkins executor ]========================="
+    sh """
+        sudo curl -s -L -o /usr/local/bin/kubectl https://dl.k8s.io/release/\$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl && sudo chmod +x /usr/local/bin/kubectl
+        kubectl version --client --output=yaml
+
+        curl -fsSL https://get.helm.sh/helm-v3.12.3-linux-amd64.tar.gz | sudo tar -C /usr/local/bin --strip-components 1 -xzf - linux-amd64/helm
+
+        sudo curl -fsSL https://github.com/mikefarah/yq/releases/download/v4.44.1/yq_linux_amd64 -o /usr/local/bin/yq && sudo chmod +x /usr/local/bin/yq
+        sudo curl -fsSL https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux64 -o /usr/local/bin/jq && sudo chmod +x /usr/local/bin/jq
+
+        sudo curl -sLo /usr/local/bin/minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && sudo chmod +x /usr/local/bin/minikube
+    """
+
+    if ("$IMAGE_PXC") {
+        currentBuild.description = "$GIT_BRANCH-$PLATFORM_VER-CW_$CLUSTER_WIDE-" + "$IMAGE_PXC".split(":")[1]
+    }
+
+    if ("$IMAGE_PXC") {
+        release = ("$RELEASE_RUN" == "YES") ? "RELEASE-" : ""
+        cw = ("$CLUSTER_WIDE" == "YES") ? "CW" : "NON-CW"
+        currentBuild.description = "$release$GIT_BRANCH-$PLATFORM_VER-$cw-" + "$IMAGE_PXC".split(":")[1]
+    }
+
     GIT_SHORT_COMMIT = sh(script: 'git -C source rev-parse --short HEAD', , returnStdout: true).trim()
-    PARAMS_HASH = sh(script: "echo $GIT_BRANCH-$GIT_SHORT_COMMIT-$PLATFORM_VER-$CLUSTER_WIDE-$OPERATOR_IMAGE-$IMAGE_PXC-$IMAGE_PROXY-$IMAGE_HAPROXY-$IMAGE_BACKUP-$IMAGE_LOGCOLLECTOR-$IMAGE_PMM_CLIENT-$IMAGE_PMM_SERVER | md5sum | cut -d' ' -f1", , returnStdout: true).trim()
+    PARAMS_HASH = sh(script: "echo $GIT_BRANCH-$GIT_SHORT_COMMIT-$USED_PLATFORM_VER-$CLUSTER_WIDE-$IMAGE_OPERATOR-$IMAGE_PXC-$IMAGE_PROXY-$IMAGE_HAPROXY-$IMAGE_BACKUP-$IMAGE_LOGCOLLECTOR-$IMAGE_PMM_CLIENT-$IMAGE_PMM_SERVER | md5sum | cut -d' ' -f1", , returnStdout: true).trim()
 }
 
 void dockerBuildPush() {
     echo "=========================[ Building and Pushing the operator Docker image ]========================="
     withCredentials([usernamePassword(credentialsId: 'hub.docker.com', passwordVariable: 'PASS', usernameVariable: 'USER')]) {
         sh """
-            if [[ "$OPERATOR_IMAGE" ]]; then
+            if [[ "$IMAGE_OPERATOR" ]]; then
                 echo "SKIP: Build is not needed, operator image was set!"
             else
                 cd source
@@ -96,28 +157,10 @@ void initTests() {
     }
 }
 
-void installToolsOnNode() {
-    echo "=========================[ Installing tools on the Jenkins executor ]========================="
-    sh """
-        sudo curl -s -L -o /usr/local/bin/kubectl https://dl.k8s.io/release/\$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl && sudo chmod +x /usr/local/bin/kubectl
-        kubectl version --client --output=yaml
-
-        curl -fsSL https://get.helm.sh/helm-v3.12.3-linux-amd64.tar.gz | sudo tar -C /usr/local/bin --strip-components 1 -xzf - linux-amd64/helm
-
-        sudo sh -c "curl -s -L https://github.com/mikefarah/yq/releases/download/v4.35.1/yq_linux_amd64 > /usr/local/bin/yq"
-        sudo chmod +x /usr/local/bin/yq
-
-        sudo sh -c "curl -s -L https://github.com/jqlang/jq/releases/download/jq-1.6/jq-linux64 > /usr/local/bin/jq"
-        sudo chmod +x /usr/local/bin/jq
-
-        sudo curl -sLo /usr/local/bin/minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && sudo chmod +x /usr/local/bin/minikube
-    """
-}
-
 void clusterRunner(String cluster) {
     sh """
         export CHANGE_MINIKUBE_NONE_USER=true
-        /usr/local/bin/minikube start --kubernetes-version $PLATFORM_VER --cpus=6 --memory=28G
+        minikube start --kubernetes-version $PLATFORM_VER --cpus=6 --memory=28G
     """
 
     for (int i=0; i<tests.size(); i++) {
@@ -144,7 +187,7 @@ void runTest(Integer TEST_ID) {
 
                 export DEBUG_TESTS=1
                 [[ "$CLUSTER_WIDE" == "YES" ]] && export OPERATOR_NS=pxc-operator
-                [[ "$OPERATOR_IMAGE" ]] && export IMAGE=$OPERATOR_IMAGE || export IMAGE=perconalab/percona-xtradb-cluster-operator:$GIT_BRANCH
+                export IMAGE=$IMAGE_OPERATOR
                 export IMAGE_PXC=$IMAGE_PXC
                 export IMAGE_PROXY=$IMAGE_PROXY
                 export IMAGE_HAPROXY=$IMAGE_HAPROXY
@@ -190,17 +233,27 @@ void pushArtifactFile(String FILE_NAME) {
     }
 }
 
-TestsReport = '<testsuite name=\\"PXC-MiniKube\\">\n'
 void makeReport() {
     echo "=========================[ Generating Test Report ]========================="
-    for (int i=0; i<tests.size(); i++) {
-        def testResult = tests[i]["result"]
-        def testTime = tests[i]["time"]
-        def testName = tests[i]["name"]
-
-        TestsReport = TestsReport + '<testcase name=\\"' + testName + '\\" time=\\"' + testTime + '\\"><'+ testResult +'/></testcase>\n'
+    testsReport = '<testsuite name="PXC-MiniKube">\n'
+    for (int i = 0; i < tests.size(); i ++) {
+        testsReport += '<testcase name="' + tests[i]["name"] + '" time="' + tests[i]["time"] + '"><'+ tests[i]["result"] +'/></testcase>\n'
     }
-    TestsReport = TestsReport + '</testsuite>\n'
+    testsReport += '</testsuite>\n'
+
+    echo "=========================[ Generating Parameters Report ]========================="
+    pipelineParameters = """
+        testsuite name=PXC-MiniKube
+        IMAGE_OPERATOR=$IMAGE_OPERATOR
+        IMAGE_PXC=$IMAGE_PXC
+        IMAGE_PROXY=$IMAGE_PROXY
+        IMAGE_HAPROXY=$IMAGE_HAPROXY
+        IMAGE_BACKUP=$IMAGE_BACKUP
+        IMAGE_LOGCOLLECTOR=$IMAGE_LOGCOLLECTOR
+        IMAGE_PMM_CLIENT=$IMAGE_PMM_CLIENT
+        IMAGE_PMM_SERVER=$IMAGE_PMM_SERVER
+        USED_PLATFORM_VER=$USED_PLATFORM_VER
+    """
 }
 
 pipeline {
@@ -208,7 +261,6 @@ pipeline {
         CLEAN_NAMESPACE = 1
         DB_TAG = sh(script: "[[ \"$IMAGE_PXC\" ]] && echo $IMAGE_PXC | awk -F':' '{print \$2}' || echo main", , returnStdout: true).trim()
     }
-
     parameters {
         choice(
             choices: ['run-minikube.csv', 'run-distro.csv'],
@@ -223,6 +275,16 @@ pipeline {
             description: 'Ignore passed tests in previous run (run all)',
             name: 'IGNORE_PREVIOUS_RUN'
         )
+        choice(
+            choices: 'NO\nYES',
+            description: 'Release run?',
+            name: 'RELEASE_RUN'
+        )
+        string(
+            defaultValue: '80',
+            description: 'For RELEASE_RUN only. Major version like 80, 57, etc',
+            name: 'PILLAR_VERSION'
+        )
         string(
             defaultValue: 'main',
             description: 'Tag/Branch for percona/percona-xtradb-cluster-operator repository',
@@ -233,7 +295,7 @@ pipeline {
             name: 'GIT_REPO')
         string(
             defaultValue: 'latest',
-            description: 'Minikube Kubernetes Version',
+            description: 'Minikube kubernetes version',
             name: 'PLATFORM_VER')
         choice(
             choices: 'YES\nNO',
@@ -242,7 +304,7 @@ pipeline {
         string(
             defaultValue: '',
             description: 'Operator image: perconalab/percona-xtradb-cluster-operator:main',
-            name: 'OPERATOR_IMAGE')
+            name: 'IMAGE_OPERATOR')
         string(
             defaultValue: '',
             description: 'PXC image: perconalab/percona-xtradb-cluster-operator:main-pxc8.0',
@@ -272,20 +334,18 @@ pipeline {
             description: 'PMM server image: perconalab/pmm-server:dev-latest',
             name: 'IMAGE_PMM_SERVER')
     }
-
     agent {
         label 'docker-32gb'
     }
-
     options {
         buildDiscarder(logRotator(daysToKeepStr: '-1', artifactDaysToKeepStr: '-1', numToKeepStr: '30', artifactNumToKeepStr: '30'))
         skipDefaultCheckout()
     }
-
     stages {
-        stage('Checkout sources') {
+        stage('Prepare node') {
             steps {
-                checkoutSources()
+                verifyParams()
+                prepareNode()
             }
         }
         stage('Docker Build and Push') {
@@ -308,18 +368,22 @@ pipeline {
             }
         }
     }
-
     post {
         always {
             echo "CLUSTER ASSIGNMENTS\n" + tests.toString().replace("], ","]\n").replace("]]","]").replaceFirst("\\[","")
             makeReport()
-            sh """
-                echo "$TestsReport" > TestsReport.xml
-            """
             step([$class: 'JUnitResultArchiver', testResults: '*.xml', healthScaleFactor: 1.0])
-            archiveArtifacts '*.xml'
+            archiveArtifacts '*.xml,*.txt'
+
+            script {
+                if (currentBuild.result != null && currentBuild.result != 'SUCCESS') {
+                    slackSend channel: '#cloud-dev-ci', color: '#FF0000', message: "[$JOB_NAME]: build $currentBuild.result, $BUILD_URL"
+                }
+            }
+
             sh """
-                /usr/local/bin/minikube delete || true
+                minikube delete || true
+                sudo docker system prune --volumes -af
             """
             deleteDir()
         }

--- a/cloud/jenkins/pxc_operator_minikube.groovy
+++ b/cloud/jenkins/pxc_operator_minikube.groovy
@@ -26,17 +26,13 @@ void prepareNode() {
         cloud/local/checkout $GIT_REPO $GIT_BRANCH
     """
 
-    if ("$RELEASE_RUN" == "YES") {
+    if ("$PILLAR_VERSION" != "none") {
         echo "=========================[ Getting parameters for release test ]========================="
         IMAGE_OPERATOR = IMAGE_OPERATOR ?: getParam("IMAGE_OPERATOR")
-        if ("$IMAGE_PXC" ==~ /^\d+$/) {
-            IMAGE_PXC = getParam("IMAGE_PXC", "IMAGE_PXC${IMAGE_PXC}")
-        }
+        IMAGE_PXC = IMAGE_PXC ?: getParam("IMAGE_PXC", "IMAGE_PXC${PILLAR_VERSION}")
         IMAGE_PROXY = IMAGE_PROXY ?: getParam("IMAGE_PROXY")
         IMAGE_HAPROXY = IMAGE_HAPROXY ?: getParam("IMAGE_HAPROXY")
-        if ("$IMAGE_BACKUP" ==~ /^\d+$/) {
-            IMAGE_BACKUP = getParam("IMAGE_BACKUP", "IMAGE_BACKUP${IMAGE_BACKUP}")
-        }
+        IMAGE_BACKUP = IMAGE_BACKUP ?: getParam("IMAGE_BACKUP", "IMAGE_BACKUP${PILLAR_VERSION}")
         IMAGE_LOGCOLLECTOR = IMAGE_LOGCOLLECTOR ?: getParam("IMAGE_LOGCOLLECTOR")
         IMAGE_PMM_CLIENT = IMAGE_PMM_CLIENT ?: getParam("IMAGE_PMM_CLIENT")
         IMAGE_PMM_SERVER = IMAGE_PMM_SERVER ?: getParam("IMAGE_PMM_SERVER")
@@ -65,7 +61,7 @@ void prepareNode() {
     }
 
     if ("$IMAGE_PXC") {
-        release = ("$RELEASE_RUN" == "YES") ? "RELEASE-" : ""
+        release = ("$PILLAR_VERSION" == "YES") ? "RELEASE-" : ""
         cw = ("$CLUSTER_WIDE" == "YES") ? "CW" : "NON-CW"
         currentBuild.description = "$release$GIT_BRANCH-$PLATFORM_VER-$cw-" + "$IMAGE_PXC".split(":")[1]
     }
@@ -269,9 +265,9 @@ pipeline {
             name: 'IGNORE_PREVIOUS_RUN'
         )
         choice(
-            choices: 'NO\nYES',
-            description: 'Release run?',
-            name: 'RELEASE_RUN'
+            choices: 'none\n80\n57',
+            description: 'Can be 08, 57, etc. Implies release run.',
+            name: 'PILLAR_VERSION'
         )
         string(
             defaultValue: 'main',

--- a/cloud/jenkins/pxc_operator_minikube.groovy
+++ b/cloud/jenkins/pxc_operator_minikube.groovy
@@ -7,8 +7,8 @@ void verifyParams() {
         if (!"$PILLAR_VERSION" && !"$IMAGE_PXC") {
             error("Either PILLAR_VERSION or IMAGE_PXC should be provided for release run!")
         }
-        USED_PLATFORM_VER="$PLATFORM_VER"
     }
+    USED_PLATFORM_VER="$PLATFORM_VER"
 }
 
 String getParam(String PARAM_NAME) {

--- a/pmm/pmm2-ui-tests-matrix.groovy
+++ b/pmm/pmm2-ui-tests-matrix.groovy
@@ -73,15 +73,8 @@ pipeline {
                 stage('Run IA tests using @ia'){
                     steps {
                         script {
-                            runUITestsJob(GIT_BRANCH, GIT_COMMIT_HASH, DOCKER_VERSION, CLIENT_VERSION, '@ia', MYSQL_IMAGE, POSTGRES_IMAGE, MONGO_IMAGE, PROXYSQL_IMAGE, PMM_QA_GIT_BRANCH, '--addclient=ms,1');
+                            runUITestsJob(GIT_BRANCH, GIT_COMMIT_HASH, DOCKER_VERSION, CLIENT_VERSION, '@ia', MYSQL_IMAGE, POSTGRES_IMAGE, MONGO_IMAGE, PROXYSQL_IMAGE, PMM_QA_GIT_BRANCH, '');
                         }
-                    }
-                }
-                stage('Run MySQL BM Tests using @bm-mysql'){
-                    steps {
-                        script {
-                            runUITestsJob(GIT_BRANCH, GIT_COMMIT_HASH, DOCKER_VERSION, CLIENT_VERSION, '@bm-mysql', MYSQL_IMAGE, POSTGRES_IMAGE, MONGO_IMAGE, PROXYSQL_IMAGE, PMM_QA_GIT_BRANCH, '--mo-version "8.0" --mongo-replica-for-backup --setup-bm-mysql');
-                        }"
                     }
                 }
                 stage('Run Instances Tests using @instances'){
@@ -115,7 +108,7 @@ pipeline {
                 stage('Run SSL/TLS tests remote @ssl-mongo'){
                     steps {
                         script {
-                            runUITestsJob(GIT_BRANCH, GIT_COMMIT_HASH, DOCKER_VERSION, CLIENT_VERSION, '@ssl-mongo', MYSQL_IMAGE, POSTGRES_IMAGE, MONGO_IMAGE, PROXYSQL_IMAGE, PMM_QA_GIT_BRANCH, '');
+                            runUITestsJob(GIT_BRANCH, GIT_COMMIT_HASH, DOCKER_VERSION, CLIENT_VERSION, '@ssl-mongo', MYSQL_IMAGE, POSTGRES_IMAGE, MONGO_IMAGE, PROXYSQL_IMAGE, PMM_QA_GIT_BRANCH, '--mo-version=8.0 --setup-mongodb-ssl');
                         }
                     }
                 }


### PR DESCRIPTION
Implement usage of `release_versions` file from `percona-xtradb-cluster-operator` repo as a source of IMAGES and supported k8s versions for jenkins job.
Two new parameters are added:

`PILLAR_VERSION` - which pillar version to use. If set, implies a release run.
If any image is provided in job params during run - it will overwrite image from file.

Rename parameter `OPERATOR_IMAGE` to `IMAGE_OPERATOR`

Adding the `--enable-ip-alias` parameter to the `gcloud container clusters create ...` command

To prevent Google from automatically upgrading the GKE cluster midway, we will use `--add-maintenance-exclusion-start` and `--add-maintenance-exclusion-end`

test runs:
**GKE:**
non-release run: https://cloud.cd.percona.com/view/PXC/job/pxc-operator-gke-version/1175/
release run: https://cloud.cd.percona.com/view/PXC/job/pxc-operator-gke-version/1178/

https://cloud.cd.percona.com/view/PXC/job/pxc-operator-eks-version/77/

**AKS:**
non-release run: https://cloud.cd.percona.com/view/PXC/job/pxc-operator-aks-version/85/
release-run: https://cloud.cd.percona.com/view/PXC/job/pxc-operator-aks-version/87/


https://cloud.cd.percona.com/view/PXC/job/pxc-operator-aws-openshift-4/610/

**Minikube:**
non-release run: https://cloud.cd.percona.com/view/PXC/job/pxc-operator-minikube/434/
release run: https://cloud.cd.percona.com/view/PXC/job/pxc-operator-minikube/435/