### PR TITLE
Followup fixes to PKG-682 PKG-575

### DIFF
--- a/pxb/v2/jenkins/percona-xtrabackup-8.0-compile-param.yml
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.0-compile-param.yml
@@ -48,22 +48,21 @@
          type: user-defined
          name: DOCKER_OS
          values:
-         - centos:7
          - centos:8
          - oraclelinux:9
-         - ubuntu:bionic
          - ubuntu:focal
          - ubuntu:jammy
-         - debian:buster
+         - ubuntu:noble
          - debian:bullseye
+         - debian:bookworm
          - asan
     builders:
     - trigger-builds:
       - project: percona-xtrabackup-8.0-compile-pipeline
         current-parameters: true
         predefined-parameters: |
-          DOCKER_OS=${DOCKER_OS}
-          CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+          DOCKER_OS=${{DOCKER_OS}}
+          CMAKE_BUILD_TYPE=${{CMAKE_BUILD_TYPE}}
         block: true
         block-thresholds:
           build-step-failure-threshold: FAILURE
@@ -74,10 +73,10 @@
     - copyartifact:
         project: percona-xtrabackup-8.0-compile-pipeline
         which-build: specific-build
-        build-number: "${TRIGGERED_BUILD_NUMBERS_percona_xtrabackup_8_0_compile_pipeline}"
+        build-number: "${{TRIGGERED_BUILD_NUMBERS_percona_xtrabackup_8_0_compile_pipeline}}"
         do-not-fingerprint: true
     - shell: |
-        echo "${TRIGGERED_BUILD_NUMBERS_percona_xtrabackup_8_0_compile_pipeline}" > PIPELINE_BUILD_NUMBER
+        echo "${{TRIGGERED_BUILD_NUMBERS_percona_xtrabackup_8_0_compile_pipeline}}" > PIPELINE_BUILD_NUMBER
         gunzip build.log.gz
     publishers:
     - raw:

--- a/pxb/v2/jenkins/percona-xtrabackup-8.0-compile-pipeline.groovy
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.0-compile-pipeline.groovy
@@ -11,7 +11,7 @@ pipeline {
             name: 'BRANCH',
             trim: true)
         choice(
-            choices: 'centos:7\ncentos:8\noraclelinux:9\nubuntu:bionic\nubuntu:focal\nubuntu:jammy\ndebian:buster\ndebian:bullseye\nasan',
+            choices: 'centos:8\noraclelinux:9\nubuntu:focal\nubuntu:jammy\nubuntu:noble\ndebian:bullseye\ndebian:bookworm\nasan',
             description: 'OS version for compilation',
             name: 'DOCKER_OS')
         choice(

--- a/pxb/v2/jenkins/percona-xtrabackup-8.0-compile-pipeline.yml
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.0-compile-pipeline.yml
@@ -25,14 +25,13 @@
     - choice:
         name: DOCKER_OS
         choices:
-        - centos:7
         - centos:8
         - oraclelinux:9
-        - ubuntu:bionic
         - ubuntu:focal
         - ubuntu:jammy
-        - debian:buster
+        - ubuntu:noble
         - debian:bullseye
+        - debian:bookworm
         - asan
         description: OS version for compilation
     - choice:
@@ -54,4 +53,4 @@
         choices:
         - docker-32gb
         - docker
-        description: Run build on specified instance type. 
+        description: Run build on specified instance type.

--- a/pxb/v2/jenkins/percona-xtrabackup-8.0-test-cloud-pipeline.groovy
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.0-test-cloud-pipeline.groovy
@@ -1,7 +1,7 @@
 pipeline {
     parameters {
         choice(
-            choices: 'centos:7\ncentos:8\noraclelinux:9\nubuntu:jammy\ndebian:bullseye\nasan',
+            choices: 'centos:8\noraclelinux:9\nubuntu:focal\nubuntu:jammy\nubuntu:noble\ndebian:bullseye\ndebian:bookworm\nasan',
             description: 'OS version for compilation',
             name: 'DOCKER_OS')
         choice(

--- a/pxb/v2/jenkins/percona-xtrabackup-8.0-test-cloud-pipeline.yml
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.0-test-cloud-pipeline.yml
@@ -17,11 +17,13 @@
     - choice:
         name: DOCKER_OS
         choices:
-          - centos:7
           - centos:8
           - oraclelinux:9
+          - ubuntu:focal
           - ubuntu:jammy
+          - ubuntu:noble
           - debian:bullseye
+          - debain:bookworm
           - asan
         description: OS version for compilation
     - choice:

--- a/pxb/v2/jenkins/percona-xtrabackup-8.0-test-param.yml
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.0-test-param.yml
@@ -64,14 +64,13 @@
         type: user-defined
         name: DOCKER_OS
         values:
-        - centos:7
         - centos:8
         - oraclelinux:9
-        - ubuntu:bionic
         - ubuntu:focal
         - ubuntu:jammy
-        - debian:buster
+        - ubuntu:noble
         - debian:bullseye
+        - debian:bookworm
         - asan
     - axis:
         name: XTRABACKUP_TARGET

--- a/pxb/v2/jenkins/percona-xtrabackup-8.0-test-pipeline.groovy
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.0-test-pipeline.groovy
@@ -1,7 +1,7 @@
 pipeline {
     parameters {
         choice(
-            choices: 'centos:8\noraclelinux:9\nubuntu:jammy\nubuntu:noble\ndebian:bullseye\ndebian:bookworm\nasan',
+            choices: 'centos:8\noraclelinux:9\nubuntu:focal\nubuntu:jammy\nubuntu:noble\ndebian:bullseye\ndebian:bookworm\nasan',
             description: 'OS version for compilation',
             name: 'DOCKER_OS')
         choice(

--- a/pxb/v2/jenkins/percona-xtrabackup-8.0-test-pipeline.yml
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.0-test-pipeline.yml
@@ -19,6 +19,7 @@
         choices:
           - centos:8
           - oraclelinux:9
+          - ubuntu:focal
           - ubuntu:jammy
           - ubuntu:noble
           - debian:bullseye

--- a/pxb/v2/jenkins/percona-xtrabackup-8.0-trunk.yml
+++ b/pxb/v2/jenkins/percona-xtrabackup-8.0-trunk.yml
@@ -38,17 +38,17 @@
     - copyartifact:
         project: percona-xtrabackup-8.0-compile-param
         which-build: specific-build
-        build-number: "${TRIGGERED_BUILD_NUMBERS_percona_xtrabackup_8_0_compile_param}"
+        build-number: "${{TRIGGERED_BUILD_NUMBERS_percona_xtrabackup_8_0_compile_param}}"
         do-not-fingerprint: true
     - shell: |
-        echo "${TRIGGERED_BUILD_NUMBERS_percona_xtrabackup_8_0_compile_param}" > COMPILE_PIPELINE_BUILD_NUMBER
+        echo "${{TRIGGERED_BUILD_NUMBERS_percona_xtrabackup_8_0_compile_param}}" > COMPILE_PIPELINE_BUILD_NUMBER
     - copyartifact:
         project: percona-xtrabackup-8.0-test-param
         which-build: specific-build
-        build-number: "${TRIGGERED_BUILD_NUMBERS_percona_xtrabackup_8_0_test_param}"
+        build-number: "${{TRIGGERED_BUILD_NUMBERS_percona_xtrabackup_8_0_test_param}}"
         do-not-fingerprint: true
     - shell: |
-        echo "${TRIGGERED_BUILD_NUMBERS_percona_xtrabackup_8_0_test_param}" > TEST_PIPELINE_BUILD_NUMBER
+        echo "${{TRIGGERED_BUILD_NUMBERS_percona_xtrabackup_8_0_test_param}}" > TEST_PIPELINE_BUILD_NUMBER
     publishers:
     - raw:
         xml: !!binary |


### PR DESCRIPTION
PKG-682 :Update the platforms for PXB jenkins jobs PKG-575 : PXB Jenkins: Test failures are not reported and all jobs are shown as failed

Fixes:
------
Update PXB test platforms. Bring back Ubuntu focal (for additional 6months). Final list of paltforms are

         - centos:8
         - oraclelinux:9
         - ubuntu:focal
         - ubuntu:jammy
         - ubuntu:noble
         - debian:bullseye
         - debian:bookworm
         - asan

Update other pipelines to use {{ }} for variable declarations