### PR TITLE
PKG-1073: Fix OpenShift cluster S3 backup name matching

### DIFF
--- a/vars/openshiftCluster.groovy
+++ b/vars/openshiftCluster.groovy
@@ -421,7 +421,7 @@ def list(Map config = [:]) {
         // Transform discovered clusters to match expected format
         def clusters = []
         discoveredClusters.each { cluster ->
-            clusters << [
+            def clusterInfo = [
                 name: cluster.name,
                 version: cluster.metadata?.openshift_version ?: 'Unknown',
                 region: cluster.metadata?.aws_region ?: params.region,
@@ -433,6 +433,11 @@ def list(Map config = [:]) {
                 has_backup: cluster.s3State?.hasBackup ? 'Yes' : 'No',
                 resource_count: cluster.resources?.size() ?: 0
             ]
+            // Include base name if present (for clusters with random suffixes)
+            if (cluster.baseName) {
+                clusterInfo.baseName = cluster.baseName
+            }
+            clusters << clusterInfo
         }
 
         // Log discovery summary

--- a/vars/openshiftTools.groovy
+++ b/vars/openshiftTools.groovy
@@ -540,6 +540,10 @@ def formatClustersSummary(List clusters, String title = "OPENSHIFT CLUSTERS") {
         // Format each cluster
         clusters.each { cluster ->
             summary.append("Cluster: ${cluster.name}\n")
+            // Show base name if it differs from the cluster name (for clusters with random suffixes)
+            if (cluster.baseName && cluster.baseName != cluster.name) {
+                summary.append("  S3 Base Name:   ${cluster.baseName}\n")
+            }
             summary.append("  Version:        ${cluster.version}\n")
             summary.append("  Region:         ${cluster.region}\n")
             summary.append("  Created:        ${cluster.created_at}\n")


### PR DESCRIPTION
## Fix OpenShift Cluster S3 Backup Name Matching

**Jira Ticket:** [PKG-1073](https://perconadev.atlassian.net/browse/PKG-1073) - Fix OpenShift cluster S3 backup name matching in Jenkins pipelines

### Problem
The OpenShift cluster list job incorrectly reported clusters as "Missing S3 backup!" even when backups existed. This occurred because:
- AWS resources use cluster names with random suffixes (e.g., `test-cluster-7-qc8lc`)
- S3 backups are stored under base names without suffixes (e.g., `test-cluster-7`)
- The discovery code used exact name matching, causing mismatches

### Solution
Updated the cluster discovery consolidation logic to use prefix matching instead of exact matching. AWS cluster names are now correctly matched to their S3 backups when the AWS name starts with the S3 base name followed by a hyphen.

### Changes
1. **`vars/openshiftDiscovery.groovy`**:
   - Rewrote consolidation logic using prefix matching for AWS clusters with S3 backups
   - Added `baseName` field to track S3 backup name when it differs from AWS cluster name
   - Properly tracks matched clusters to avoid duplicates

2. **`vars/openshiftTools.groovy`**:
   - Display `S3 Base Name` in cluster summary when it differs from cluster name
   - Helps operators understand the actual S3 backup location

3. **`vars/openshiftCluster.groovy`**:
   - Pass through the `baseName` field in cluster list transformation
   - Ensures base name information is available in Jenkins job output

### Example
**Before:**
```
Cluster: test-cluster-7-qc8lc
  Status: Active (Missing S3 backup!)
```

**After:**
```
Cluster: test-cluster-7-qc8lc
  S3 Base Name: test-cluster-7
  Status: Active (Normal)
```

[PKG-1073]: https://perconadev.atlassian.net/browse/PKG-1073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ