### PR TITLE
PKG-1045 hetzner: start worker after cloud-init completion

### DIFF
--- a/IaC/cloud.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/cloud.cd/init.groovy.d/htz.cloud.groovy
@@ -78,6 +78,7 @@ networkMap['percona-vpc-eu'] = '10442325' // percona-vpc-eu
 initMap = [:]
 initMap['fedora-docker'] = '''#!/bin/bash -x
     set -o xtrace
+    ( sudo systemctl stop sshd; sleep 300; sudo systemctl start sshd ) &
     sudo fallocate -l 32G /swapfile
     sudo chmod 600 /swapfile
     sudo mkswap /swapfile
@@ -86,7 +87,7 @@ initMap['fedora-docker'] = '''#!/bin/bash -x
         sleep 1
         echo "try again"
     done
-    until sudo dnf install -y java-21-openjdk-headless ca-certificates curl gnupg unzip git dnf-plugins-core; do
+    until sudo dnf install -y java-21-openjdk-headless ca-certificates curl gnupg unzip git dnf-plugins-core cronie bc; do
         sleep 1
         echo "try again"
     done
@@ -122,6 +123,7 @@ initMap['fedora-docker'] = '''#!/bin/bash -x
     echo '{"experimental": true, "ipv6": true, "fixed-cidr-v6": "fd3c:a8b0:18eb:5c06::/64"}' | sudo tee /etc/docker/daemon.json
     sudo systemctl status docker || sudo systemctl start docker
     echo "* * * * * root /usr/sbin/route add default gw 10.30.232.1 eth0" | sudo tee /etc/cron.d/fix-default-route
+    sudo systemctl start sshd
 '''
 initMap['fedora42-x64-nbg1']     = initMap['fedora-docker']
 initMap['fedora42-x64-hel1']     = initMap['fedora-docker']

--- a/IaC/pg.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/pg.cd/init.groovy.d/htz.cloud.groovy
@@ -78,6 +78,7 @@ networkMap['percona-vpc-eu'] = '10442325' // percona-vpc-eu
 initMap = [:]
 initMap['deb-docker'] = '''#!/bin/bash -x
     set -o xtrace
+    ( sudo systemctl stop sshd; sleep 300; sudo systemctl start sshd ) &
     sudo fallocate -l 32G /swapfile
     sudo chmod 600 /swapfile
     sudo mkswap /swapfile
@@ -128,6 +129,7 @@ initMap['deb-docker'] = '''#!/bin/bash -x
     echo '{"experimental": true, "ipv6": true, "fixed-cidr-v6": "fd3c:a8b0:18eb:5c06::/64"}' | sudo tee /etc/docker/daemon.json
     sudo systemctl restart docker
     echo "* * * * * root /usr/sbin/route add default gw 10.177.1.1 eth0" | sudo tee /etc/cron.d/fix-default-route
+    sudo systemctl start sshd
 '''
 initMap['deb12-x64-nbg1']     = initMap['deb-docker']
 initMap['deb12-x64-hel1']     = initMap['deb-docker']

--- a/IaC/pmm.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/pmm.cd/init.groovy.d/htz.cloud.groovy
@@ -78,6 +78,7 @@ networkMap['percona-vpc-eu'] = '10442325' // percona-vpc-eu
 initMap = [:]
 initMap['deb-docker'] = '''#!/bin/bash -x
     set -o xtrace
+    ( sudo systemctl stop sshd; sleep 300; sudo systemctl start sshd ) &
     sudo fallocate -l 32G /swapfile
     sudo chmod 600 /swapfile
     sudo mkswap /swapfile
@@ -128,6 +129,7 @@ initMap['deb-docker'] = '''#!/bin/bash -x
     echo '{"experimental": true, "ipv6": true, "fixed-cidr-v6": "fd3c:a8b0:18eb:5c06::/64"}' | sudo tee /etc/docker/daemon.json
     sudo systemctl restart docker
     echo "* * * * * root /usr/sbin/route add default gw 10.177.1.1 eth0" | sudo tee /etc/cron.d/fix-default-route
+    sudo systemctl start sshd
 '''
 initMap['deb12-x64-nbg1']     = initMap['deb-docker']
 initMap['deb12-x64-hel1']     = initMap['deb-docker']

--- a/IaC/ps3.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/ps3.cd/init.groovy.d/htz.cloud.groovy
@@ -78,6 +78,7 @@ networkMap['percona-vpc-eu'] = '10442325' // percona-vpc-eu
 initMap = [:]
 initMap['deb-docker'] = '''#!/bin/bash -x
     set -o xtrace
+    ( sudo systemctl stop sshd; sleep 300; sudo systemctl start sshd ) &
     sudo fallocate -l 32G /swapfile
     sudo chmod 600 /swapfile
     sudo mkswap /swapfile
@@ -128,6 +129,7 @@ initMap['deb-docker'] = '''#!/bin/bash -x
     echo '{"experimental": true, "ipv6": true, "fixed-cidr-v6": "fd3c:a8b0:18eb:5c06::/64"}' | sudo tee /etc/docker/daemon.json
     sudo systemctl restart docker
     echo "* * * * * root /usr/sbin/route add default gw 10.177.1.1 eth0" | sudo tee /etc/cron.d/fix-default-route
+    sudo systemctl start sshd
 '''
 initMap['deb12-x64-nbg1']     = initMap['deb-docker']
 initMap['deb12-x64-hel1']     = initMap['deb-docker']

--- a/IaC/ps57.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/ps57.cd/init.groovy.d/htz.cloud.groovy
@@ -78,6 +78,7 @@ networkMap['percona-vpc-eu'] = '10442325' // percona-vpc-eu
 initMap = [:]
 initMap['deb-docker'] = '''#!/bin/bash -x
     set -o xtrace
+    ( sudo systemctl stop sshd; sleep 300; sudo systemctl start sshd ) &
     sudo fallocate -l 32G /swapfile
     sudo chmod 600 /swapfile
     sudo mkswap /swapfile
@@ -128,6 +129,7 @@ initMap['deb-docker'] = '''#!/bin/bash -x
     echo '{"experimental": true, "ipv6": true, "fixed-cidr-v6": "fd3c:a8b0:18eb:5c06::/64"}' | sudo tee /etc/docker/daemon.json
     sudo systemctl restart docker
     echo "* * * * * root /usr/sbin/route add default gw 10.177.1.1 eth0" | sudo tee /etc/cron.d/fix-default-route
+    sudo systemctl start sshd
 '''
 initMap['deb12-x64-nbg1']     = initMap['deb-docker']
 initMap['deb12-x64-hel1']     = initMap['deb-docker']

--- a/IaC/ps80.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/ps80.cd/init.groovy.d/htz.cloud.groovy
@@ -78,6 +78,7 @@ networkMap['percona-vpc-eu'] = '10442325' // percona-vpc-eu
 initMap = [:]
 initMap['deb-docker'] = '''#!/bin/bash -x
     set -o xtrace
+    ( sudo systemctl stop sshd; sleep 300; sudo systemctl start sshd ) &
     sudo fallocate -l 32G /swapfile
     sudo chmod 600 /swapfile
     sudo mkswap /swapfile
@@ -128,6 +129,7 @@ initMap['deb-docker'] = '''#!/bin/bash -x
     echo '{"experimental": true, "ipv6": true, "fixed-cidr-v6": "fd3c:a8b0:18eb:5c06::/64"}' | sudo tee /etc/docker/daemon.json
     sudo systemctl restart docker
     echo "* * * * * root /usr/sbin/route add default gw 10.177.1.1 eth0" | sudo tee /etc/cron.d/fix-default-route
+    sudo systemctl start sshd
 '''
 initMap['deb12-x64-nbg1']     = initMap['deb-docker']
 initMap['deb12-x64-hel1']     = initMap['deb-docker']

--- a/IaC/psmdb.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/psmdb.cd/init.groovy.d/htz.cloud.groovy
@@ -78,6 +78,7 @@ networkMap['percona-vpc-eu'] = '10442325' // percona-vpc-eu
 initMap = [:]
 initMap['deb-docker'] = '''#!/bin/bash -x
     set -o xtrace
+    ( sudo systemctl stop sshd; sleep 300; sudo systemctl start sshd ) &
     sudo fallocate -l 32G /swapfile
     sudo chmod 600 /swapfile
     sudo mkswap /swapfile
@@ -128,6 +129,7 @@ initMap['deb-docker'] = '''#!/bin/bash -x
     echo '{"experimental": true, "ipv6": true, "fixed-cidr-v6": "fd3c:a8b0:18eb:5c06::/64"}' | sudo tee /etc/docker/daemon.json
     sudo systemctl restart docker
     echo "* * * * * root /usr/sbin/route add default gw 10.177.1.1 eth0" | sudo tee /etc/cron.d/fix-default-route
+    sudo systemctl start sshd
 '''
 initMap['deb12-x64-nbg1']     = initMap['deb-docker']
 initMap['deb12-x64-hel1']     = initMap['deb-docker']

--- a/IaC/pxb.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/pxb.cd/init.groovy.d/htz.cloud.groovy
@@ -78,6 +78,7 @@ networkMap['percona-vpc-eu'] = '10442325' // percona-vpc-eu
 initMap = [:]
 initMap['deb-docker'] = '''#!/bin/bash -x
     set -o xtrace
+    ( sudo systemctl stop sshd; sleep 300; sudo systemctl start sshd ) &
     sudo fallocate -l 32G /swapfile
     sudo chmod 600 /swapfile
     sudo mkswap /swapfile
@@ -128,6 +129,7 @@ initMap['deb-docker'] = '''#!/bin/bash -x
     echo '{"experimental": true, "ipv6": true, "fixed-cidr-v6": "fd3c:a8b0:18eb:5c06::/64"}' | sudo tee /etc/docker/daemon.json
     sudo systemctl restart docker
     echo "* * * * * root /usr/sbin/route add default gw 10.177.1.1 eth0" | sudo tee /etc/cron.d/fix-default-route
+    sudo systemctl start sshd
 '''
 initMap['deb12-x64-nbg1']     = initMap['deb-docker']
 initMap['deb12-x64-hel1']     = initMap['deb-docker']

--- a/IaC/pxc.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/pxc.cd/init.groovy.d/htz.cloud.groovy
@@ -78,6 +78,7 @@ networkMap['percona-vpc-eu'] = '10442325' // percona-vpc-eu
 initMap = [:]
 initMap['deb-docker'] = '''#!/bin/bash -x
     set -o xtrace
+    ( sudo systemctl stop sshd; sleep 300; sudo systemctl start sshd ) &
     sudo fallocate -l 32G /swapfile
     sudo chmod 600 /swapfile
     sudo mkswap /swapfile
@@ -128,6 +129,7 @@ initMap['deb-docker'] = '''#!/bin/bash -x
     echo '{"experimental": true, "ipv6": true, "fixed-cidr-v6": "fd3c:a8b0:18eb:5c06::/64"}' | sudo tee /etc/docker/daemon.json
     sudo systemctl restart docker
     echo "* * * * * root /usr/sbin/route add default gw 10.177.1.1 eth0" | sudo tee /etc/cron.d/fix-default-route
+    sudo systemctl start sshd
 '''
 initMap['deb12-x64-nbg1']     = initMap['deb-docker']
 initMap['deb12-x64-hel1']     = initMap['deb-docker']

--- a/IaC/rel.cd/init.groovy.d/htz.cloud.groovy
+++ b/IaC/rel.cd/init.groovy.d/htz.cloud.groovy
@@ -78,6 +78,7 @@ networkMap['percona-vpc-eu'] = '10442325' // percona-vpc-eu
 initMap = [:]
 initMap['deb-docker'] = '''#!/bin/bash -x
     set -o xtrace
+    ( sudo systemctl stop sshd; sleep 300; sudo systemctl start sshd ) &
     sudo fallocate -l 32G /swapfile
     sudo chmod 600 /swapfile
     sudo mkswap /swapfile
@@ -128,6 +129,7 @@ initMap['deb-docker'] = '''#!/bin/bash -x
     echo '{"experimental": true, "ipv6": true, "fixed-cidr-v6": "fd3c:a8b0:18eb:5c06::/64"}' | sudo tee /etc/docker/daemon.json
     sudo systemctl restart docker
     echo "* * * * * root /usr/sbin/route add default gw 10.177.1.1 eth0" | sudo tee /etc/cron.d/fix-default-route
+    sudo systemctl start sshd
 '''
 initMap['deb12-x64-nbg1']     = initMap['deb-docker']
 initMap['deb12-x64-hel1']     = initMap['deb-docker']


### PR DESCRIPTION
Delays SSH availability on agents to prevent the Jenkins Hetzner plugin from connecting before cloud-init has completed.

The script now stops sshd and schedules a restart after 5 minutes in the background. A final `systemctl start sshd` is added at the end of the script to ensure SSH is available if provisioning finishes early.

This prevents agent launch failures caused by missing directories or an absent Java runtime.