### PR TITLE
CLOUD-893: add DEBUG_TESTS param diabled by default

### DIFF
--- a/cloud/jenkins/psmdbo_aks.groovy
+++ b/cloud/jenkins/psmdbo_aks.groovy
@@ -223,7 +223,7 @@ void runTest(Integer TEST_ID) {
                 sh """
                     cd source
 
-                    export DEBUG_TESTS=1
+                    [[ "$DEBUG_TESTS" == "YES" ]] && export DEBUG_TESTS=1
                     [[ "$CLUSTER_WIDE" == "YES" ]] && export OPERATOR_NS=psmdb-operator
                     [[ "$IMAGE_OPERATOR" ]] && export IMAGE=$IMAGE_OPERATOR || export IMAGE=perconalab/percona-server-mongodb-operator:$GIT_BRANCH
                     export IMAGE_MONGOD=$IMAGE_MONGOD
@@ -333,6 +333,7 @@ pipeline {
         string(name: 'IMAGE_PMM_CLIENT', defaultValue: '', description: 'ex: perconalab/pmm-client:dev-latest')
         string(name: 'IMAGE_PMM_SERVER', defaultValue: '', description: 'ex: perconalab/pmm-server:dev-latest')
         string(name: 'AKS_LOCATION', defaultValue: '', description: 'AKS location to use for cluster. By default "eastus" is for aks-1 job and "norwayeast" for aks-2')
+        choice(name: 'DEBUG_TESTS', choices: 'NO\nYES', description: 'Run tests with debug')
     }
     agent {
         label 'docker'

--- a/cloud/jenkins/psmdbo_eks.groovy
+++ b/cloud/jenkins/psmdbo_eks.groovy
@@ -232,7 +232,7 @@ void runTest(Integer TEST_ID) {
                     sh """
                         cd source
 
-                        export DEBUG_TESTS=1
+                        [[ "$DEBUG_TESTS" == "YES" ]] && export DEBUG_TESTS=1
                         [[ "$CLUSTER_WIDE" == "YES" ]] && export OPERATOR_NS=psmdb-operator
                         [[ "$IMAGE_OPERATOR" ]] && export IMAGE=$IMAGE_OPERATOR || export IMAGE=perconalab/percona-server-mongodb-operator:$GIT_BRANCH
                         export IMAGE_MONGOD=$IMAGE_MONGOD
@@ -368,6 +368,7 @@ pipeline {
         string(name: 'IMAGE_PMM_CLIENT', defaultValue: '', description: 'ex: perconalab/pmm-client:dev-latest')
         string(name: 'IMAGE_PMM_SERVER', defaultValue: '', description: 'ex: perconalab/pmm-server:dev-latest')
         string(name: 'EKS_REGION', defaultValue: 'eu-west-3', description: 'EKS region to use for cluster')
+        choice(name: 'DEBUG_TESTS', choices: 'NO\nYES', description: 'Run tests with debug')
     }
     agent {
         label 'docker'

--- a/cloud/jenkins/psmdbo_gke.groovy
+++ b/cloud/jenkins/psmdbo_gke.groovy
@@ -252,7 +252,7 @@ void runTest(Integer TEST_ID) {
                 sh """
                     cd source
 
-                    export DEBUG_TESTS=1
+                    [[ "$DEBUG_TESTS" == "YES" ]] && export DEBUG_TESTS=1
                     [[ "$CLUSTER_WIDE" == "YES" ]] && export OPERATOR_NS=psmdb-operator
                     [[ "$IMAGE_OPERATOR" ]] && export IMAGE=$IMAGE_OPERATOR || export IMAGE=perconalab/percona-server-mongodb-operator:$GIT_BRANCH
                     export IMAGE_MONGOD=$IMAGE_MONGOD
@@ -364,6 +364,7 @@ pipeline {
         string(name: 'IMAGE_PMM_CLIENT', defaultValue: '', description: 'ex: perconalab/pmm-client:dev-latest')
         string(name: 'IMAGE_PMM_SERVER', defaultValue: '', description: 'ex: perconalab/pmm-server:dev-latest')
         string(name: 'GKE_REGION', defaultValue: 'us-central1-a', description: 'GKE region to use for cluster')
+        choice(name: 'DEBUG_TESTS', choices: 'NO\nYES', description: 'Run tests with debug')
     }
     agent {
         label 'docker'

--- a/cloud/jenkins/psmdbo_minikube.groovy
+++ b/cloud/jenkins/psmdbo_minikube.groovy
@@ -164,7 +164,7 @@ void runTest(Integer TEST_ID) {
             sh """
                 cd source
 
-                export DEBUG_TESTS=1
+                [[ "$DEBUG_TESTS" == "YES" ]] && export DEBUG_TESTS=1
                 [[ "$CLUSTER_WIDE" == "YES" ]] && export OPERATOR_NS=psmdb-operator
                 [[ "$IMAGE_OPERATOR" ]] && export IMAGE=$IMAGE_OPERATOR || export IMAGE=perconalab/percona-server-mongodb-operator:$GIT_BRANCH
                 export IMAGE_MONGOD=$IMAGE_MONGOD
@@ -253,6 +253,7 @@ pipeline {
         string(name: 'IMAGE_BACKUP', defaultValue: '', description: 'ex: perconalab/percona-server-mongodb-operator:main-backup')
         string(name: 'IMAGE_PMM_CLIENT', defaultValue: '', description: 'ex: perconalab/pmm-client:dev-latest')
         string(name: 'IMAGE_PMM_SERVER', defaultValue: '', description: 'ex: perconalab/pmm-server:dev-latest')
+        choice(name: 'DEBUG_TESTS', choices: 'NO\nYES', description: 'Run tests with debug')
     }
     agent {
         label 'docker-32gb'

--- a/cloud/jenkins/psmdbo_openshift.groovy
+++ b/cloud/jenkins/psmdbo_openshift.groovy
@@ -255,7 +255,7 @@ void runTest(Integer TEST_ID) {
                 sh """
                     cd source
 
-                    export DEBUG_TESTS=1
+                    [[ "$DEBUG_TESTS" == "YES" ]] && export DEBUG_TESTS=1
                     [[ "$CLUSTER_WIDE" == "YES" ]] && export OPERATOR_NS=psmdb-operator
                     [[ "$IMAGE_OPERATOR" ]] && export IMAGE=$IMAGE_OPERATOR || export IMAGE=perconalab/percona-server-mongodb-operator:$GIT_BRANCH
                     export IMAGE_MONGOD=$IMAGE_MONGOD
@@ -369,6 +369,7 @@ pipeline {
         string(name: 'IMAGE_PMM_CLIENT', defaultValue: '', description: 'ex: perconalab/pmm-client:dev-latest')
         string(name: 'IMAGE_PMM_SERVER', defaultValue: '', description: 'ex: perconalab/pmm-server:dev-latest')
         string(name: 'AWS_REGION', defaultValue: 'eu-west-3', description: 'AWS region to use for openshift cluster')
+        choice(name: 'DEBUG_TESTS', choices: 'NO\nYES', description: 'Run tests with debug')
     }
     agent {
         label 'docker'

--- a/cloud/jenkins/pxco_aks.groovy
+++ b/cloud/jenkins/pxco_aks.groovy
@@ -230,7 +230,7 @@ void runTest(Integer TEST_ID) {
                 sh """
                     cd source
 
-                    export DEBUG_TESTS=1
+                    [[ "$DEBUG_TESTS" == "YES" ]] && export DEBUG_TESTS=1
                     [[ "$CLUSTER_WIDE" == "YES" ]] && export OPERATOR_NS=pxc-operator
                     [[ "$IMAGE_OPERATOR" ]] && export IMAGE=$IMAGE_OPERATOR || export IMAGE=perconalab/percona-xtradb-cluster-operator:$GIT_BRANCH
                     export IMAGE_PXC=$IMAGE_PXC
@@ -402,6 +402,10 @@ pipeline {
             defaultValue: '',
             description: 'AKS location to use for cluster. By default "eastus" is for aks-1 job and "norwayeast" for aks-2',
             name: 'AKS_LOCATION')
+        choice(
+            choices: 'NO\nYES',
+            description: 'Run tests with debug',
+            name: 'DEBUG_TESTS')
     }
     agent {
         label 'docker'

--- a/cloud/jenkins/pxco_eks.groovy
+++ b/cloud/jenkins/pxco_eks.groovy
@@ -245,7 +245,7 @@ void runTest(Integer TEST_ID) {
                     sh """
                         cd source
 
-                        export DEBUG_TESTS=1
+                        [[ "$DEBUG_TESTS" == "YES" ]] && export DEBUG_TESTS=1
                         [[ "$CLUSTER_WIDE" == "YES" ]] && export OPERATOR_NS=pxc-operator
                         [[ "$IMAGE_OPERATOR" ]] && export IMAGE=$IMAGE_OPERATOR || export IMAGE=perconalab/percona-xtradb-cluster-operator:$GIT_BRANCH
                         export IMAGE_PXC=$IMAGE_PXC
@@ -442,6 +442,10 @@ pipeline {
             defaultValue: 'eu-west-3',
             description: 'EKS region to use for cluster',
             name: 'EKS_REGION')
+        choice(
+            choices: 'NO\nYES',
+            description: 'Run tests with debug',
+            name: 'DEBUG_TESTS')
     }
     agent {
         label 'docker'

--- a/cloud/jenkins/pxco_gke.groovy
+++ b/cloud/jenkins/pxco_gke.groovy
@@ -252,7 +252,7 @@ void runTest(Integer TEST_ID) {
                 sh """
                     cd source
 
-                    export DEBUG_TESTS=1
+                    [[ "$DEBUG_TESTS" == "YES" ]] && export DEBUG_TESTS=1
                     [[ "$CLUSTER_WIDE" == "YES" ]] && export OPERATOR_NS=pxc-operator
                     [[ "$IMAGE_OPERATOR" ]] && export IMAGE=$IMAGE_OPERATOR || export IMAGE=perconalab/percona-xtradb-cluster-operator:$GIT_BRANCH
                     export IMAGE_PXC=$IMAGE_PXC
@@ -427,6 +427,10 @@ pipeline {
             defaultValue: 'us-central1-a',
             description: 'GKE region to use for cluster',
             name: 'GKE_REGION')
+        choice(
+            choices: 'NO\nYES',
+            description: 'Run tests with debug',
+            name: 'DEBUG_TESTS')
     }
     agent {
         label 'docker'

--- a/cloud/jenkins/pxco_minikube.groovy
+++ b/cloud/jenkins/pxco_minikube.groovy
@@ -167,7 +167,7 @@ void runTest(Integer TEST_ID) {
             sh """
                 cd source
 
-                export DEBUG_TESTS=1
+                [[ "$DEBUG_TESTS" == "YES" ]] && export DEBUG_TESTS=1
                 [[ "$CLUSTER_WIDE" == "YES" ]] && export OPERATOR_NS=pxc-operator
                 [[ "$IMAGE_OPERATOR" ]] && export IMAGE=$IMAGE_OPERATOR || export IMAGE=perconalab/percona-xtradb-cluster-operator:$GIT_BRANCH
                 export IMAGE_PXC=$IMAGE_PXC
@@ -314,6 +314,10 @@ pipeline {
             defaultValue: '',
             description: 'PMM server image: perconalab/pmm-server:dev-latest',
             name: 'IMAGE_PMM_SERVER')
+        choice(
+            choices: 'NO\nYES',
+            description: 'Run tests with debug',
+            name: 'DEBUG_TESTS')
     }
     agent {
         label 'docker-32gb'

--- a/cloud/jenkins/pxco_openshift.groovy
+++ b/cloud/jenkins/pxco_openshift.groovy
@@ -262,7 +262,7 @@ void runTest(Integer TEST_ID) {
                 sh """
                     cd source
 
-                    export DEBUG_TESTS=1
+                    [[ "$DEBUG_TESTS" == "YES" ]] && export DEBUG_TESTS=1
                     [[ "$CLUSTER_WIDE" == "YES" ]] && export OPERATOR_NS=pxc-operator
                     [[ "$IMAGE_OPERATOR" ]] && export IMAGE=$IMAGE_OPERATOR || export IMAGE=perconalab/percona-xtradb-cluster-operator:$GIT_BRANCH
                     export IMAGE_PXC=$IMAGE_PXC
@@ -437,6 +437,10 @@ pipeline {
             defaultValue: 'eu-west-2',
             description: 'AWS region to use for openshift cluster',
             name: 'AWS_REGION')
+        choice(
+            choices: 'NO\nYES',
+            description: 'Run tests with debug',
+            name: 'DEBUG_TESTS')
     }
     agent {
         label 'docker'


### PR DESCRIPTION
At the moment all the tests in pxc and psmdb playbooks run on jenkins with enabled debug which floods the output and makes analysis of the failures harder. With this PR the debug will be disabled by default. PG and PS tests use kuttl so skipped in this PR.