### PR TITLE
PXB-3795: Build PXB on Amazon Linux 2023 (x86_64 + aarch64)

### DIFF
--- a/pxb/v2/local/build-binary
+++ b/pxb/v2/local/build-binary
@@ -106,6 +106,12 @@ if [[ "${DOCKER_OS}" = "centos-8" ]] || [[ "${DOCKER_OS}" = "asan" ]]; then
   fi
 fi
 
+# AL2023 ships gcc14 as the named package, not an SCL. Set CC/CXX directly.
+if [[ "${DOCKER_OS}" = "amazonlinux-2023" ]] && [[ ${XB_VERSION_MAJOR} -ge 9 ]]; then
+  export CC=gcc14-gcc
+  export CXX=gcc14-g++
+fi
+
 XTRABACKUP_VERSION="${XB_VERSION_MAJOR}.${XB_VERSION_MINOR}.${XB_VERSION_PATCH}${XB_VERSION_EXTRA}"
 FULL_PRODUCT_NAME="percona-xtrabackup-${XTRABACKUP_VERSION}-$(uname -s)-$(uname -m)-${DOCKER_OS}${TAG}"
 

--- a/pxc/docker/install-deps
+++ b/pxc/docker/install-deps
@@ -3,20 +3,44 @@
 set -o xtrace
 set -o errexit
 #
+
+# Bounded retry for transient failures (network blips, locked repo metadata).
+# Fail-fast after RETRY_MAX attempts so docker build does not hang on
+# permanent errors (404, missing package). Backoff is linear: 1s, 2s, ..., Ns.
+RETRY_MAX="${RETRY_MAX:-5}"
+retry() {
+    local attempt=0
+    until "$@"; do
+        attempt=$((attempt + 1))
+        if [ "$attempt" -ge "$RETRY_MAX" ]; then
+            echo "FATAL: retry exhausted after ${RETRY_MAX} attempts: $*" >&2
+            return 1
+        fi
+        sleep "$attempt"
+    done
+}
+
 DOWNLOAD_ROOT=/tmp/source_downloads
 wget_loop() {
     local FILE="$1"
     local URL="$2"
 
     mkdir -p "${DOWNLOAD_ROOT}"
-    until wget --progress=dot:giga -O "${DOWNLOAD_ROOT}/${FILE}" "${URL}"; do
-        echo "sleep before retry"
-        sleep 1
-    done
+    retry wget --progress=dot:giga -O "${DOWNLOAD_ROOT}/${FILE}" "${URL}"
 }
-#
+
+# Distro facts. Empty on apt-based systems; computed inside the yum block below.
+RHVER=""
+DIST=""
+
 if [ -f /usr/bin/yum ]; then
+  # AL2023 does not define %rhel, so use a sentinel to keep the RHVER
+  # arithmetic comparisons throughout this block reliable.
   RHVER="$(rpm --eval %rhel)"
+  DIST="$(rpm --eval %dist)"
+  [[ "${DIST}" == ".amzn2023" ]] && RHVER=2023
+
+  mkdir -p /etc/yum/vars
   rpm --eval %_arch > /etc/yum/vars/basearch
   
   yum list installed
@@ -26,43 +50,31 @@ if [ -f /usr/bin/yum ]; then
       sed -i 's|#\s*baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
   fi
 
+  # percona-release supplies the (deprecated) tools repo with qpress for the
+  # OL8/OL9/CentOS7 (8.0) builds below. AL2023 (RHVER sentinel 2023) and OL10
+  # build 8.4+/9.7+, which do not install qpress, so they skip it.
   if [[ ${RHVER} -lt 10 ]]; then
       yum install -y https://repo.percona.com/yum/percona-release-latest.noarch.rpm
       percona-release enable-only tools testing
   fi
 
-  until yum -y update; do
-    yum clean all
-    echo "waiting"
-    sleep 1
-  done
+  retry sh -c 'yum clean all && yum -y update'
 
   PKGLIST+=" wget"
 
+  # AL2023 has no EPEL and needs none (packages come from the distro base repos),
+  # so it intentionally matches no branch here.
   if [[ ${RHVER} -eq 10 ]]; then
-      until yum -y install oracle-epel-release-el10; do
-          echo "waiting"
-          sleep 1
-      done
+      retry yum -y install oracle-epel-release-el10
   elif [[ ${RHVER} -eq 8 ]]; then
-      until yum -y install oracle-epel-release-el8; do
-          echo "waiting"
-          sleep 1
-      done
-  else
-      until yum -y install epel-release; do
-          echo "waiting"
-          sleep 1
-      done
+      retry yum -y install oracle-epel-release-el8
+  elif [[ ${RHVER} -eq 9 ]] || [[ ${RHVER} -eq 7 ]]; then
+      retry yum -y install epel-release
   fi
 
   if [[ ${RHVER} -eq 8 ]]; then
       PKGLIST+=" dnf-utils"
-      until yum -y install ${PKGLIST} ; do
-        echo "waiting"
-        sleep 1
-      done
-
+      retry yum -y install ${PKGLIST}
       wget https://downloads.percona.com/downloads/packaging/python2-scons-3.0.1-9.el8.noarch.rpm -O /tmp/python2-scons-3.0.1-9.el8.noarch.rpm
       wget https://downloads.percona.com/downloads/packaging/procps-ng-3.3.15-14.0.1.el8.x86_64.rpm -O /tmp/procps-ng-3.3.15-14.0.1.el8.x86_64.rpm
       wget https://downloads.percona.com/downloads/packaging/procps-ng-devel-3.3.15-14.0.1.el8.x86_64.rpm -O /tmp/procps-ng-devel-3.3.15-14.0.1.el8.x86_64.rpm
@@ -78,41 +90,31 @@ if [ -f /usr/bin/yum ]; then
 
   if [[ ${RHVER} -eq 9 ]]; then
       PKGLIST+=" dnf-utils"
-      until yum -y install ${PKGLIST} ; do
-        echo "waiting"
-        sleep 1
-      done
-
+      retry yum -y install ${PKGLIST}
       dnf config-manager --enable ol9_codeready_builder
       PKGLIST+=" libedit-devel procps-ng-devel"
   fi
 
   if [[ ${RHVER} -eq 10 ]]; then
       PKGLIST+=" dnf-utils"
-      until yum -y install ${PKGLIST} ; do
-        echo "waiting"
-        sleep 1
-      done
-
+      retry yum -y install ${PKGLIST}
       dnf config-manager --enable ol10_codeready_builder
+      PKGLIST+=" libedit-devel procps-ng-devel"
+  fi
+
+  if [[ "${DIST}" == ".amzn2023" ]]; then
+      retry yum -y install ${PKGLIST}
       PKGLIST+=" libedit-devel procps-ng-devel"
   fi
 
   if [[ ${RHVER} -lt 8 ]]; then
       PKGLIST+=" python-docutils procps-ng-devel"
-      until yum -y install centos-release-scl; do
-        echo "waiting"
-        sleep 1
-      done
+      retry yum -y install centos-release-scl
       # switch to vault scl repos
       sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
       sed -i 's|#\s*baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
   fi
-  until yum -y install ${PKGLIST}; do
-    echo "waiting"
-    sleep 1
-  done
-
+  retry yum -y install ${PKGLIST}
   if [[ ${RHVER} -eq 8 ]]; then
       dnf config-manager --enable ol8_codeready_builder
   fi
@@ -128,20 +130,42 @@ if [ -f /usr/bin/yum ]; then
     cyrus-sasl-devel cyrus-sasl-scram krb5-devel libudev-devel python3-pip python3-devel libevent-devel \
     "
 
+  # AL2023 does not ship a few of the above packages. Drop them word-wise so the
+  # final yum install does not fail (order-independent, unlike a substring strip).
+  # systemd-devel (added in the PXC-specific block below) substitutes
+  # libudev-devel. perl-Sys-MemInfo and ccache are not required to build pxb on
+  # AL2023; skip them.
+  if [[ "${DIST}" == ".amzn2023" ]]; then
+      AL2023_SKIP=" perl-Sys-MemInfo ccache libudev-devel "
+      _filtered=""
+      for pkg in ${PKGLIST}; do
+          [[ "${AL2023_SKIP}" == *" ${pkg} "* ]] && continue
+          _filtered+=" ${pkg}"
+      done
+      PKGLIST="${_filtered}"
+  fi
+
   # mysql-devel / mariadb-connector-c-devel
-  if [[ ${RHVER} -eq 10 ]]; then
+  if [[ ${RHVER} -eq 10 ]] || [[ "${DIST}" == ".amzn2023" ]]; then
       PKGLIST+=" mariadb-connector-c-devel"
   else
       PKGLIST+=" mysql-devel"
   fi
 
-  # PXC specific
-  PKGLIST+=" libmicrohttpd-devel re2-devel check-devel scons libgcrypt-devel libev-devel vim-common \
-    perl-CPAN rsync python3 patchelf automake bzip2 gnutls gnutls-devel patch lsof socat stunnel pigz net-tools netcat \
+  # PXC specific (common list; only scons and the netcat package name differ by distro)
+  PKGLIST+=" libmicrohttpd-devel re2-devel check-devel libgcrypt-devel libev-devel vim-common \
+    perl-CPAN rsync python3 patchelf automake bzip2 gnutls gnutls-devel patch lsof socat stunnel pigz net-tools \
     "
+  if [[ "${DIST}" == ".amzn2023" ]]; then
+      # AL2023: scons is not packaged (modern builds use cmake); netcat is nmap-ncat.
+      PKGLIST+=" nmap-ncat"
+  else
+      PKGLIST+=" scons netcat"
+  fi
 
-  # qpress comes from Percona repo (disabled on OL10)
-  if [[ ${RHVER} -lt 10 ]]; then
+  # qpress comes from Percona repo (disabled on OL10 and AL2023; not needed
+  # for 8.4+/9.7+ which is the only set that targets AL2023).
+  if [[ ${RHVER} -lt 10 ]] && [[ "${DIST}" != ".amzn2023" ]]; then
       PKGLIST+=" qpress"
   fi
 
@@ -187,8 +211,19 @@ if [ -f /usr/bin/yum ]; then
         PKGLIST_DEVTOOLSET15+=" gcc-toolset-15-libasan-devel gcc-toolset-15-libubsan-devel"
     fi
 
-    # KH: why?
-    if [[ ${RHVER} -ne 8 ]]; then
+    if [[ "${DIST}" == ".amzn2023" ]]; then
+        # AL2023 lacks gcc-toolset SCLs; gcc14 + gcc14-c++ provide modern toolchain.
+        # systemd-devel replaces libudev-devel. asio is bundled (see below).
+        PKGLIST+=" lz4 perl-Memoize perl-open valgrind-devel libubsan rpcgen libtirpc-devel boost-devel"
+        PKGLIST+=" gflags-devel util-linux"
+        PKGLIST+=" libxcrypt-compat ncurses-compat-libs libxcrypt-devel cyrus-sasl-gssapi"
+        PKGLIST+=" systemd-devel"
+        PKGLIST+=" gcc14 gcc14-c++ gcc14-plugin-devel"
+    fi
+
+    # asio-devel is not packaged on AL2023; xtrabackup bundles asio internally,
+    # so the build succeeds without it.
+    if [[ ${RHVER} -ne 8 ]] && [[ "${DIST}" != ".amzn2023" ]]; then
         PKGLIST+=" asio-devel"
     fi
 
@@ -196,7 +231,7 @@ if [ -f /usr/bin/yum ]; then
         PKGLIST+=" gflags-devel util-linux libtirpc-devel rpcgen boost-devel"
     fi
 
-    # compat packages available on OL9 but not on OL10
+    # compat packages available on OL9 / AL2023 but not on OL10
     if [[ ${RHVER} -eq 9 ]]; then
         PKGLIST+=" libxcrypt-compat ncurses-compat-libs"
     fi
@@ -232,31 +267,15 @@ if [ -f /usr/bin/yum ]; then
         PKGLIST+=" devtoolset-8-valgrind devtoolset-8-valgrind-devel perl-Digest-Perl-MD5 libedit-devel"
     fi
 
-    until yum -y install ${PKGLIST} ; do
-        echo "waiting"
-        sleep 1
-    done
-
+    retry yum -y install ${PKGLIST}
     if [[ ${RHVER} -eq 10 ]]; then
-        until yum -y install ${PKGLIST_DEVTOOLSET15}; do
-            echo "waiting"
-            sleep 1
-        done
+        retry yum -y install ${PKGLIST_DEVTOOLSET15}
     elif [[ ${RHVER} -eq 9 ]]; then
-        until yum -y install ${PKGLIST_DEVTOOLSET12} ${PKGLIST_DEVTOOLSET13}; do
-            echo "waiting"
-            sleep 1
-        done
+        retry yum -y install ${PKGLIST_DEVTOOLSET12} ${PKGLIST_DEVTOOLSET13}
     elif [[ ${RHVER} -eq 8 ]]; then
-        until yum -y install ${PKGLIST_DEVTOOLSET10} ${PKGLIST_DEVTOOLSET11} ${PKGLIST_DEVTOOLSET12} ${PKGLIST_DEVTOOLSET13} ${PKGLIST_DEVTOOLSET14}; do
-            echo "waiting"
-            sleep 1
-        done
+        retry yum -y install ${PKGLIST_DEVTOOLSET10} ${PKGLIST_DEVTOOLSET11} ${PKGLIST_DEVTOOLSET12} ${PKGLIST_DEVTOOLSET13} ${PKGLIST_DEVTOOLSET14}
     elif [[ ${RHVER} -eq 7 ]]; then
-        until yum -y --enablerepo=centos-sclo-rh-testing install ${PKGLIST_DEVTOOLSET10} ${PKGLIST_DEVTOOLSET11}; do
-            echo "waiting"
-            sleep 1
-        done
+        retry yum -y --enablerepo=centos-sclo-rh-testing install ${PKGLIST_DEVTOOLSET10} ${PKGLIST_DEVTOOLSET11}
     fi
 
     if [[ ${RHVER} -eq 8 ]]; then
@@ -264,7 +283,7 @@ if [ -f /usr/bin/yum ]; then
         update-alternatives --set python /usr/bin/python2
     fi
 
-    if [[ ${RHVER} -eq 9 ]] || [[ ${RHVER} -eq 10 ]]; then
+    if [[ ${RHVER} -eq 9 ]] || [[ ${RHVER} -eq 10 ]] || [[ "${DIST}" == ".amzn2023" ]]; then
         ln -fs /usr/bin/python3 /usr/bin/python
     fi
 
@@ -273,32 +292,26 @@ if [ -f /usr/bin/yum ]; then
         rm /anaconda-post.log
     fi
 #   Install mysql-connector for QA framework run
-    if [[ ${RHVER} -ge 10 ]]; then
+    # AL2023 pip3 (21.x) lacks --break-system-packages; PEP 668 is not enforced
+    # there anyway, so the plain "pip3 install" form is sufficient.
+    if [[ ${RHVER} -ge 10 ]] && [[ "${DIST}" != ".amzn2023" ]]; then
         pip3 install --break-system-packages mysql-connector mysqlclient
     else
         pip3 install mysql-connector mysqlclient
     fi
+
 fi
 
 if [ -f /usr/bin/apt-get ]; then
     echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 
-    until apt-get update; do
-        sleep 1
-        echo "waiting"
-    done
+    retry apt-get update
 
-    until apt-get -y install lsb-release gnupg wget bc curl; do
-        sleep 1
-        echo "waiting"
-    done
+    retry apt-get -y install lsb-release gnupg wget bc curl
 
     DIST=$(lsb_release -sc)
 
-    until apt-get update; do
-        sleep 1
-        echo "waiting"
-    done
+    retry apt-get update
 
     # Percona Server (keep this list the same as in PS install-deps)
     PKGLIST=" \
@@ -318,7 +331,7 @@ if [ -f /usr/bin/apt-get ]; then
         python3-sphinx stunnel pigz net-tools netcat-openbsd \
     "
     # PXC specific - TODO: these packages are not present in PS, but were specified in common list. Verify if/why they are needed
-    PGKLIST+=" libsasl2-modules-gssapi-mit libgnutls28-dev"
+    PKGLIST+=" libsasl2-modules-gssapi-mit libgnutls28-dev"
 
     # liblz4-tool renamed to lz4 in Trixie
     if [[ ${DIST} == "trixie" ]]; then
@@ -411,11 +424,7 @@ if [ -f /usr/bin/apt-get ]; then
         PKGLIST+=" libre2-dev"
     fi
 
-    until apt-get -y install ${PKGLIST}; do
-        echo "waiting"
-        sleep 1
-    done
-
+    retry apt-get -y install ${PKGLIST}
     # Install mysql-connector for QA framework run
     if [[ ${DIST} == 'bookworm' ]] || [[ ${DIST} == 'noble' ]] || [[ ${DIST} == 'trixie' ]]; then
         pip3 install mysql-connector --break-system-packages
@@ -491,10 +500,9 @@ if [ ! -f /usr/local/lib/libeatmydata.so ]; then
 fi
 
 if [ -f /usr/bin/yum ]; then
-    RHVER="$(rpm --eval %rhel)"
-    if [[ ${RHVER} -ge 10 ]]; then
+    if [[ ${RHVER} -ge 10 ]] && [[ "${DIST}" != ".amzn2023" ]]; then
         pip3 install --break-system-packages --upgrade sphinx==5.3.0
-    elif [[ ${RHVER} -eq 9 ]]; then
+    elif [[ ${RHVER} -eq 9 ]] || [[ "${DIST}" == ".amzn2023" ]]; then
         pip3 install --upgrade sphinx==5.3.0
     else
         pip3 install --upgrade sphinx==1.6.7


### PR DESCRIPTION
**Feature**

- Add AL2023 x86_64/aarch64 image dependencies and the PXB 9.x compiler path.

**Why**

- Enable PXB builds on the requested AL2023 platforms.
- Bound dependency retries across distros and restore two omitted Debian/Ubuntu packages.

**Tickets**

- [PXB-3795](https://perconadev.atlassian.net/browse/PXB-3795) (This slice), [PXB-3745](https://perconadev.atlassian.net/browse/PXB-3745) (Parent).
- Companion: [PR 4093](https://github.com/Percona-Lab/jenkins-pipelines/pull/4093) (ARM and job wiring, merges after this).


[PXB-3795]: https://perconadev.atlassian.net/browse/PXB-3795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PXB-3745]: https://perconadev.atlassian.net/browse/PXB-3745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ