### PR TITLE
Add CopyArtifact permission for openshift-helm-tests job

### DIFF
--- a/pmm/openshift/openshift-cluster-create.yml
+++ b/pmm/openshift/openshift-cluster-create.yml
@@ -208,3 +208,5 @@
           - build-discarder:
                 days-to-keep: 30
                 num-to-keep: 100
+          - copyartifact:
+                projects: openshift-helm-tests


### PR DESCRIPTION
## Summary

Grants the `openshift-helm-tests` job permission to copy artifacts from `openshift-cluster-create` builds.

## Problem

The `openshift-helm-tests` job was failing at the "Copy Artifacts" stage with:
```
Unable to find project for artifact copy: openshift-cluster-create

This may be due to incorrect project name or permission settings
```

## Root Cause

Jenkins' Copy Artifact plugin requires explicit permission configuration. The `openshift-cluster-create` job needed to grant permission to `openshift-helm-tests` to access its archived artifacts (specifically the kubeconfig file).

## Solution

Added `copyartifact` property to the job definition:
```yaml
properties:
  - copyartifact:
      projects: openshift-helm-tests
```

## Changes

**File: `pmm/openshift/openshift-cluster-create.yml`**
- Added copyartifact permission for openshift-helm-tests

## Test Plan

- [ ] Run openshift-helm-tests job
- [ ] Verify "Copy Artifacts" stage succeeds
- [ ] Verify kubeconfig is successfully copied
- [ ] Verify kubectl cluster access validation passes