### PR TITLE
Use docker images from my user satyapercona because the other images …

### DIFF
--- a/pxb/v2/docker/run-test
+++ b/pxb/v2/docker/run-test
@@ -29,7 +29,7 @@ if [[ ${WITH_XBCLOUD_TESTS} == "true" ]]; then
   check_pxb_network
   docker run -d --security-opt seccomp=unconfined --cap-add=NET_ADMIN \
   --env PASSWORD=someStrongPWD --env USER=myuser -p 9000:9000 --rm \
-  -p 9001:9001 ${DOCKER_NETWORK_FLAG} --name s3 altmannmarcelo/minio:latest
+  -p 9001:9001 ${DOCKER_NETWORK_FLAG} --name s3 satyapercona/minio:latest
 
   export S3_SERVER_IP=$(docker inspect s3 | egrep "\"IPAddress\": \"([0-9]{1,3}\.){3}[0-9]{1,3}" | awk -F'"' '{print $4}' | head -n 1)
   export XBCLOUD_CREDENTIALS="--storage=s3 --s3-endpoint='http://${S3_SERVER_IP}:9000' --s3-access-key=myuser --s3-secret-key=someStrongPWD --s3-bucket=newbucket"
@@ -37,7 +37,7 @@ fi
 
 if [[ ${WITH_VAULT_TESTS} == "true" ]]; then
     check_pxb_network
-    docker run -d --security-opt seccomp=unconfined --cap-add=NET_ADMIN --rm -p 8200:8200 ${DOCKER_NETWORK_FLAG} --name vault altmannmarcelo/vault:latest
+    docker run -d --security-opt seccomp=unconfined --cap-add=NET_ADMIN --rm -p 8200:8200 ${DOCKER_NETWORK_FLAG} --name vault satyapercona/vault:latest
     docker cp vault:/opt/vault/tls/tls.crt ${ROOT_DIR}/vault.crt
     export VAULT_SERVER_IP=$(docker inspect vault | egrep "\"IPAddress\": \"([0-9]{1,3}\.){3}[0-9]{1,3}" | awk -F'"' '{print $4}' | head -n 1)
     export TOKEN=$(docker logs vault | grep 'export VAULT_TOKEN' | awk -F'=' '{print $2}')


### PR DESCRIPTION
…have expired certificates

See jenkins jobs faililng to due to vault certificate issue: 
```++ docker logs vault
13:33:08  ++ grep 'export VAULT_TOKEN'
13:33:08  ++ awk -F= '{print $2}'
13:33:08  2025-01-08T13:32:56.131Z [INFO]  proxy environment: http_proxy="" https_proxy="" no_proxy=""
13:33:08  2025-01-08T13:32:56.132Z [INFO]  incrementing seal generation: generation=1
13:33:08  2025-01-08T13:32:56.132Z [WARN]  no `api_addr` value specified in config or in VAULT_API_ADDR; falling back to detection if possible, but this value should be manually set
13:33:08  2025-01-08T13:32:56.132Z [INFO]  core: Initializing version history cache for core
13:33:08  2025-01-08T13:32:56.132Z [INFO]  events: Starting event system
13:33:08  2025-01-08T13:33:01.132Z [INFO]  http: TLS handshake error from 127.0.0.1:58482: remote error: tls: bad certificate
13:33:08  Get "https://127.0.0.1:8200/v1/sys/seal-status": tls: failed to verify certificate: x509: certificate has expired or is not yet valid: current time 2025-01-08T13:33:01Z is after 2024-12-17T14:40:37Z
13:33:08  Token (will be hidden): 
13:33:08  Error authenticating: An error occurred attempting to ask for a token. The raw error message is shown below, but usually this is because you attempted to pipe a value into the command or you are executing outside of a terminal (tty). If you want to pipe the value, pass "-" as the argument to read from stdin. The raw error was: file descriptor 0 is not a terminal
13:33:08  2025-01-08T13:33:01.218Z [INFO]  http: TLS handshake error from 127.0.0.1:58488: remote error: tls: bad certificate
13:33:08  Error enabling: Post "https://127.0.0.1:8200/v1/sys/mounts/secret": tls: failed to verify certificate: x509: certificate has expired or is not yet valid: current time 2025-01-08T13:33:01Z is after 2024-12-17T14:40:37Z```
