### PR TITLE
Updating PSP branch to use for nightly build to use TDE_REL_17_STABLE. 

### DIFF
--- a/ppg/pg_tde_nightly.groovy
+++ b/ppg/pg_tde_nightly.groovy
@@ -41,11 +41,11 @@ pipeline {
             description: 'URL for pg_tde repository',
             name: 'GIT_REPO')
         string(
-            defaultValue: 'main',
+            defaultValue: 'TDE_REL_17_STABLE',
             description: 'Tag/Branch for pg_tde repository',
             name: 'PG_BRANCH')
         string(
-            defaultValue: '17.0',
+            defaultValue: 'TDE_NIGHTLY',
             description: 'Tag/Branch for pg_tde packaging repository',
             name: 'GIT_BRANCH')
         string(


### PR DESCRIPTION
Updating PSP branch to use for nightly build. Similarly, updated postgres-packaging branch to TDE_NIGHTLY to reflect the new branch for nightly releases.