### PR TITLE
PMM-7 Rename PMM2 rpmbuild image

### DIFF
--- a/pmm/infrastructure/rpm-build.groovy
+++ b/pmm/infrastructure/rpm-build.groovy
@@ -18,8 +18,7 @@ pipeline {
         DOCKER_TAG = "rpmbuild"
     }
     // Tag versions: (see what's available for download at https://gallery.ecr.aws/e7j3v3n0/rpmbuild)
-    // rpmbuild:2   - PMM2 el7
-    // rpmbuild:ol9 - PMM2 el9
+    // rpmbuild:2   - PMM2 el9
     // rpmbuild:3   - PMM3 el9
     stages {
         stage('Prepare') {
@@ -57,7 +56,7 @@ pipeline {
             steps {
                 sh '''
                     cd build/docker/rpmbuild/
-                    docker buildx build --pull --platform linux/amd64,linux/arm64 --tag ${IMAGE_REGISTRY}/${DOCKER_TAG}:ol9 -f Dockerfile.el9 --push .
+                    docker buildx build --pull --platform linux/amd64,linux/arm64 --tag ${IMAGE_REGISTRY}/${DOCKER_TAG}:2 -f Dockerfile.el9 --push .
                 '''
             }
         }

--- a/pmm/pmm2-client-autobuild-amd.groovy
+++ b/pmm/pmm2-client-autobuild-amd.groovy
@@ -110,7 +110,7 @@ pipeline {
                         stage('Build client source rpm EL9') {
                             steps {
                                 sh """
-                                    ${PATH_TO_SCRIPTS}/build-client-srpm public.ecr.aws/e7j3v3n0/rpmbuild:ol9
+                                    ${PATH_TO_SCRIPTS}/build-client-srpm public.ecr.aws/e7j3v3n0/rpmbuild:2
                                 """
                             }
                         }
@@ -132,7 +132,7 @@ pipeline {
                         stage('Build client binary rpm EL9') {
                             steps {
                                 sh """
-                                    ${PATH_TO_SCRIPTS}/build-client-rpm public.ecr.aws/e7j3v3n0/rpmbuild:ol9
+                                    ${PATH_TO_SCRIPTS}/build-client-rpm public.ecr.aws/e7j3v3n0/rpmbuild:2
                                 """
                             }
                         }

--- a/pmm/pmm2-client-autobuild-arm.groovy
+++ b/pmm/pmm2-client-autobuild-arm.groovy
@@ -109,7 +109,7 @@ pipeline {
                 stage('Build client source rpm EL9') {
                     steps {
                         sh """
-                            ${PATH_TO_SCRIPTS}/build-client-srpm public.ecr.aws/e7j3v3n0/rpmbuild:ol9
+                            ${PATH_TO_SCRIPTS}/build-client-srpm public.ecr.aws/e7j3v3n0/rpmbuild:2
                         """
                     }
                 }
@@ -131,7 +131,7 @@ pipeline {
                 stage('Build client binary rpm EL9') {
                     steps {
                         sh """
-                            ${PATH_TO_SCRIPTS}/build-client-rpm public.ecr.aws/e7j3v3n0/rpmbuild:ol9
+                            ${PATH_TO_SCRIPTS}/build-client-rpm public.ecr.aws/e7j3v3n0/rpmbuild:2
                         """
                     }
                 }

--- a/pmm/pmm2-release-candidate.groovy
+++ b/pmm/pmm2-release-candidate.groovy
@@ -193,7 +193,7 @@ pipeline {
                             git config --global user.name "PMM Jenkins"
                             export GIT_SSH_COMMAND="/usr/bin/ssh -i ${SSHKEY} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
 
-                            docker run --rm -v $PWD/.:/pmm public.ecr.aws/e7j3v3n0/rpmbuild:ol9 sh -c '
+                            docker run --rm -v $PWD/.:/pmm public.ecr.aws/e7j3v3n0/rpmbuild:2 sh -c '
                                 cd /pmm
                                 make init
                                 make -C api descriptors

--- a/pmm/pmm2-server-autobuild-el9.groovy
+++ b/pmm/pmm2-server-autobuild-el9.groovy
@@ -78,7 +78,7 @@ pipeline {
         }
         stage('Build client source rpm') {
             steps {
-                sh "${PATH_TO_SCRIPTS}/build-client-srpm public.ecr.aws/e7j3v3n0/rpmbuild:ol9"
+                sh "${PATH_TO_SCRIPTS}/build-client-srpm public.ecr.aws/e7j3v3n0/rpmbuild:2"
                 stash includes: 'results/srpm/pmm*-client-*.src.rpm', name: 'rpms'
                 uploadRPM()
             }
@@ -88,7 +88,7 @@ pipeline {
                 sh """
                     set -o errexit
 
-                    ${PATH_TO_SCRIPTS}/build-client-rpm public.ecr.aws/e7j3v3n0/rpmbuild:ol9
+                    ${PATH_TO_SCRIPTS}/build-client-rpm public.ecr.aws/e7j3v3n0/rpmbuild:2
 
                     mkdir -p tmp/pmm-server/RPMS/
                     cp results/rpm/pmm*-client-*.rpm tmp/pmm-server/RPMS/
@@ -102,13 +102,6 @@ pipeline {
                 withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'pmm-staging-slave', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
                     sh '''
                         set -o errexit
-
-                        # These are used by `src/github.com/percona/pmm/build/scripts/vars`
-                        ## export ROOT_DIR=${WORKSPACE}
-                        export RPMBUILD_DOCKER_IMAGE=public.ecr.aws/e7j3v3n0/rpmbuild:ol9
-                        export RPMBUILD_DIST="el9"
-                        # Set this variable if we need to rebuils all rpms, for example to refresh stale assets stored in S3 build cache
-                        # export FORCE_REBUILD=1
 
                         ${PATH_TO_SCRIPTS}/build-server-rpm-all
                     '''
@@ -135,8 +128,7 @@ pipeline {
                         export DOCKER_TAG=perconalab/pmm-server:$(date -u '+%Y%m%d%H%M')
                     fi
 
-                    export RPMBUILD_DOCKER_IMAGE=public.ecr.aws/e7j3v3n0/rpmbuild:ol9
-                    export RPMBUILD_DIST="el9"
+                    export RPMBUILD_DOCKER_IMAGE=public.ecr.aws/e7j3v3n0/rpmbuild:2
                     export DOCKERFILE=Dockerfile.el9
                     # Build a docker image
                     ${PATH_TO_SCRIPTS}/build-server-docker

--- a/pmm/pmm2-submodules.groovy
+++ b/pmm/pmm2-submodules.groovy
@@ -113,7 +113,7 @@ pipeline {
                         set -o errexit
                         aws ecr-public get-login-password --region us-east-1 | docker login -u AWS --password-stdin public.ecr.aws/e7j3v3n0
 
-                        ${PATH_TO_SCRIPTS}/build-client-srpm public.ecr.aws/e7j3v3n0/rpmbuild:ol9
+                        ${PATH_TO_SCRIPTS}/build-client-srpm public.ecr.aws/e7j3v3n0/rpmbuild:2
                     '''
                 }
             }
@@ -126,7 +126,7 @@ pipeline {
 
                         aws ecr-public get-login-password --region us-east-1 | docker login -u AWS --password-stdin public.ecr.aws/e7j3v3n0
 
-                        ${PATH_TO_SCRIPTS}/build-client-rpm public.ecr.aws/e7j3v3n0/rpmbuild:ol9
+                        ${PATH_TO_SCRIPTS}/build-client-rpm public.ecr.aws/e7j3v3n0/rpmbuild:2
 
                         mkdir -p tmp/pmm-server/RPMS/
                         cp results/rpm/pmm2-client-*.rpm tmp/pmm-server/RPMS/
@@ -164,8 +164,7 @@ pipeline {
 
                         export RPM_EPOCH=1
                         export PATH=${PATH}:$(pwd -P)/${PATH_TO_SCRIPTS}
-                        export RPMBUILD_DOCKER_IMAGE=public.ecr.aws/e7j3v3n0/rpmbuild:ol9
-                        export RPMBUILD_DIST="el9"
+                        export RPMBUILD_DOCKER_IMAGE=public.ecr.aws/e7j3v3n0/rpmbuild:2
 
                         ${PATH_TO_SCRIPTS}/build-server-rpm-all
                     '''
@@ -186,8 +185,7 @@ pipeline {
                         export PUSH_DOCKER=1
                         export DOCKER_TAG=perconalab/pmm-server-fb:${BRANCH_NAME}-${FB_COMMIT:0:7}
 
-                        export RPMBUILD_DOCKER_IMAGE=public.ecr.aws/e7j3v3n0/rpmbuild:ol9
-                        export RPMBUILD_DIST="el9"
+                        export RPMBUILD_DOCKER_IMAGE=public.ecr.aws/e7j3v3n0/rpmbuild:2
                         export DOCKERFILE=Dockerfile.el9
 
                         ${PATH_TO_SCRIPTS}/build-server-docker

--- a/pmm/pmm2-submodules.groovy
+++ b/pmm/pmm2-submodules.groovy
@@ -164,7 +164,6 @@ pipeline {
 
                         export RPM_EPOCH=1
                         export PATH=${PATH}:$(pwd -P)/${PATH_TO_SCRIPTS}
-                        export RPMBUILD_DOCKER_IMAGE=public.ecr.aws/e7j3v3n0/rpmbuild:2
 
                         ${PATH_TO_SCRIPTS}/build-server-rpm-all
                     '''
@@ -184,8 +183,6 @@ pipeline {
 
                         export PUSH_DOCKER=1
                         export DOCKER_TAG=perconalab/pmm-server-fb:${BRANCH_NAME}-${FB_COMMIT:0:7}
-
-                        export RPMBUILD_DOCKER_IMAGE=public.ecr.aws/e7j3v3n0/rpmbuild:2
                         export DOCKERFILE=Dockerfile.el9
 
                         ${PATH_TO_SCRIPTS}/build-server-docker

--- a/pmm/v3/pmm3-server-autobuild.groovy
+++ b/pmm/v3/pmm3-server-autobuild.groovy
@@ -103,12 +103,8 @@ pipeline {
                     sh '''
                         set -o errexit
 
-                        # These are used by `src/github.com/percona/pmm/build/scripts/vars`
-                        ## export ROOT_DIR=${WORKSPACE}
                         export RPMBUILD_DOCKER_IMAGE=public.ecr.aws/e7j3v3n0/rpmbuild:3
                         export RPMBUILD_DIST="el9"
-                        # Set this variable if we need to rebuils all rpms, for example to refresh stale assets stored in S3 build cache
-                        # export FORCE_REBUILD=1
 
                         ${PATH_TO_SCRIPTS}/build-server-rpm-all
                     '''


### PR DESCRIPTION
Background

With the deprecation of RHEL 7 builds, we want to go ahead with following naming for our `rpmbuild` images:

- rpmbuild:2   - PMM2 el9
- rpmbuild:3   - PMM3 el9
