### PR TITLE
PKG-1331: codify Jenkins S3 buckets in IaC for CloudFormation import

### DIFF
--- a/IaC/JenkinsArtifactory.yml
+++ b/IaC/JenkinsArtifactory.yml
@@ -15,6 +15,43 @@ Resources:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: AES256
             BucketKeyEnabled: false
+      LoggingConfiguration:
+        DestinationBucketName: s3-access-logs-119175775298
+        LogFilePrefix: logs/percona-jenkins-artifactory/
+      LifecycleConfiguration:
+        TransitionDefaultMinimumObjectSize: all_storage_classes_128K
+        Rules:
+          - Id: 30 Days Cleanup
+            Status: Enabled
+            Prefix: pxc-
+            ExpirationInDays: 30
+            NoncurrentVersionExpiration:
+              NoncurrentDays: 1
+          - Id: 30 Days cloud-*
+            Status: Enabled
+            Prefix: cloud-
+            ExpirationInDays: 30
+            NoncurrentVersionExpiration:
+              NoncurrentDays: 1
+          - Id: 30 Days fb-*
+            Status: Enabled
+            Prefix: fb-
+            ExpirationInDays: 30
+            NoncurrentVersionExpiration:
+              NoncurrentDays: 1
+          - Id: 30 Days psmdb-*
+            Status: Enabled
+            Prefix: psmdb-
+            ExpirationInDays: 30
+            NoncurrentVersionExpiration:
+              NoncurrentDays: 30
+          - Id: BUILDS
+            Status: Enabled
+            Prefix: BUILDS/
+            ExpirationInDays: 30
+            NoncurrentVersionExpiration:
+              NoncurrentDays: 30
+              NewerNoncurrentVersions: 2
       Tags:
       - Key: iit-billing-tag
         Value: jenkins

--- a/IaC/JenkinsArtifactory.yml
+++ b/IaC/JenkinsArtifactory.yml
@@ -1,0 +1,26 @@
+---
+AWSTemplateFormatVersion: 2010-09-09
+Description: Cross-fleet percona-jenkins-artifactory S3 bucket (shared by every Jenkins master).
+
+Resources:
+
+  PerconaJenkinsArtifactoryBucket: # Shared artefact / property-file store referenced by every master's pipelines and IAM grants
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      BucketName: percona-jenkins-artifactory
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+            BucketKeyEnabled: false
+      Tags:
+      - Key: iit-billing-tag
+        Value: jenkins
+
+Outputs:
+
+  PerconaJenkinsArtifactoryBucketArn:
+    Description: ARN of the percona-jenkins-artifactory bucket
+    Value: !GetAtt PerconaJenkinsArtifactoryBucket.Arn

--- a/IaC/JenkinsArtifactory.yml
+++ b/IaC/JenkinsArtifactory.yml
@@ -55,9 +55,3 @@ Resources:
       Tags:
       - Key: iit-billing-tag
         Value: jenkins
-
-Outputs:
-
-  PerconaJenkinsArtifactoryBucketArn:
-    Description: ARN of the percona-jenkins-artifactory bucket
-    Value: !GetAtt PerconaJenkinsArtifactoryBucket.Arn

--- a/IaC/pmm.cd/S3-us-east-1.yaml
+++ b/IaC/pmm.cd/S3-us-east-1.yaml
@@ -70,9 +70,3 @@ Resources:
             Condition:
               StringEquals:
                 s3:x-amz-acl: bucket-owner-full-control
-
-Outputs:
-
-  PerconaVmBucketArn:
-    Description: ARN of the percona-vm bucket
-    Value: !GetAtt PerconaVmBucket.Arn

--- a/IaC/pmm.cd/S3-us-east-1.yaml
+++ b/IaC/pmm.cd/S3-us-east-1.yaml
@@ -1,0 +1,26 @@
+---
+AWSTemplateFormatVersion: 2010-09-09
+Description: pmm.cd S3 buckets in us-east-1 (PMM Server OVA / docker image tarball storage).
+
+Resources:
+
+  PerconaVmBucket: # PMM Server OVA images and docker image tarballs
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      BucketName: percona-vm
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+            BucketKeyEnabled: false
+      Tags:
+      - Key: PerconaApproved
+        Value: HD-26384
+
+Outputs:
+
+  PerconaVmBucketArn:
+    Description: ARN of the percona-vm bucket
+    Value: !GetAtt PerconaVmBucket.Arn

--- a/IaC/pmm.cd/S3-us-east-1.yaml
+++ b/IaC/pmm.cd/S3-us-east-1.yaml
@@ -4,20 +4,72 @@ Description: pmm.cd S3 buckets in us-east-1 (PMM Server OVA / docker image tarba
 
 Resources:
 
-  PerconaVmBucket: # PMM Server OVA images and docker image tarballs
+  PerconaVmBucket: # PMM Server OVA images and docker image tarballs (public-read via ACL + bucket policy; CloudTrail audit trail)
     Type: AWS::S3::Bucket
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
     Properties:
       BucketName: percona-vm
+      AccessControl: PublicRead
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: AES256
             BucketKeyEnabled: false
+      LifecycleConfiguration:
+        TransitionDefaultMinimumObjectSize: varies_by_storage_class
+        Rules:
+          - Id: Remove after 3 months
+            Status: Enabled
+            Prefix: ''
+            ExpirationInDays: 90
+            Transitions:
+              - StorageClass: STANDARD_IA
+                TransitionInDays: 30
+            NoncurrentVersionExpiration:
+              NoncurrentDays: 1
+            AbortIncompleteMultipartUpload:
+              DaysAfterInitiation: 1
+      LoggingConfiguration:
+        DestinationBucketName: s3-access-logs-119175775298
+        LogFilePrefix: logs/percona-vm/
+      WebsiteConfiguration:
+        IndexDocument: index.html
+        ErrorDocument: error.html
       Tags:
       - Key: PerconaApproved
         Value: HD-26384
+
+  PerconaVmBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      Bucket: !Ref PerconaVmBucket
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowPublicRead
+            Effect: Allow
+            Principal:
+              AWS: '*'
+            Action: s3:GetObject
+            Resource: arn:aws:s3:::percona-vm/*.ova
+          - Sid: AWSCloudTrailAclCheck20150319
+            Effect: Allow
+            Principal:
+              Service: cloudtrail.amazonaws.com
+            Action: s3:GetBucketAcl
+            Resource: arn:aws:s3:::percona-vm
+          - Sid: AWSCloudTrailWrite20150319
+            Effect: Allow
+            Principal:
+              Service: cloudtrail.amazonaws.com
+            Action: s3:PutObject
+            Resource: arn:aws:s3:::percona-vm/AWSLogs/119175775298/*
+            Condition:
+              StringEquals:
+                s3:x-amz-acl: bucket-owner-full-control
 
 Outputs:
 

--- a/IaC/pmm.cd/S3.yaml
+++ b/IaC/pmm.cd/S3.yaml
@@ -44,9 +44,3 @@ Resources:
               AWS: '*'
             Action: s3:GetObject
             Resource: arn:aws:s3:::pmm-build-cache/*
-
-Outputs:
-
-  PmmBuildCacheBucketArn:
-    Description: ARN of the pmm-build-cache bucket
-    Value: !GetAtt PmmBuildCacheBucket.Arn

--- a/IaC/pmm.cd/S3.yaml
+++ b/IaC/pmm.cd/S3.yaml
@@ -21,7 +21,6 @@ Resources:
         Rules:
           - Id: delete_files_older_than_30_days
             Status: Enabled
-            Prefix: ''
             ExpirationInDays: 30
       Tags:
       - Key: PerconaApproved

--- a/IaC/pmm.cd/S3.yaml
+++ b/IaC/pmm.cd/S3.yaml
@@ -1,0 +1,47 @@
+---
+AWSTemplateFormatVersion: 2010-09-09
+Description: pmm.cd S3 buckets.
+
+Resources:
+
+  PerconaVmBucket: # PMM Server OVA images and docker image tarballs (us-east-1)
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      BucketName: percona-vm
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+            BucketKeyEnabled: false
+      Tags:
+      - Key: PerconaApproved
+        Value: HD-26384
+
+  PmmBuildCacheBucket: # PR-build pmm-client tarballs uploaded with --acl public-read
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      BucketName: pmm-build-cache
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+            BucketKeyEnabled: false
+      Tags:
+      - Key: PerconaApproved
+        Value: HD-26384
+      - Key: iit-billing-tag
+        Value: pmm-feature-builds
+
+Outputs:
+
+  PerconaVmBucketArn:
+    Description: ARN of the percona-vm bucket
+    Value: !GetAtt PerconaVmBucket.Arn
+
+  PmmBuildCacheBucketArn:
+    Description: ARN of the pmm-build-cache bucket
+    Value: !GetAtt PmmBuildCacheBucket.Arn

--- a/IaC/pmm.cd/S3.yaml
+++ b/IaC/pmm.cd/S3.yaml
@@ -1,23 +1,8 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: pmm.cd S3 buckets.
+Description: pmm.cd S3 buckets (us-east-2 stack; percona-vm in us-east-1 is in IaC/pmm.cd/S3-us-east-1.yaml).
 
 Resources:
-
-  PerconaVmBucket: # PMM Server OVA images and docker image tarballs (us-east-1)
-    Type: AWS::S3::Bucket
-    DeletionPolicy: Retain
-    UpdateReplacePolicy: Retain
-    Properties:
-      BucketName: percona-vm
-      BucketEncryption:
-        ServerSideEncryptionConfiguration:
-          - ServerSideEncryptionByDefault:
-              SSEAlgorithm: AES256
-            BucketKeyEnabled: false
-      Tags:
-      - Key: PerconaApproved
-        Value: HD-26384
 
   PmmBuildCacheBucket: # PR-build pmm-client tarballs uploaded with --acl public-read
     Type: AWS::S3::Bucket
@@ -37,10 +22,6 @@ Resources:
         Value: pmm-feature-builds
 
 Outputs:
-
-  PerconaVmBucketArn:
-    Description: ARN of the percona-vm bucket
-    Value: !GetAtt PerconaVmBucket.Arn
 
   PmmBuildCacheBucketArn:
     Description: ARN of the pmm-build-cache bucket

--- a/IaC/pmm.cd/S3.yaml
+++ b/IaC/pmm.cd/S3.yaml
@@ -4,22 +4,46 @@ Description: pmm.cd S3 buckets (us-east-2 stack; percona-vm in us-east-1 is in I
 
 Resources:
 
-  PmmBuildCacheBucket: # PR-build pmm-client tarballs uploaded with --acl public-read
+  PmmBuildCacheBucket: # PR-build pmm-client tarballs (public-read via ACL + bucket policy)
     Type: AWS::S3::Bucket
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
     Properties:
       BucketName: pmm-build-cache
+      AccessControl: PublicRead
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: AES256
             BucketKeyEnabled: false
+      LifecycleConfiguration:
+        TransitionDefaultMinimumObjectSize: varies_by_storage_class
+        Rules:
+          - Id: delete_files_older_than_30_days
+            Status: Enabled
+            Prefix: ''
+            ExpirationInDays: 30
       Tags:
       - Key: PerconaApproved
         Value: HD-26384
       - Key: iit-billing-tag
         Value: pmm-feature-builds
+
+  PmmBuildCacheBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      Bucket: !Ref PmmBuildCacheBucket
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowPublicRead
+            Effect: Allow
+            Principal:
+              AWS: '*'
+            Action: s3:GetObject
+            Resource: arn:aws:s3:::pmm-build-cache/*
 
 Outputs:
 

--- a/IaC/ps80.cd/S3.yaml
+++ b/IaC/ps80.cd/S3.yaml
@@ -84,9 +84,3 @@ Resources:
       Tags:
       - Key: iit-billing-tag
         Value: jenkins-ps
-
-Outputs:
-
-  PsBuildCacheBucketArn:
-    Description: ARN of the shared PS build cache bucket
-    Value: !GetAtt PsBuildCacheBucket.Arn

--- a/IaC/ps80.cd/S3.yaml
+++ b/IaC/ps80.cd/S3.yaml
@@ -1,0 +1,33 @@
+---
+AWSTemplateFormatVersion: 2010-09-09
+Description: ps80.cd S3 buckets (canonical home for the shared ps-build-cache used by ps57.cd, ps80.cd, and ps3.cd PS-family masters).
+
+Resources:
+
+  PsBuildCacheBucket: # ccache / build-artefact cache shared across the PS family
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      BucketName: ps-build-cache
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+            BucketKeyEnabled: false
+      VersioningConfiguration:
+        Status: Suspended
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: false
+        BlockPublicPolicy: false
+        IgnorePublicAcls: false
+        RestrictPublicBuckets: false
+      Tags:
+      - Key: iit-billing-tag
+        Value: jenkins-ps
+
+Outputs:
+
+  PsBuildCacheBucketArn:
+    Description: ARN of the shared PS build cache bucket
+    Value: !GetAtt PsBuildCacheBucket.Arn

--- a/IaC/ps80.cd/S3.yaml
+++ b/IaC/ps80.cd/S3.yaml
@@ -17,6 +17,65 @@ Resources:
             BucketKeyEnabled: false
       VersioningConfiguration:
         Status: Suspended
+      LifecycleConfiguration:
+        TransitionDefaultMinimumObjectSize: all_storage_classes_128K
+        Rules:
+          - Id: 30 Days Cleanup
+            Status: Enabled
+            Prefix: ''
+            ExpirationInDays: 30
+            NoncurrentVersionExpiration:
+              NoncurrentDays: 1
+            AbortIncompleteMultipartUpload:
+              DaysAfterInitiation: 1
+          - Id: Delete7DayRetentionObjects
+            Status: Enabled
+            TagFilters:
+              - Key: RetentionDays
+                Value: '7'
+            ExpirationInDays: 7
+            NoncurrentVersionExpiration:
+              NoncurrentDays: 1
+          - Id: Delete14DayRetentionObjects
+            Status: Enabled
+            TagFilters:
+              - Key: RetentionDays
+                Value: '14'
+            ExpirationInDays: 14
+            NoncurrentVersionExpiration:
+              NoncurrentDays: 1
+          - Id: Delete21DayRetentionObjects
+            Status: Enabled
+            TagFilters:
+              - Key: RetentionDays
+                Value: '21'
+            ExpirationInDays: 21
+            NoncurrentVersionExpiration:
+              NoncurrentDays: 1
+          - Id: Delete30DayRetentionObjects
+            Status: Enabled
+            TagFilters:
+              - Key: RetentionDays
+                Value: '30'
+            ExpirationInDays: 30
+            NoncurrentVersionExpiration:
+              NoncurrentDays: 1
+          - Id: Delete60DayRetentionObjects
+            Status: Enabled
+            TagFilters:
+              - Key: RetentionDays
+                Value: '60'
+            ExpirationInDays: 60
+            NoncurrentVersionExpiration:
+              NoncurrentDays: 1
+          - Id: Delete120DayRetentionObjects
+            Status: Enabled
+            TagFilters:
+              - Key: RetentionDays
+                Value: '120'
+            ExpirationInDays: 120
+            NoncurrentVersionExpiration:
+              NoncurrentDays: 1
       PublicAccessBlockConfiguration:
         BlockPublicAcls: false
         BlockPublicPolicy: false

--- a/IaC/pxb.cd/S3.yaml
+++ b/IaC/pxb.cd/S3.yaml
@@ -1,12 +1,28 @@
+# Stack name: pxb-backup-ci-bucket (legacy single-bucket name; now holds all pxb.cd S3).
+#
+# Initial deploy (PxbBackupCiBucket, PKG-1330):
 # aws cloudformation --region us-west-2 create-stack \
 #   --template-body file://IaC/pxb.cd/S3.yaml \
 #   --stack-name pxb-backup-ci-bucket \
 #   --tags Key=iit-billing-tag,Value=pxb Key=team,Value=pxb Key=owner,Value=tomislav.plavcic Key=ticket,Value=PKG-1330 \
 #   --parameters ParameterKey=BucketName,ParameterValue=pxb-backup-ci \
 #   --profile percona-dev-admin
+#
+# Import existing pxb-build-cache bucket into the stack:
+# aws cloudformation --region us-west-2 create-change-set \
+#   --stack-name pxb-backup-ci-bucket \
+#   --change-set-name import-pxb-build-cache \
+#   --change-set-type IMPORT \
+#   --resources-to-import ResourceType=AWS::S3::Bucket,LogicalResourceId=PxbBuildCacheBucket,ResourceIdentifier='{"BucketName":"pxb-build-cache"}' \
+#   --template-body file://IaC/pxb.cd/S3.yaml \
+#   --profile percona-dev-admin
+# aws cloudformation --region us-west-2 execute-change-set \
+#   --stack-name pxb-backup-ci-bucket \
+#   --change-set-name import-pxb-build-cache \
+#   --profile percona-dev-admin
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: S3 bucket for the PXB backup-test framework CI runs (PKG-1330).
+Description: pxb.cd S3 buckets (pxb-backup-ci from PKG-1330, pxb-build-cache imported as follow-up).
 
 Parameters:
 
@@ -20,7 +36,7 @@ Parameters:
 
 Resources:
 
-  PxbBackupCiBucket: # S3 bucket used by the PXB backup-test framework in CI
+  PxbBackupCiBucket: # S3 bucket used by the PXB backup-test framework in CI (PKG-1330)
     Type: AWS::S3::Bucket
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
@@ -41,12 +57,29 @@ Resources:
       - Key: ticket
         Value: PKG-1330
 
+  PxbBuildCacheBucket: # Build artefact cache used by every PXB build/test pipeline. Imported via CF IMPORT change set; properties match the existing bucket's state so import does not trigger drift. Hardening (enable PublicAccessBlock, tag for billing) is out of scope for the import PR and tracked separately.
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      BucketName: pxb-build-cache
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+            BucketKeyEnabled: false
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: false
+        BlockPublicPolicy: false
+        IgnorePublicAcls: false
+        RestrictPublicBuckets: false
+
 Outputs:
 
-  BucketName:
-    Description: Name of the PXB backup CI bucket
-    Value: !Ref PxbBackupCiBucket
-
-  BucketArn:
+  BackupCiBucketArn:
     Description: ARN of the PXB backup CI bucket
     Value: !GetAtt PxbBackupCiBucket.Arn
+
+  BuildCacheBucketArn:
+    Description: ARN of the PXB build-cache bucket
+    Value: !GetAtt PxbBuildCacheBucket.Arn

--- a/IaC/pxb.cd/S3.yaml
+++ b/IaC/pxb.cd/S3.yaml
@@ -76,10 +76,10 @@ Resources:
 
 Outputs:
 
-  BackupCiBucketArn:
+  BucketName:
+    Description: Name of the PXB backup CI bucket
+    Value: !Ref PxbBackupCiBucket
+
+  BucketArn:
     Description: ARN of the PXB backup CI bucket
     Value: !GetAtt PxbBackupCiBucket.Arn
-
-  BuildCacheBucketArn:
-    Description: ARN of the PXB build-cache bucket
-    Value: !GetAtt PxbBuildCacheBucket.Arn

--- a/IaC/pxc.cd/S3.yaml
+++ b/IaC/pxc.cd/S3.yaml
@@ -1,0 +1,23 @@
+---
+AWSTemplateFormatVersion: 2010-09-09
+Description: pxc.cd S3 buckets.
+
+Resources:
+
+  PxcBuildCacheBucket: # PXC build / test artefact cache; objects are uploaded with --acl public-read
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      BucketName: pxc-build-cache
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+            BucketKeyEnabled: false
+
+Outputs:
+
+  PxcBuildCacheBucketArn:
+    Description: ARN of the pxc-build-cache bucket
+    Value: !GetAtt PxcBuildCacheBucket.Arn

--- a/IaC/pxc.cd/S3.yaml
+++ b/IaC/pxc.cd/S3.yaml
@@ -40,9 +40,3 @@ Resources:
               NoncurrentDays: 30
             AbortIncompleteMultipartUpload:
               DaysAfterInitiation: 30
-
-Outputs:
-
-  PxcBuildCacheBucketArn:
-    Description: ARN of the pxc-build-cache bucket
-    Value: !GetAtt PxcBuildCacheBucket.Arn

--- a/IaC/pxc.cd/S3.yaml
+++ b/IaC/pxc.cd/S3.yaml
@@ -15,6 +15,31 @@ Resources:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: AES256
             BucketKeyEnabled: false
+      LifecycleConfiguration:
+        TransitionDefaultMinimumObjectSize: all_storage_classes_128K
+        Rules:
+          - Id: 30 Days Cleanup
+            Status: Enabled
+            Prefix: jenkins-pxc
+            ExpirationInDays: 30
+            NoncurrentVersionExpiration:
+              NoncurrentDays: 1
+            AbortIncompleteMultipartUpload:
+              DaysAfterInitiation: 1
+          - Id: 90 Days Cleanup
+            Status: Enabled
+            Prefix: jenkins-percona-xtrabackup
+            ExpirationInDays: 90
+            NoncurrentVersionExpiration:
+              NoncurrentDays: 1
+          - Id: pxc-build-cache 30 day cleanup
+            Status: Enabled
+            Prefix: ''
+            ExpirationInDays: 30
+            NoncurrentVersionExpiration:
+              NoncurrentDays: 30
+            AbortIncompleteMultipartUpload:
+              DaysAfterInitiation: 30
 
 Outputs:
 

--- a/IaC/pxc.cd/S3.yaml
+++ b/IaC/pxc.cd/S3.yaml
@@ -34,7 +34,6 @@ Resources:
               NoncurrentDays: 1
           - Id: pxc-build-cache 30 day cleanup
             Status: Enabled
-            Prefix: ''
             ExpirationInDays: 30
             NoncurrentVersionExpiration:
               NoncurrentDays: 30

--- a/IaC/rel.cd/S3-us-east-1.yaml
+++ b/IaC/rel.cd/S3-us-east-1.yaml
@@ -1,0 +1,31 @@
+---
+AWSTemplateFormatVersion: 2010-09-09
+Description: rel.cd S3 buckets in us-east-1 (Jenkins job XML backup target).
+
+Resources:
+
+  JenkinsPerconaJobsBackupBucket: # Jenkins job XML backup target with PublicAccessBlock fully on
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      BucketName: jenkins-percona-jobs-backup
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+            BucketKeyEnabled: false
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      Tags:
+      - Key: iit-billing-tag
+        Value: jenkins-release
+
+Outputs:
+
+  JenkinsPerconaJobsBackupBucketArn:
+    Description: ARN of the jenkins-percona-jobs-backup bucket
+    Value: !GetAtt JenkinsPerconaJobsBackupBucket.Arn

--- a/IaC/rel.cd/S3-us-east-1.yaml
+++ b/IaC/rel.cd/S3-us-east-1.yaml
@@ -26,9 +26,3 @@ Resources:
       Tags:
       - Key: iit-billing-tag
         Value: jenkins-release
-
-Outputs:
-
-  JenkinsPerconaJobsBackupBucketArn:
-    Description: ARN of the jenkins-percona-jobs-backup bucket
-    Value: !GetAtt JenkinsPerconaJobsBackupBucket.Arn

--- a/IaC/rel.cd/S3-us-east-1.yaml
+++ b/IaC/rel.cd/S3-us-east-1.yaml
@@ -15,6 +15,9 @@ Resources:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: AES256
             BucketKeyEnabled: false
+      LoggingConfiguration:
+        DestinationBucketName: s3-access-logs-119175775298
+        LogFilePrefix: logs/jenkins-percona-jobs-backup/
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
         BlockPublicPolicy: true

--- a/IaC/rel.cd/S3.yaml
+++ b/IaC/rel.cd/S3.yaml
@@ -1,0 +1,50 @@
+---
+AWSTemplateFormatVersion: 2010-09-09
+Description: rel.cd S3 buckets.
+
+Resources:
+
+  JenkinsPerconaJobsBackupBucket: # Jenkins job XML backup target (us-east-1; PublicAccessBlock fully on)
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      BucketName: jenkins-percona-jobs-backup
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+            BucketKeyEnabled: false
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      Tags:
+      - Key: iit-billing-tag
+        Value: jenkins-release
+
+  RelRepoCacheBucket: # cached upstream repo tag lists for rel.cd check-remote-repo (eu-west-1)
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      BucketName: rel-repo-cache
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+            BucketKeyEnabled: false
+      Tags:
+      - Key: iit-billing-tag
+        Value: jenkins-cloud
+
+Outputs:
+
+  JenkinsPerconaJobsBackupBucketArn:
+    Description: ARN of the jenkins-percona-jobs-backup bucket
+    Value: !GetAtt JenkinsPerconaJobsBackupBucket.Arn
+
+  RelRepoCacheBucketArn:
+    Description: ARN of the rel-repo-cache bucket
+    Value: !GetAtt RelRepoCacheBucket.Arn

--- a/IaC/rel.cd/S3.yaml
+++ b/IaC/rel.cd/S3.yaml
@@ -18,9 +18,3 @@ Resources:
       Tags:
       - Key: iit-billing-tag
         Value: jenkins-cloud
-
-Outputs:
-
-  RelRepoCacheBucketArn:
-    Description: ARN of the rel-repo-cache bucket
-    Value: !GetAtt RelRepoCacheBucket.Arn

--- a/IaC/rel.cd/S3.yaml
+++ b/IaC/rel.cd/S3.yaml
@@ -1,30 +1,10 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: rel.cd S3 buckets.
+Description: rel.cd S3 buckets (eu-west-1 stack; jenkins-percona-jobs-backup in us-east-1 is in IaC/rel.cd/S3-us-east-1.yaml).
 
 Resources:
 
-  JenkinsPerconaJobsBackupBucket: # Jenkins job XML backup target (us-east-1; PublicAccessBlock fully on)
-    Type: AWS::S3::Bucket
-    DeletionPolicy: Retain
-    UpdateReplacePolicy: Retain
-    Properties:
-      BucketName: jenkins-percona-jobs-backup
-      BucketEncryption:
-        ServerSideEncryptionConfiguration:
-          - ServerSideEncryptionByDefault:
-              SSEAlgorithm: AES256
-            BucketKeyEnabled: false
-      PublicAccessBlockConfiguration:
-        BlockPublicAcls: true
-        BlockPublicPolicy: true
-        IgnorePublicAcls: true
-        RestrictPublicBuckets: true
-      Tags:
-      - Key: iit-billing-tag
-        Value: jenkins-release
-
-  RelRepoCacheBucket: # cached upstream repo tag lists for rel.cd check-remote-repo (eu-west-1)
+  RelRepoCacheBucket: # cached upstream repo tag lists for rel.cd check-remote-repo
     Type: AWS::S3::Bucket
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
@@ -40,10 +20,6 @@ Resources:
         Value: jenkins-cloud
 
 Outputs:
-
-  JenkinsPerconaJobsBackupBucketArn:
-    Description: ARN of the jenkins-percona-jobs-backup bucket
-    Value: !GetAtt JenkinsPerconaJobsBackupBucket.Arn
 
   RelRepoCacheBucketArn:
     Description: ARN of the rel-repo-cache bucket


### PR DESCRIPTION
**Bug**: 9 Jenkins S3 buckets were ad-hoc (no IaC tracking).

**Fix**: 8 CloudFormation templates: per-master `IaC/<master>.cd/S3.yaml` plus top-level `IaC/JenkinsArtifactory.yml`. All 9 buckets imported via CF IMPORT; `detect-stack-drift` returns `IN_SYNC` on every stack. `DeletionPolicy: Retain` on every resource.

**Tickets**: [PKG-1331](https://perconadev.atlassian.net/browse/PKG-1331) (this), [PKG-1330](https://perconadev.atlassian.net/browse/PKG-1330) (origin).

[PKG-1331]: https://perconadev.atlassian.net/browse/PKG-1331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-1330]: https://perconadev.atlassian.net/browse/PKG-1330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ