### PR TITLE
PMM-14304: Add ability to control source branch for PMM Helm chart in openshift-cluster-create job

### DIFF
--- a/pmm/openshift/openshift-cluster-create.yml
+++ b/pmm/openshift/openshift-cluster-create.yml
@@ -118,6 +118,11 @@
                 description: "Helm chart version for PMM deployment (default: 1.4.7 for PMM 3.x)"
                 trim: true
           - string:
+                name: PMM_HELM_CHART_BRANCH
+                default: ""
+                description: "Branch from percona-helm-charts repo to use for PMM deployment (optional, overrides chart version)"
+                trim: true
+          - string:
                 name: PMM_IMAGE_REPOSITORY
                 default: "percona/pmm-server"
                 description: "Docker image repository (e.g., percona/pmm-server, perconalab/pmm-server)"

--- a/pmm/openshift/openshift_cluster_create.groovy
+++ b/pmm/openshift/openshift_cluster_create.groovy
@@ -216,8 +216,15 @@ Deploy PMM:           ${params.DEPLOY_PMM ? 'Yes' : 'No'}"""
                     if (params.DEPLOY_PMM) {
                         preCreationSummary += """
 PMM Repository:       ${params.PMM_IMAGE_REPOSITORY}
-PMM Image Tag:        ${params.PMM_IMAGE_TAG}
-Helm Chart Version:   ${params.PMM_HELM_CHART_VERSION}
+PMM Image Tag:        ${params.PMM_IMAGE_TAG}"""
+                        if (params.PMM_HELM_CHART_BRANCH) {
+                            preCreationSummary += """
+Helm Chart Branch:    ${params.PMM_HELM_CHART_BRANCH} (from percona-helm-charts)"""
+                        } else {
+                            preCreationSummary += """
+Helm Chart Version:   ${params.PMM_HELM_CHART_VERSION}"""
+                        }
+                        preCreationSummary += """
 Admin Password:       ${params.PMM_ADMIN_PASSWORD == '<GENERATED>' ? 'Auto-generated' : 'User-specified'}"""
                     }
 
@@ -370,6 +377,7 @@ Starting cluster creation process...
                             deployPMM: params.DEPLOY_PMM,
                             pmmImageTag: params.PMM_IMAGE_TAG,
                             pmmHelmChartVersion: params.PMM_HELM_CHART_VERSION,
+                            pmmHelmChartBranch: params.PMM_HELM_CHART_BRANCH ?: '',
                             pmmImageRepository: params.PMM_IMAGE_REPOSITORY,
                             pmmAdminPassword: params.PMM_ADMIN_PASSWORD ?: '<GENERATED>',  // Default to auto-generation
                             // SSL Configuration
@@ -431,7 +439,7 @@ Starting cluster creation process...
                     echo ""
                     echo "SSL Method: ${params.SSL_METHOD}"
                     echo "Base Domain: ${params.BASE_DOMAIN}"
-                    
+
                     def sslConfig = [
                         clusterName: env.FINAL_CLUSTER_NAME,
                         baseDomain: params.BASE_DOMAIN,
@@ -442,26 +450,26 @@ Starting cluster creation process...
                     ]
 
                     def sslResults = [:]
-                    
+
                     if (params.SSL_METHOD == 'letsencrypt') {
                         echo "Setting up Let's Encrypt certificates..."
-                        
+
                         // Configure console domain
-                        def consoleDomain = params.CONSOLE_CUSTOM_DOMAIN ?: 
+                        def consoleDomain = params.CONSOLE_CUSTOM_DOMAIN ?:
                             "console-${env.FINAL_CLUSTER_NAME}.${params.BASE_DOMAIN}"
-                        
+
                         sslConfig.consoleDomain = consoleDomain
-                        
+
                         // Setup Let's Encrypt
                         sslResults = openshiftSSL.setupLetsEncrypt(sslConfig)
-                        
+
                         if (sslResults.consoleCert) {
                             echo "✓ Console certificate configured for: ${consoleDomain}"
                             env.CONSOLE_SSL_DOMAIN = consoleDomain
                         }
                     } else if (params.SSL_METHOD == 'acm') {
                         echo "Setting up AWS ACM certificates..."
-                        
+
                         withCredentials([
                             aws(
                                 credentialsId: 'jenkins-openshift-aws',
@@ -470,25 +478,25 @@ Starting cluster creation process...
                             )
                         ]) {
                             def services = []
-                            
+
                             // Add PMM service if deployed
                             if (params.DEPLOY_PMM && env.PMM_URL) {
-                                def pmmDomain = params.PMM_CUSTOM_DOMAIN ?: 
+                                def pmmDomain = params.PMM_CUSTOM_DOMAIN ?:
                                     "pmm-${env.FINAL_CLUSTER_NAME}.${params.BASE_DOMAIN}"
-                                
+
                                 services.add([
                                     name: 'monitoring-service',
                                     namespace: 'pmm-monitoring',
                                     domain: pmmDomain
                                 ])
                             }
-                            
+
                             sslConfig.services = services
                             sslConfig.accessKey = AWS_ACCESS_KEY_ID
                             sslConfig.secretKey = AWS_SECRET_ACCESS_KEY
-                            
+
                             sslResults = awsCertificates.setupACM(sslConfig)
-                            
+
                             if (sslResults.services) {
                                 sslResults.services.each { name, config ->
                                     if (config.configured) {
@@ -501,10 +509,10 @@ Starting cluster creation process...
                             }
                         }
                     }
-                    
+
                     // Store SSL results for post-creation display
                     env.SSL_CONFIGURED = sslResults ? 'true' : 'false'
-                    
+
                     if (sslResults.errors && !sslResults.errors.isEmpty()) {
                         echo "SSL configuration completed with warnings:"
                         sslResults.errors.each { error ->
@@ -540,12 +548,12 @@ Starting cluster creation process...
                     echo "------------------"
                     echo "API URL:              ${env.CLUSTER_API_URL}"
                     echo "Console URL:          ${env.CLUSTER_CONSOLE_URL ?: 'Pending...'}"
-                    
+
                     // Display SSL console URL if configured
                     if (params.ENABLE_SSL && params.SSL_METHOD == 'letsencrypt' && env.CONSOLE_SSL_DOMAIN) {
                         echo "Console SSL URL:      https://${env.CONSOLE_SSL_DOMAIN}"
                     }
-                    
+
                     echo "Kubeconfig:           Available in Jenkins artifacts"
                     echo ""
 
@@ -566,16 +574,20 @@ Starting cluster creation process...
                         echo "-------------------------------"
                         echo "Repository Used:      ${params.PMM_IMAGE_REPOSITORY}"
                         echo "Image Tag:            ${params.PMM_IMAGE_TAG}"
-                        echo "Helm Chart:           ${params.PMM_HELM_CHART_VERSION}"
+                        if (params.PMM_HELM_CHART_BRANCH) {
+                            echo "Helm Chart Branch:    ${params.PMM_HELM_CHART_BRANCH} (from percona-helm-charts)"
+                        } else {
+                            echo "Helm Chart:           ${params.PMM_HELM_CHART_VERSION}"
+                        }
                         echo "Namespace:            pmm-monitoring"
                         echo "Access URL:           ${env.PMM_URL}"
                         echo "IP Address:           ${env.PMM_IP}"
                         echo "Username:             admin"
                         echo "Password:             ${passwordInfo}"
-                        
+
                         // Display SSL info if configured
                         if (params.ENABLE_SSL && params.SSL_METHOD == 'acm' && env.SSL_CONFIGURED == 'true') {
-                            def pmmDomain = params.PMM_CUSTOM_DOMAIN ?: 
+                            def pmmDomain = params.PMM_CUSTOM_DOMAIN ?:
                                 "pmm-${env.FINAL_CLUSTER_NAME}.${params.BASE_DOMAIN}"
                             echo "SSL Access:           https://${pmmDomain}"
                         }
@@ -620,18 +632,18 @@ Starting cluster creation process...
                     descriptionHtml.append("<b>Region:</b> ${params.AWS_REGION}<br/>")
                     descriptionHtml.append("<b>Status:</b> Active<br/>")
                     descriptionHtml.append("<br/>")
-                    
+
                     // OpenShift access details
                     descriptionHtml.append("<b>Access URLs:</b><br/>")
                     descriptionHtml.append("• Console: <a href='https://console-openshift-console.apps.${env.FINAL_CLUSTER_NAME}.cd.percona.com'>https://console-openshift-console.apps.${env.FINAL_CLUSTER_NAME}.cd.percona.com</a><br/>")
                     descriptionHtml.append("• API: <code>https://api.${env.FINAL_CLUSTER_NAME}.cd.percona.com:6443</code><br/>")
                     descriptionHtml.append("<br/>")
-                    
+
                     descriptionHtml.append("<b>Login Command:</b><br/>")
                     descriptionHtml.append("<code>oc login https://api.${env.FINAL_CLUSTER_NAME}.cd.percona.com:6443 -u kubeadmin -p &lt;password&gt;</code><br/>")
                     descriptionHtml.append("<i>(Password in Jenkins artifacts)</i><br/>")
                     descriptionHtml.append("<br/>")
-                    
+
                     // PMM details if deployed
                     if (env.PMM_URL) {
                         descriptionHtml.append("<b>PMM Monitoring:</b><br/>")
@@ -642,19 +654,19 @@ Starting cluster creation process...
                         descriptionHtml.append("• Version: ${params.PMM_IMAGE_TAG}<br/>")
                         descriptionHtml.append("<br/>")
                     }
-                    
+
                     // Cluster resources
                     descriptionHtml.append("<b>Resources:</b><br/>")
                     descriptionHtml.append("• Masters: 3 × ${params.MASTER_INSTANCE_TYPE}<br/>")
                     descriptionHtml.append("• Workers: ${params.WORKER_COUNT} × ${params.WORKER_INSTANCE_TYPE}<br/>")
                     descriptionHtml.append("<br/>")
-                    
+
                     // Lifecycle details
                     descriptionHtml.append("<b>Lifecycle:</b><br/>")
                     descriptionHtml.append("• Auto-delete: ${params.DELETE_AFTER_HOURS} hours<br/>")
                     descriptionHtml.append("• Team: ${params.TEAM_NAME}<br/>")
                     descriptionHtml.append("• S3 Backup: <code>s3://${env.S3_BUCKET}/${env.FINAL_CLUSTER_NAME}/</code><br/>")
-                    
+
                     currentBuild.description = descriptionHtml.toString()
 
                     // Keep display name consistent

--- a/vars/openshiftCluster.groovy
+++ b/vars/openshiftCluster.groovy
@@ -804,6 +804,10 @@ def deployPMM(Map params) {
 
         helmCommand += ' \\\n            --wait --timeout 10m'
 
+        // Log the full Helm command for debugging
+        openshiftTools.log('DEBUG', "Executing Helm command:")
+        echo helmCommand
+
         sh helmCommand
 
     sh """


### PR DESCRIPTION
## Summary
Adds `PMM_HELM_CHART_BRANCH` parameter to deploy PMM from a specific branch in percona-helm-charts repository instead of published charts.

## Technical Implementation
- When `PMM_HELM_CHART_BRANCH` is set:
  - Clones `https://github.com/percona/percona-helm-charts.git` to a temporary location
  - Checks out specified branch
  - Uses local chart path `<temp-dir>/percona-helm-charts/charts/pmm` in helm command
  - Skips `--version` flag (uses chart from source)
- When empty/unset: uses existing behavior (published chart from Helm repo with version)

## Changes
- `openshift-cluster-create.yml`: Added `PMM_HELM_CHART_BRANCH` string parameter
- `openshift_cluster_create.groovy`: Passes parameter to library, shows branch in summaries
- `openshiftCluster.groovy`: Modified `deployPMM()` to handle branch-based deployment

## Use Case
Test unreleased PMM Helm chart changes in real OpenShift environments before publishing.

## Jira
[PMM-14304](https://perconadev.atlassian.net/browse/PMM-14304)

[PMM-14304]: https://perconadev.atlassian.net/browse/PMM-14304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ