### PR TITLE
Fix azure loadbalancer type in Operator jobs

### DIFF
--- a/cloud/jenkins/pgo_aks.groovy
+++ b/cloud/jenkins/pgo_aks.groovy
@@ -206,7 +206,7 @@ void createCluster(String CLUSTER_SUFFIX) {
         az aks create -n $CLUSTER_NAME-$CLUSTER_SUFFIX \
             -g percona-operators \
             --subscription eng-cloud-dev \
-            --load-balancer-sku basic \
+            --load-balancer-sku standard \
             --enable-managed-identity \
             --node-count 3 \
             --node-vm-size Standard_B4ms \

--- a/cloud/jenkins/psmdbo_aks.groovy
+++ b/cloud/jenkins/psmdbo_aks.groovy
@@ -231,7 +231,7 @@ void createCluster(String CLUSTER_SUFFIX) {
         az aks create -n $CLUSTER_NAME-$CLUSTER_SUFFIX \
             -g percona-operators \
             --subscription eng-cloud-dev \
-            --load-balancer-sku basic \
+            --load-balancer-sku standard \
             --enable-managed-identity \
             --node-count 3 \
             --node-vm-size Standard_B4ms \

--- a/cloud/jenkins/pxco_aks.groovy
+++ b/cloud/jenkins/pxco_aks.groovy
@@ -200,7 +200,7 @@ void createCluster(String CLUSTER_SUFFIX) {
         az aks create -n $CLUSTER_NAME-$CLUSTER_SUFFIX \
             -g percona-operators \
             --subscription eng-cloud-dev \
-            --load-balancer-sku basic \
+            --load-balancer-sku standard \
             --enable-managed-identity \
             --node-count 3 \
             --node-vm-size Standard_B4ms \


### PR DESCRIPTION
Update operator jobs to use Standard Load Balancer since Azure has deprecated Basic.
https://azure.microsoft.com/en-us/updates?id=azure-basic-load-balancer-will-be-retired-on-30-september-2025-upgrade-to-standard-load-balancer