### PR TITLE
PKG-691 : libaio.so.1 is not available on ubuntu noble docker image

### DIFF
--- a/pxb/v2/local/test-binary
+++ b/pxb/v2/local/test-binary
@@ -125,6 +125,36 @@ else
     fi
     ./bootstrap.sh --pxb-type=${CMAKE_BUILD_TYPE} --type=${XTRABACKUP_TARGET} --version=${XTRABACKUP_TARGET_VERSION}
 fi
+
+fix_libaio_symlink() {
+    local server_dir="$1"
+    local binary="$server_dir/bin/mysqld"
+    local missing_lib="libaio.so.1"
+    local target_path="/usr/lib/x86_64-linux-gnu"
+    local real_lib="$target_path/${missing_lib}t64"
+    local link_lib="$target_path/$missing_lib"
+
+    if [ ! -x "$binary" ]; then
+        echo "Error: $binary does not exist or is not executable."
+        return 1
+    fi
+
+    if ldd "$binary" | grep -q "$missing_lib => not found"; then
+        echo "$missing_lib is missing in $binary."
+
+        if [ -e "$real_lib" ]; then
+            echo "$real_lib exists. Creating symlink..."
+            sudo ln -sf "$real_lib" "$link_lib"
+            echo "Symlink created: $link_lib -> $real_lib"
+        else
+            echo "Error: $real_lib not found. Cannot fix missing $missing_lib."
+            return 2
+        fi
+    fi
+}
+
+fix_libaio_symlink ./server
+
 if [[ ${CMAKE_BUILD_TYPE} == "Debug" ]]; then
     if [[ ${XTRABACKUP_TARGET} == "innodb80" ]] || [[ ${XTRABACKUP_TARGET} == "innodb57" ]]; then
         XBTR_ARGS+=" -D"


### PR DESCRIPTION
When upstream tarballs (2.28 glibc) version on ubuntu noble, mysqld binary cannot used due to misisng libaio.so.1 library.

On this platforms, it is available as libaio.so.1t64. This problem is not applicable for system packages(deb or rpm) and is also not applicable for Percona Server binaries (they are shipped iwht libaio in lib/private)

Fix:
----
When pxb downloads these tarballs, check for missing libaio and if OS has libaio.so.1t64, create a symlink of it.