### PR TITLE
PSQLADM-567 Port PSQLADM-555 PXC fix to Hetzner branch

### DIFF
--- a/proxysql/qa-proxysql2-param.yml
+++ b/proxysql/qa-proxysql2-param.yml
@@ -82,12 +82,10 @@
          type: user-defined
          name: DOCKER_OS
          values:
-          - centos:7
           - centos:8
           - ubuntu:jammy
           - ubuntu:focal
           - ubuntu:noble
-          - debian:buster
           - debian:bullseye
           - debian:bookworm  
     builders:

--- a/proxysql/test-proxysql
+++ b/proxysql/test-proxysql
@@ -170,16 +170,29 @@ enable_repo proxysql testing
 install_package proxysql3
 
 if [[ "${PXC_VERSION}" == "PXC84" ]]; then
+  # Fetch PXC versions
+  LATEST_VERSION_84=$(git ls-remote --refs --sort='version:refname' --tags https://github.com/percona/percona-xtradb-cluster | \
+      grep 'Percona-XtraDB-Cluster-8.4' | tail -n1 | cut -d '/' -f3 | cut -d '-' -f4)
+  VERSION_SUFFIX_84=$(git ls-remote --refs --sort='version:refname' --tags https://github.com/percona/percona-xtradb-cluster | \
+      grep 'Percona-XtraDB-Cluster-8.4' | tail -n1 | cut -d '/' -f3 | cut -d '-' -f5)
+
   # Downloading PXC-8.4 tarball package
-  sudo wget -q -O ${WORKDIR_ABS}/WORKDIR/Percona-XtraDB-Cluster_8.4.0-1.1_Linux.x86_64.glibc${glibc_version}-minimal.tar.gz https://downloads.percona.com/downloads/Percona-XtraDB-Cluster-84/Percona-XtraDB-Cluster-8.4.0/binary/tarball/Percona-XtraDB-Cluster_8.4.0-1.1_Linux.x86_64.glibc${glibc_version}-minimal.tar.gz
+  sudo wget -q -O ${WORKDIR_ABS}/WORKDIR/Percona-XtraDB-Cluster_${LATEST_VERSION_84}_Linux.x86_64.glibc${glibc_version}-minimal.tar.gz\
+      http://downloads.percona.com/downloads/Percona-XtraDB-Cluster-84/Percona-XtraDB-Cluster-${LATEST_VERSION_84}/binary/tarball/Percona-XtraDB-Cluster_${LATEST_VERSION_84}-${VERSION_SUFFIX_84}_Linux.x86_64.glibc${glibc_version}-minimal.tar.gz
 
   # Installing PXC-8.4 client package
   enable_repo pxc-84-lts release
   install_package percona-xtradb-cluster-client
 elif [[ "${PXC_VERSION}" == "PXC80" ]]; then
+  # Fetch PXC versions
+  LATEST_VERSION_80=$(git ls-remote --refs --sort='version:refname' --tags https://github.com/percona/percona-xtradb-cluster | \
+      grep 'Percona-XtraDB-Cluster-8.0' | tail -n1 | cut -d '/' -f3 | cut -d '-' -f4)
+  VERSION_SUFFIX_80=$(git ls-remote --refs --sort='version:refname' --tags https://github.com/percona/percona-xtradb-cluster | \
+      grep 'Percona-XtraDB-Cluster-8.0' | tail -n1 | cut -d '/' -f3 | cut -d '-' -f5)
 
   # Downloading PXC-8.0 tarball package
-  sudo wget -q -O ${WORKDIR_ABS}/WORKDIR/Percona-XtraDB-Cluster_8.0.36-28.1_Linux.x86_64.glibc${glibc_version}-minimal.tar.gz https://downloads.percona.com/downloads/Percona-XtraDB-Cluster-80/Percona-XtraDB-Cluster-8.0.36/binary/tarball/Percona-XtraDB-Cluster_8.0.36-28.1_Linux.x86_64.glibc${glibc_version}-minimal.tar.gz
+  sudo wget -q -O ${WORKDIR_ABS}/WORKDIR/Percona-XtraDB-Cluster_${LATEST_VERSION_80}_Linux.x86_64.glibc${glibc_version}-minimal.tar.gz \
+      http://downloads.percona.com/downloads/Percona-XtraDB-Cluster-80/Percona-XtraDB-Cluster-${LATEST_VERSION_80}/binary/tarball/Percona-XtraDB-Cluster_${LATEST_VERSION_80}-${VERSION_SUFFIX_80}_Linux.x86_64.glibc${glibc_version}-minimal.tar.gz
 
   # Installing PXC-8.0 client package
   enable_repo pxc-80 release


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PSQLADM-567

Fetches the latest versions of PXC packges

Replaces the hardcoded values to fetch the PXC packages to run in the jenkins job with a mechanism to always fetch the latest version of the packages available.

Also, removes centos-7 and debian-buster from the qa-proxysql2-param job.