### PR TITLE
Change PMM route from edge to passthrough termination

### DIFF
--- a/vars/openshiftCluster.groovy
+++ b/vars/openshiftCluster.groovy
@@ -711,12 +711,11 @@ def deployPMM(Map params) {
 
     sh """
         export PATH="\$HOME/.local/bin:\$PATH"
-        # Create OpenShift route for HTTPS access
-        # Fixed: Use correct service name and HTTP port for edge termination
-        oc create route edge pmm-https \
+        # Create OpenShift route for HTTPS access with passthrough termination
+        # This allows end-to-end TLS for both HTTPS and GRPC traffic
+        oc create route passthrough pmm-https \
             --service=monitoring-service \
-            --port=http \
-            --insecure-policy=Redirect \
+            --port=https \
             -n ${params.pmmNamespace} || true
     """
 


### PR DESCRIPTION
## Summary

This PR changes the PMM OpenShift route configuration from edge termination to passthrough termination to enable proper GRPC connectivity for PMM clients.

## Problem

With edge termination, TLS is terminated at the OpenShift router level, which breaks GRPC connections. PMM clients require end-to-end TLS with HTTP/2 for GRPC communication to work correctly.

## Solution

Changed the route configuration to use passthrough termination, which:
- Preserves TLS end-to-end from client to PMM pod
- Allows both HTTPS web UI access and GRPC API connections to work
- Enables PMM clients to connect and send metrics

## Changes

Modified `vars/openshiftCluster.groovy`:
- Changed route type from `edge` to `passthrough`
- Changed target port from `http` to `https`
- Removed `--insecure-policy=Redirect` flag (not applicable for passthrough routes)

## Testing

- Created test cluster with passthrough route
- Verified PMM web UI remains accessible via HTTPS
- Successfully connected PMM client via GRPC
- Confirmed metrics collection working properly