### PR TITLE
PG-2353: Auto-prune superseded AMIs + factory hardening

### DIFF
--- a/.github/workflows/ppg-ami-factory.yml
+++ b/.github/workflows/ppg-ami-factory.yml
@@ -47,6 +47,7 @@ concurrency:
 env:
   AWS_REGION: eu-central-1
   FACTORY_ENV: ${{ github.event.inputs.env || 'prod' }}
+  KEEP_GENERATIONS: '2' # per (os, os_major, arch) prod/test bases the post-promote prune keeps
 
 jobs:
   # No-AWS gate: a malformed template or bad combo fails HERE, before bake spins
@@ -100,10 +101,18 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Install Session Manager plugin
+        env:
+          # Pinned to an immutable versioned URL + verified SHA256 (supply-chain): never
+          # `latest`. The plugin is installed in a job holding AWS OIDC creds, so the bytes
+          # are integrity-checked. Bump deliberately and re-record the digest of the new
+          # version's .deb (curl the versioned URL, sha256sum it).
+          SMP_VERSION: 1.2.835.0
+          SMP_SHA256: 7c6dcad12518571cc7959a713e6a8ae1bdf6ed66fd9bee37dc189e39ca58ae03
         run: |
           set -euo pipefail
           if ! command -v session-manager-plugin >/dev/null; then
-            curl -fsSL "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" -o /tmp/smp.deb
+            curl -fsSL "https://s3.amazonaws.com/session-manager-downloads/plugin/${SMP_VERSION}/ubuntu_64bit/session-manager-plugin.deb" -o /tmp/smp.deb
+            echo "${SMP_SHA256}  /tmp/smp.deb" | sha256sum -c -
             sudo dpkg -i /tmp/smp.deb
           fi
           session-manager-plugin --version
@@ -158,8 +167,11 @@ jobs:
         run: |
           set -euo pipefail
           echo "smoke candidate: $AMI"
+          # `packer init` is CI infra (plugin download); a transient init failure must NOT
+          # deregister a good candidate. Only a real boot/install (build) failure does.
           # Deregister ONLY on a real boot/install failure (never on a later promote-tag failure).
-          ( cd smoke && packer init . && packer build -color=false \
+          ( cd smoke && packer init . ) || { echo "smoke packer init failed (CI infra, not a candidate defect); keeping $AMI"; echo "- smoke: init failed (kept $AMI)" >> "$GITHUB_STEP_SUMMARY"; exit 1; }
+          ( cd smoke && packer build -color=false \
               -var "candidate_ami=$AMI" -var "os=${OS}" -var "os_major=${OS_MAJOR}" \
               -var "arch=${ARCH}" -var "region=${AWS_REGION}" . ) \
           || { echo "smoke (boot+install) failed; deregistering $AMI + its snapshots"; aws ec2 deregister-image --delete-associated-snapshots --region "$AWS_REGION" --image-id "$AMI"; echo "- smoke: FAIL (deregistered $AMI)" >> "$GITHUB_STEP_SUMMARY"; exit 1; }
@@ -179,6 +191,31 @@ jobs:
             echo "promote attempt $a failed; retry in $((a * 5))s"; sleep $((a * 5))
           done
           echo "- promote: $pr" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Prune superseded (keep last ${{ env.KEEP_GENERATIONS }})
+        working-directory: ppg/packer
+        # Housekeeping must never fail an already-promoted bake, but it is not
+        # silent either: the script appends counts to $GITHUB_STEP_SUMMARY and
+        # emits ::warning:: annotations on any skipped deregister, failed
+        # snapshot cleanup, or combo left over the keep count.
+        continue-on-error: true
+        env:
+          OS: ${{ matrix.os || 'oraclelinux' }}
+          OS_MAJOR: ${{ matrix.os_major }}
+          ARCH: ${{ matrix.arch }}
+          AMI: ${{ steps.build.outputs.ami }}
+        run: |
+          set -euo pipefail
+          # Deregister this combo's older promoted bases, keeping the newest KEEP_GENERATIONS.
+          # deprecate_at only marks, it never deletes, so without this the inventory grows.
+          : "${AMI:?build output ami is empty, refusing to prune unguarded}"
+          role=ppg-package-test
+          [ "$FACTORY_ENV" = "test" ] && role=ppg-test-package-test
+          # PROMOTED_AMI guards the prune against EC2 eventual consistency: the script
+          # refuses to act unless the just-promoted AMI is the newest visible match.
+          # OS_NAME scopes the prune to this matrix leg's os so combos sharing an
+          # os_major + arch (oraclelinux 9 vs rocky 9) never prune each other.
+          PROMOTED_AMI="$AMI" OS_NAME="$OS" bash scripts/prune-superseded.sh "$role" "$OS_MAJOR" "$ARCH" "${KEEP_GENERATIONS:-2}" 1 "$AWS_REGION"
 
   notify:
     needs: bake

--- a/.github/workflows/ppg-ami-factory.yml
+++ b/.github/workflows/ppg-ami-factory.yml
@@ -194,11 +194,13 @@ jobs:
 
       - name: Prune superseded (keep last ${{ env.KEEP_GENERATIONS }})
         working-directory: ppg/packer
-        # Housekeeping must never fail an already-promoted bake, but it is not
-        # silent either: the script appends counts to $GITHUB_STEP_SUMMARY and
-        # emits ::warning:: annotations on any skipped deregister, failed
-        # snapshot cleanup, or combo left over the keep count.
-        continue-on-error: true
+        # Promote already ran, so a prune failure cannot un-ship the AMI: it
+        # fails only this leg (fail-fast is off) and pages via the notify job.
+        # No continue-on-error: a step failing under it keeps the job green
+        # (outcome=failure, conclusion=success), which makes the notify job's
+        # failure() unreachable. The script appends counts to
+        # $GITHUB_STEP_SUMMARY and exits non-zero on any failed deregister,
+        # failed snapshot cleanup, or combo left over the keep count.
         env:
           OS: ${{ matrix.os || 'oraclelinux' }}
           OS_MAJOR: ${{ matrix.os_major }}

--- a/.github/workflows/ppg-ami-factory.yml
+++ b/.github/workflows/ppg-ami-factory.yml
@@ -48,6 +48,7 @@ concurrency:
 env:
   AWS_REGION: eu-central-1
   FACTORY_ENV: ${{ github.event.inputs.env || 'prod' }}
+  KEEP_GENERATIONS: '2' # per (os, os_major, arch) prod/test bases the post-promote prune keeps
 
 jobs:
   # No-AWS gate: a malformed template or bad combo fails HERE, before bake spins
@@ -101,10 +102,18 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Install Session Manager plugin
+        env:
+          # Pinned to an immutable versioned URL + verified SHA256 (supply-chain): never
+          # `latest`. The plugin is installed in a job holding AWS OIDC creds, so the bytes
+          # are integrity-checked. Bump deliberately and re-record the digest of the new
+          # version's .deb (curl the versioned URL, sha256sum it).
+          SMP_VERSION: 1.2.835.0
+          SMP_SHA256: 7c6dcad12518571cc7959a713e6a8ae1bdf6ed66fd9bee37dc189e39ca58ae03
         run: |
           set -euo pipefail
           if ! command -v session-manager-plugin >/dev/null; then
-            curl -fsSL "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" -o /tmp/smp.deb
+            curl -fsSL "https://s3.amazonaws.com/session-manager-downloads/plugin/${SMP_VERSION}/ubuntu_64bit/session-manager-plugin.deb" -o /tmp/smp.deb
+            echo "${SMP_SHA256}  /tmp/smp.deb" | sha256sum -c -
             sudo dpkg -i /tmp/smp.deb
           fi
           session-manager-plugin --version
@@ -159,8 +168,11 @@ jobs:
         run: |
           set -euo pipefail
           echo "smoke candidate: $AMI"
+          # `packer init` is CI infra (plugin download); a transient init failure must NOT
+          # deregister a good candidate. Only a real boot/install (build) failure does.
           # Deregister ONLY on a real boot/install failure (never on a later promote-tag failure).
-          ( cd smoke && packer init . && packer build -color=false \
+          ( cd smoke && packer init . ) || { echo "smoke packer init failed (CI infra, not a candidate defect); keeping $AMI"; echo "- smoke: init failed (kept $AMI)" >> "$GITHUB_STEP_SUMMARY"; exit 1; }
+          ( cd smoke && packer build -color=false \
               -var "candidate_ami=$AMI" -var "os=${OS}" -var "os_major=${OS_MAJOR}" \
               -var "arch=${ARCH}" -var "region=${AWS_REGION}" . ) \
           || { echo "smoke (boot+install) failed; deregistering $AMI + its snapshots"; aws ec2 deregister-image --delete-associated-snapshots --region "$AWS_REGION" --image-id "$AMI"; echo "- smoke: FAIL (deregistered $AMI)" >> "$GITHUB_STEP_SUMMARY"; exit 1; }
@@ -180,6 +192,50 @@ jobs:
             echo "promote attempt $a failed; retry in $((a * 5))s"; sleep $((a * 5))
           done
           echo "- promote: $pr" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Prune superseded (keep last ${{ env.KEEP_GENERATIONS }})
+        # Prod only: the test role has no consumer pins to floor on, and its
+        # images are cleaned by `just prune-test`.
+        if: env.FACTORY_ENV == 'prod'
+        working-directory: ppg/packer
+        # Promote already ran, so a prune failure cannot un-ship the AMI: it
+        # fails only this leg (fail-fast is off) and pages via the notify job.
+        # No continue-on-error: a step failing under it keeps the job green
+        # (outcome=failure, conclusion=success), which makes the notify job's
+        # failure() unreachable. The script appends counts to
+        # $GITHUB_STEP_SUMMARY and exits non-zero on any failed deregister,
+        # failed snapshot cleanup, or combo left over the keep count.
+        env:
+          OS: ${{ matrix.os || 'oraclelinux' }}
+          OS_MAJOR: ${{ matrix.os_major }}
+          ARCH: ${{ matrix.arch }}
+          AMI: ${{ steps.build.outputs.ami }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # Deregister this combo's older promoted bases, keeping the newest KEEP_GENERATIONS.
+          # deprecate_at only marks, it never deletes, so without this the inventory grows.
+          : "${AMI:?build output ami is empty, refusing to prune unguarded}"
+          role=ppg-package-test
+          [ "$FACTORY_ENV" = "test" ] && role=ppg-test-package-test
+          # PROMOTED_AMI guards the prune against EC2 eventual consistency: the script
+          # refuses to act unless the just-promoted AMI is the newest visible match.
+          # OS_NAME scopes the prune to this matrix leg's os so combos sharing an
+          # os_major + arch (oraclelinux 9 vs rocky 9) never prune each other.
+          # The pins come from master at prune time, not from this run's checkout,
+          # so a re-run of an old workflow run cannot protect stale pins.
+          git fetch --quiet --depth 1 origin master
+          git show FETCH_HEAD:vars/moleculeEnvPPG.groovy > "${RUNNER_TEMP}/pins.groovy"
+          # Images named by open same-repo refresh PRs are protected too: merging
+          # such a PR must never point pg.cd at a deregistered image.
+          protect_files=""
+          for head in $(gh api --paginate "repos/${GITHUB_REPOSITORY}/pulls?state=open&base=master&per_page=100" \
+                        --jq '.[] | select(.head.repo.owner.login == "'"${GITHUB_REPOSITORY_OWNER}"'") | select(.head.ref | test("^ppg-ami-refresh(-[0-9]{8})?$")) | .head.ref'); do
+            git fetch --quiet --depth 1 origin "$head"
+            git show FETCH_HEAD:vars/moleculeEnvPPG.groovy > "${RUNNER_TEMP}/pins-${head}.groovy"
+            protect_files="${protect_files:+${protect_files}:}${RUNNER_TEMP}/pins-${head}.groovy"
+          done
+          PINS_FILE="${RUNNER_TEMP}/pins.groovy" PROTECT_FILES="$protect_files" PROMOTED_AMI="$AMI" OS_NAME="$OS" bash scripts/prune-superseded.sh "$role" "$OS_MAJOR" "$ARCH" "${KEEP_GENERATIONS:-2}" 1 "$AWS_REGION"
 
   update-molecule-env:
     name: Update moleculeEnvPPG.groovy (OL/Rocky AMI IDs)

--- a/ppg/packer/README.md
+++ b/ppg/packer/README.md
@@ -81,13 +81,22 @@ is the newest `role=ppg-package-test` AMI by `CreationDate` (no SSM parameter).
 
 ## Housekeeping (all via `just`, fail-safe)
 
-Cleanup is recipes too. Every prune recipe **lists by default** and deregisters
-only on an explicit `1`; the guard **never deletes a promoted prod base** and
-fail-closes on an AMI it cannot positively classify.
+Superseded prod bases are pruned **automatically**: after each successful promote the
+workflow runs `scripts/prune-superseded.sh` for that combo, keeping the last
+`KEEP_GENERATIONS` (default 2, newest + one rollback). `deprecate_at` only marks an AMI
+deprecated, it never deletes, so without this the inventory grows with every refresh.
+The `just prune-superseded` recipe shares that same script for ad-hoc / backfill cleanup.
+
+Every prune recipe **lists by default** and deregisters only on an explicit `1`; the guard
+**never deletes the newest-per-combo base** and fail-closes on an AMI it cannot classify.
+Demoted rollback AMIs (`role=*-superseded*`) are never touched by any recipe. The
+post-promote prune additionally refuses to act while the just-promoted AMI is not yet
+visible as the newest of its combo, and reports every skipped deregister, failed
+snapshot cleanup, or over-keep residue as a workflow warning + step-summary line.
 
 ```bash
 just list                # current factory AMIs (prod|test)
-just prune-superseded    # older prod dups (keeps newest per combo); add 1 to delete
+just prune-superseded    # older prod dups (keeps newest 2 per combo); add 1 to delete
 just prune-test          # isolated env=test AMIs;                   add 1 to delete
 just prune-stale         # raw/candidate intermediates + orphans;    add 1 to delete
 just prune-all           # prune-test + prune-stale

--- a/ppg/packer/README.md
+++ b/ppg/packer/README.md
@@ -85,13 +85,22 @@ is the newest `role=ppg-package-test` AMI by `CreationDate` (no SSM parameter).
 
 ## Housekeeping (all via `just`, fail-safe)
 
-Cleanup is recipes too. Every prune recipe **lists by default** and deregisters
-only on an explicit `1`; the guard **never deletes a promoted prod base** and
-fail-closes on an AMI it cannot positively classify.
+Superseded prod bases are pruned **automatically**: after each successful promote the
+workflow runs `scripts/prune-superseded.sh` for that combo, keeping the last
+`KEEP_GENERATIONS` (default 2, newest + one rollback). `deprecate_at` only marks an AMI
+deprecated, it never deletes, so without this the inventory grows with every refresh.
+The `just prune-superseded` recipe shares that same script for ad-hoc / backfill cleanup.
+
+Every prune recipe **lists by default** and deregisters only on an explicit `1`; the guard
+**never deletes the newest-per-combo base** and fail-closes on an AMI it cannot classify.
+Demoted rollback AMIs (`role=*-superseded*`) are never touched by any recipe. The
+post-promote prune additionally refuses to act while the just-promoted AMI is not yet
+visible as the newest of its combo, and reports every skipped deregister, failed
+snapshot cleanup, or over-keep residue as a workflow warning + step-summary line.
 
 ```bash
 just list                # current factory AMIs (prod|test)
-just prune-superseded    # older prod dups (keeps newest per combo); add 1 to delete
+just prune-superseded    # older prod dups (keeps newest 2 per combo); add 1 to delete
 just prune-test          # isolated env=test AMIs;                   add 1 to delete
 just prune-stale         # raw/candidate intermediates + orphans;    add 1 to delete
 just prune-all           # prune-test + prune-stale

--- a/ppg/packer/justfile
+++ b/ppg/packer/justfile
@@ -74,7 +74,8 @@ _promote ami role:
 
 # deregister an AMI + delete its backing snapshots. Idempotent (an already-gone AMI
 # is a no-op) but NOT error-masking: a genuine API failure aborts rather than silently
-# leaking a snapshot. describe-images --image-ids errors InvalidAMIID.NotFound when gone.
+# leaking a snapshot, and a non-success snapshot result exits non-zero after being
+# reported, so caller loops can count it instead of ending on a silent success.
 _deregister ami:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -100,6 +101,10 @@ _deregister ami:
       echo "  WARN snapshot cleanup for {{ami}}: $snapshot_result" >&2
     done <<< "$snapshot_failures"
 
+    if [[ -n "$snapshot_failures" ]]; then
+      exit 1
+    fi
+
 # deregister every self-owned AMI matching a tag filter (+ snapshots), with a HARD guard
 # that NEVER touches a promoted prod base (role={{role_prod}}) or an AMI it cannot classify.
 # Lists by default; deletes only on apply=1. Args after apply are the describe-images filters.
@@ -109,6 +114,7 @@ _prune-by-filter apply +filters:
     ids=$(aws ec2 describe-images --profile {{profile}} --region {{region}} --owners self \
       {{filters}} --query 'Images[].ImageId' --output text)
     [ -z "$ids" ] && { echo "  (nothing matches)"; exit 0; }
+    deregister_failures=0
     for ami in $ids; do
       role=$(aws ec2 describe-images --profile {{profile}} --region {{region}} --image-ids "$ami" \
         --query "Images[0].Tags[?Key=='role']|[0].Value" --output text)
@@ -117,8 +123,19 @@ _prune-by-filter apply +filters:
       if [ "$role" = "{{role_prod}}" ] || [ -z "$role" ] || [ "$role" = None ]; then echo "  SKIP $ami (protected: role=${role:-<none>})"; continue; fi
       # fail-safe: deregister ONLY on an exact apply=1; any other value (incl a malformed
       # `apply=1` arg, which just passes as the literal "apply=1") lists without deleting.
-      if [ "{{apply}}" = "1" ]; then echo "  deregister $ami (role=$role)"; just _deregister "$ami"; else echo "  would deregister $ami (role=$role)"; fi
+      # || keeps the sweep going: one failed deregister must not skip the rest.
+      if [ "{{apply}}" = "1" ]; then
+        echo "  deregister $ami (role=$role)"
+        just _deregister "$ami" || deregister_failures=$((deregister_failures + 1))
+      else
+        echo "  would deregister $ami (role=$role)"
+      fi
     done
+
+    if (( deregister_failures > 0 )); then
+      echo "  ${deregister_failures} deregister(s) failed" >&2
+      exit 1
+    fi
 
 # ===========================================================================
 # packer build / validate (OL + Rocky refresh, Rocky lineage roots via seed-rocky)
@@ -286,6 +303,7 @@ prune-stale apply="0":
       --filters Name=tag:iit-billing-tag,Values={{billing_tag}} Name=tag:os,Values={{os_csv}} \
       --query "Images[].[ImageId, (Tags[?Key=='role']|[0].Value) || 'None', (Tags[?Key=='factory_env']|[0].Value) || 'None']" --output text)
     [[ -z "$candidates" ]] && { echo "  (no factory AMIs)"; exit 0; }
+    deregister_failures=0
     while IFS=$'\t' read -r ami role env; do
       [[ -z "$ami" ]] && continue
       # fail-closed: never delete the prod base, nor anything we cannot positively classify.

--- a/ppg/packer/justfile
+++ b/ppg/packer/justfile
@@ -78,14 +78,27 @@ _promote ami role:
 _deregister ami:
     #!/usr/bin/env bash
     set -euo pipefail
-    err=$(mktemp)
-    snaps=$(aws ec2 describe-images --profile {{profile}} --region {{region}} --image-ids "{{ami}}" \
-      --query 'Images[0].BlockDeviceMappings[].Ebs.SnapshotId' --output text 2>"$err") || {
-        if grep -qiE "InvalidAMIID.NotFound|does not exist" "$err"; then echo "  {{ami}} already gone"; rm -f "$err"; exit 0; fi
-        echo "  ERROR describing {{ami}}:" >&2; cat "$err" >&2; rm -f "$err"; exit 1; }
-    rm -f "$err"
-    aws ec2 deregister-image --profile {{profile}} --region {{region}} --image-id "{{ami}}"
-    for s in $snaps; do [ "$s" = None ] && continue; aws ec2 delete-snapshot --profile {{profile}} --region {{region}} --snapshot-id "$s"; done
+    export AWS_RETRY_MODE="${AWS_RETRY_MODE:-standard}" AWS_MAX_ATTEMPTS="${AWS_MAX_ATTEMPTS:-8}"
+    error_file=$(mktemp)
+    snapshot_failures=$(aws ec2 deregister-image --profile {{profile}} --region {{region}} \
+      --image-id "{{ami}}" --delete-associated-snapshots --output text \
+      --query "DeleteSnapshotResults[?ReturnCode != 'success'].[SnapshotId, ReturnCode]" 2>"$error_file") || {
+        if grep -qiE "InvalidAMIID.NotFound|InvalidAMIID.Unavailable|does not exist" "$error_file"; then
+          echo "  {{ami}} already gone"
+          rm -f "$error_file"
+          exit 0
+        fi
+
+        echo "  ERROR deregistering {{ami}}:" >&2
+        cat "$error_file" >&2
+        rm -f "$error_file"
+        exit 1
+    }
+    rm -f "$error_file"
+    while IFS= read -r snapshot_result; do
+      [[ -z "$snapshot_result" ]] && continue
+      echo "  WARN snapshot cleanup for {{ami}}: $snapshot_result" >&2
+    done <<< "$snapshot_failures"
 
 # deregister every self-owned AMI matching a tag filter (+ snapshots), with a HARD guard
 # that NEVER touches a promoted prod base (role={{role_prod}}) or an AMI it cannot classify.
@@ -264,60 +277,72 @@ prune-stale apply="0":
     #!/usr/bin/env bash
     set -euo pipefail
     echo "prune-stale (apply={{apply}}; lists unless apply=1):"
-    ids=$(aws ec2 describe-images --profile {{profile}} --region {{region}} --owners self \
+    # one describe returns id + role + factory_env together (no per-AMI
+    # re-describes); the command-sub still propagates a describe failure under
+    # set -e. The || 'None' sentinels map an absent tag AND an empty tag value
+    # to the same token, so a field can never be empty and the tab-split can
+    # never shift a value into the wrong guard.
+    candidates=$(aws ec2 describe-images --profile {{profile}} --region {{region}} --owners self \
       --filters Name=tag:iit-billing-tag,Values={{billing_tag}} Name=tag:os,Values={{os_csv}} \
-      --query 'Images[].ImageId' --output text)
-    [ -z "$ids" ] && { echo "  (no factory AMIs)"; exit 0; }
-    for ami in $ids; do
-      # two scalar command-subs (not a process-sub `read`): a describe failure propagates
-      # under set -e instead of being silently swallowed, and no IFS field-shift on tag values.
-      role=$(aws ec2 describe-images --profile {{profile}} --region {{region}} --image-ids "$ami" \
-        --query "Images[0].Tags[?Key=='role']|[0].Value" --output text)
-      env=$(aws ec2 describe-images --profile {{profile}} --region {{region}} --image-ids "$ami" \
-        --query "Images[0].Tags[?Key=='factory_env']|[0].Value" --output text)
+      --query "Images[].[ImageId, (Tags[?Key=='role']|[0].Value) || 'None', (Tags[?Key=='factory_env']|[0].Value) || 'None']" --output text)
+    [[ -z "$candidates" ]] && { echo "  (no factory AMIs)"; exit 0; }
+    while IFS=$'\t' read -r ami role env; do
+      [[ -z "$ami" ]] && continue
       # fail-closed: never delete the prod base, nor anything we cannot positively classify.
-      if [ "$role" = "{{role_prod}}" ] || [ -z "$role" ] || [ "$role" = None ]; then echo "  SKIP $ami (protected: role=${role:-<none>})"; continue; fi
-      if [ "$env" = "test" ]; then echo "  SKIP $ami (test AMI -> use prune-test)"; continue; fi
-      if [ "{{apply}}" = "1" ]; then echo "  deregister $ami (role=$role env=$env)"; just _deregister "$ami"; else echo "  would deregister $ami (role=$role env=$env)"; fi
-    done
+      if [ "$role" = "{{role_prod}}" ] || [ -z "$role" ] || [ "$role" = None ]; then
+        echo "  SKIP $ami (protected: role=${role:-<none>})"
+        continue
+      fi
+      # demoted rollback AMIs (e.g. role=ppg-ol10-oversized-superseded) are deliberate keeps,
+      # not stale intermediates; only an explicit human decision removes them.
+      case "$role" in
+        *superseded*)
+          echo "  SKIP $ami (protected demotion: role=$role)"
+          continue
+          ;;
+      esac
+      if [ "$env" = "test" ]; then
+        echo "  SKIP $ami (test AMI -> use prune-test)"
+        continue
+      fi
+      if [ "{{apply}}" = "1" ]; then
+        echo "  deregister $ami (role=$role env=$env)"
+        just _deregister "$ami"
+      else
+        echo "  would deregister $ami (role=$role env=$env)"
+      fi
+    done <<< "$candidates"
 
 # list ALL factory housekeeping AMIs (test + stale intermediates); never prod. Pass `1` to delete.
 prune-all apply="0":
     @just prune-test "{{apply}}"
     @just prune-stale "{{apply}}"
 
-# deregister SUPERSEDED prod bases: per (os_major, arch) KEEP the newest role={{role_prod}}
-# AMI (the one the consumer selects) and remove older duplicates left by refreshes
-# (deprecate_at only marks, never deletes -> inventory grows). Lists by default; pass `1`
-# to deregister. NEVER deletes the newest-per-combo, and skips any AMI missing maj/arch.
-[doc("deregister superseded prod bases, keeping newest per combo; lists unless apply=1")]
-prune-superseded apply="0":
+# deregister SUPERSEDED prod bases: per (os, os_major, arch) combo KEEP the newest `keep`
+# role={{role_prod}} AMIs (the consumer + refresh select the newest; the second one is the
+# rollback) and remove older duplicates left by refreshes (deprecate_at only marks, never
+# deletes -> inventory grows). Shares scripts/prune-superseded.sh with the GHA workflow,
+# which auto-prunes keep=2 after each promote. Lists by default; pass `1` to deregister.
+[doc("deregister superseded prod bases, keeping newest `keep` per combo; lists unless apply=1")]
+prune-superseded apply="0" keep="2":
     #!/usr/bin/env bash
     set -euo pipefail
-    echo "prune-superseded (apply={{apply}}; lists unless apply=1):"
-    aws ec2 describe-images --profile {{profile}} --region {{region}} --owners self \
-      --filters Name=tag:role,Values={{role_prod}} Name=tag:os,Values={{os_csv}} Name=state,Values=available \
-      --query "reverse(sort_by(Images,&CreationDate))[].[ImageId, Tags[?Key=='os']|[0].Value, Tags[?Key=='os_major']|[0].Value, Tags[?Key=='arch']|[0].Value]" --output text \
-      | { declare -A keep
-
-          while read -r ami_id os_name major arch; do
-            [[ -z "${ami_id}" ]] && continue
-            [[ "${os_name}" = None || "${major}" = None || "${arch}" = None ]] && { echo "  SKIP ${ami_id} (untagged os/major/arch)"; continue; }
-            combo_key="${os_name}/${major}/${arch}"
-
-            if [[ -z "${keep[${combo_key}]:-}" ]]; then
-              keep[${combo_key}]=${ami_id}
-              echo "  KEEP ${ami_id} (${os_name}${major} ${arch}, newest)"
-              continue
-            fi
-
-            if [[ "{{apply}}" = "1" ]]; then
-              echo "  deregister ${ami_id} (${os_name}${major} ${arch}, superseded)"
-              just _deregister "${ami_id}"
-            else
-              echo "  would deregister ${ami_id} (${os_name}${major} ${arch}, superseded)"
-            fi
-          done; }
+    echo "prune-superseded (apply={{apply}}, keep={{keep}}; lists unless apply=1):"
+    combo_failures=0
+    # || keeps the loop going: one combo's describe failure must not skip the
+    # remaining combos; the count still fails the recipe at the end.
+    for os_name in {{os_list}}; do
+      for os_major in {{os_majors}}; do
+        for arch in {{arches}}; do
+          OS_NAME="${os_name}" bash scripts/prune-superseded.sh {{role_prod}} "${os_major}" "${arch}" {{keep}} "{{apply}}" {{region}} {{profile}} \
+            || combo_failures=$((combo_failures + 1))
+        done
+      done
+    done
+    if (( combo_failures > 0 )); then
+      echo "prune-superseded: ${combo_failures} combo(s) failed" >&2
+      exit 1
+    fi
 
 # create the SSM builder instance profile locally (one-time, for local builds).
 # PRODUCTION is terraform-managed: percona-cd-platform terraform/ppg-ami-factory.tf.

--- a/ppg/packer/justfile
+++ b/ppg/packer/justfile
@@ -80,18 +80,36 @@ _promote ami role:
 
 # deregister an AMI + delete its backing snapshots. Idempotent (an already-gone AMI
 # is a no-op) but NOT error-masking: a genuine API failure aborts rather than silently
-# leaking a snapshot. describe-images --image-ids errors InvalidAMIID.NotFound when gone.
+# leaking a snapshot, and a non-success snapshot result exits non-zero after being
+# reported, so caller loops can count it instead of ending on a silent success.
 _deregister ami:
     #!/usr/bin/env bash
     set -euo pipefail
-    err=$(mktemp)
-    snaps=$(aws ec2 describe-images --profile {{profile}} --region {{region}} --image-ids "{{ami}}" \
-      --query 'Images[0].BlockDeviceMappings[].Ebs.SnapshotId' --output text 2>"$err") || {
-        if grep -qiE "InvalidAMIID.NotFound|does not exist" "$err"; then echo "  {{ami}} already gone"; rm -f "$err"; exit 0; fi
-        echo "  ERROR describing {{ami}}:" >&2; cat "$err" >&2; rm -f "$err"; exit 1; }
-    rm -f "$err"
-    aws ec2 deregister-image --profile {{profile}} --region {{region}} --image-id "{{ami}}"
-    for s in $snaps; do [ "$s" = None ] && continue; aws ec2 delete-snapshot --profile {{profile}} --region {{region}} --snapshot-id "$s"; done
+    export AWS_RETRY_MODE="${AWS_RETRY_MODE:-standard}" AWS_MAX_ATTEMPTS="${AWS_MAX_ATTEMPTS:-8}"
+    error_file=$(mktemp)
+    snapshot_failures=$(aws ec2 deregister-image --profile {{profile}} --region {{region}} \
+      --image-id "{{ami}}" --delete-associated-snapshots --output text \
+      --query "DeleteSnapshotResults[?ReturnCode != 'success'].[SnapshotId, ReturnCode]" 2>"$error_file") || {
+        if grep -qiE "InvalidAMIID.NotFound|InvalidAMIID.Unavailable|does not exist" "$error_file"; then
+          echo "  {{ami}} already gone"
+          rm -f "$error_file"
+          exit 0
+        fi
+
+        echo "  ERROR deregistering {{ami}}:" >&2
+        cat "$error_file" >&2
+        rm -f "$error_file"
+        exit 1
+    }
+    rm -f "$error_file"
+    while IFS= read -r snapshot_result; do
+      [[ -z "$snapshot_result" ]] && continue
+      echo "  WARN snapshot cleanup for {{ami}}: $snapshot_result" >&2
+    done <<< "$snapshot_failures"
+
+    if [[ -n "$snapshot_failures" ]]; then
+      exit 1
+    fi
 
 # deregister every self-owned AMI matching a tag filter (+ snapshots), with a HARD guard
 # that NEVER touches a promoted prod base (role={{role_prod}}) or an AMI it cannot classify.
@@ -102,6 +120,7 @@ _prune-by-filter apply +filters:
     ids=$(aws ec2 describe-images --profile {{profile}} --region {{region}} --owners self \
       {{filters}} --query 'Images[].ImageId' --output text)
     [ -z "$ids" ] && { echo "  (nothing matches)"; exit 0; }
+    deregister_failures=0
     for ami in $ids; do
       role=$(aws ec2 describe-images --profile {{profile}} --region {{region}} --image-ids "$ami" \
         --query "Images[0].Tags[?Key=='role']|[0].Value" --output text)
@@ -110,8 +129,19 @@ _prune-by-filter apply +filters:
       if [ "$role" = "{{role_prod}}" ] || [ -z "$role" ] || [ "$role" = None ]; then echo "  SKIP $ami (protected: role=${role:-<none>})"; continue; fi
       # fail-safe: deregister ONLY on an exact apply=1; any other value (incl a malformed
       # `apply=1` arg, which just passes as the literal "apply=1") lists without deleting.
-      if [ "{{apply}}" = "1" ]; then echo "  deregister $ami (role=$role)"; just _deregister "$ami"; else echo "  would deregister $ami (role=$role)"; fi
+      # || keeps the sweep going: one failed deregister must not skip the rest.
+      if [ "{{apply}}" = "1" ]; then
+        echo "  deregister $ami (role=$role)"
+        just _deregister "$ami" || deregister_failures=$((deregister_failures + 1))
+      else
+        echo "  would deregister $ami (role=$role)"
+      fi
     done
+
+    if (( deregister_failures > 0 )); then
+      echo "  ${deregister_failures} deregister(s) failed" >&2
+      exit 1
+    fi
 
 # ===========================================================================
 # packer build / validate (OL + Rocky refresh, Rocky lineage roots via seed-rocky)
@@ -270,60 +300,113 @@ prune-stale apply="0":
     #!/usr/bin/env bash
     set -euo pipefail
     echo "prune-stale (apply={{apply}}; lists unless apply=1):"
-    ids=$(aws ec2 describe-images --profile {{profile}} --region {{region}} --owners self \
+    # one describe returns id + role + factory_env together (no per-AMI
+    # re-describes); the command-sub still propagates a describe failure under
+    # set -e. The || 'None' sentinels map an absent tag AND an empty tag value
+    # to the same token, so a field can never be empty and the tab-split can
+    # never shift a value into the wrong guard.
+    candidates=$(aws ec2 describe-images --profile {{profile}} --region {{region}} --owners self \
       --filters Name=tag:iit-billing-tag,Values={{billing_tag}} Name=tag:os,Values={{os_csv}} \
-      --query 'Images[].ImageId' --output text)
-    [ -z "$ids" ] && { echo "  (no factory AMIs)"; exit 0; }
-    for ami in $ids; do
-      # two scalar command-subs (not a process-sub `read`): a describe failure propagates
-      # under set -e instead of being silently swallowed, and no IFS field-shift on tag values.
-      role=$(aws ec2 describe-images --profile {{profile}} --region {{region}} --image-ids "$ami" \
-        --query "Images[0].Tags[?Key=='role']|[0].Value" --output text)
-      env=$(aws ec2 describe-images --profile {{profile}} --region {{region}} --image-ids "$ami" \
-        --query "Images[0].Tags[?Key=='factory_env']|[0].Value" --output text)
+      --query "Images[].[ImageId, (Tags[?Key=='role']|[0].Value) || 'None', (Tags[?Key=='factory_env']|[0].Value) || 'None']" --output text)
+    [[ -z "$candidates" ]] && { echo "  (no factory AMIs)"; exit 0; }
+    deregister_failures=0
+    while IFS=$'\t' read -r ami role env; do
+      [[ -z "$ami" ]] && continue
       # fail-closed: never delete the prod base, nor anything we cannot positively classify.
-      if [ "$role" = "{{role_prod}}" ] || [ -z "$role" ] || [ "$role" = None ]; then echo "  SKIP $ami (protected: role=${role:-<none>})"; continue; fi
-      if [ "$env" = "test" ]; then echo "  SKIP $ami (test AMI -> use prune-test)"; continue; fi
-      if [ "{{apply}}" = "1" ]; then echo "  deregister $ami (role=$role env=$env)"; just _deregister "$ami"; else echo "  would deregister $ami (role=$role env=$env)"; fi
-    done
+      if [ "$role" = "{{role_prod}}" ] || [ -z "$role" ] || [ "$role" = None ]; then
+        echo "  SKIP $ami (protected: role=${role:-<none>})"
+        continue
+      fi
+      # demoted rollback AMIs (e.g. role=ppg-ol10-oversized-superseded) are deliberate keeps,
+      # not stale intermediates; only an explicit human decision removes them.
+      case "$role" in
+        *superseded*)
+          echo "  SKIP $ami (protected demotion: role=$role)"
+          continue
+          ;;
+      esac
+      if [ "$env" = "test" ]; then
+        echo "  SKIP $ami (test AMI -> use prune-test)"
+        continue
+      fi
+      if [ "{{apply}}" = "1" ]; then
+        echo "  deregister $ami (role=$role env=$env)"
+        just _deregister "$ami" || deregister_failures=$((deregister_failures + 1))
+      else
+        echo "  would deregister $ami (role=$role env=$env)"
+      fi
+    done <<< "$candidates"
+    if (( deregister_failures > 0 )); then
+      echo "  ${deregister_failures} deregister(s) failed" >&2
+      exit 1
+    fi
 
 # list ALL factory housekeeping AMIs (test + stale intermediates); never prod. Pass `1` to delete.
 prune-all apply="0":
     @just prune-test "{{apply}}"
     @just prune-stale "{{apply}}"
 
-# deregister SUPERSEDED prod bases: per (os_major, arch) KEEP the newest role={{role_prod}}
-# AMI (the one the consumer selects) and remove older duplicates left by refreshes
-# (deprecate_at only marks, never deletes -> inventory grows). Lists by default; pass `1`
-# to deregister. NEVER deletes the newest-per-combo, and skips any AMI missing maj/arch.
-[doc("deregister superseded prod bases, keeping newest per combo; lists unless apply=1")]
-prune-superseded apply="0":
+# deregister SUPERSEDED prod bases: per (os, os_major, arch) combo KEEP the newest `keep`
+# role={{role_prod}} AMIs (the consumer + refresh select the newest; the second one is the
+# rollback) and remove older duplicates left by refreshes (deprecate_at only marks, never
+# deletes -> inventory grows). Shares scripts/prune-superseded.sh with the GHA workflow,
+# which auto-prunes keep=2 after each promote. Lists by default; pass `1` to deregister.
+[doc("deregister superseded prod bases, keeping newest `keep` per combo; lists unless apply=1")]
+prune-superseded apply="0" keep="2":
     #!/usr/bin/env bash
     set -euo pipefail
-    echo "prune-superseded (apply={{apply}}; lists unless apply=1):"
-    aws ec2 describe-images --profile {{profile}} --region {{region}} --owners self \
-      --filters Name=tag:role,Values={{role_prod}} Name=tag:os,Values={{os_csv}} Name=state,Values=available \
-      --query "reverse(sort_by(Images,&CreationDate))[].[ImageId, Tags[?Key=='os']|[0].Value, Tags[?Key=='os_major']|[0].Value, Tags[?Key=='arch']|[0].Value]" --output text \
-      | { declare -A keep
-
-          while read -r ami_id os_name major arch; do
-            [[ -z "${ami_id}" ]] && continue
-            [[ "${os_name}" = None || "${major}" = None || "${arch}" = None ]] && { echo "  SKIP ${ami_id} (untagged os/major/arch)"; continue; }
-            combo_key="${os_name}/${major}/${arch}"
-
-            if [[ -z "${keep[${combo_key}]:-}" ]]; then
-              keep[${combo_key}]=${ami_id}
-              echo "  KEEP ${ami_id} (${os_name}${major} ${arch}, newest)"
-              continue
-            fi
-
-            if [[ "{{apply}}" = "1" ]]; then
-              echo "  deregister ${ami_id} (${os_name}${major} ${arch}, superseded)"
-              just _deregister "${ami_id}"
-            else
-              echo "  would deregister ${ami_id} (${os_name}${major} ${arch}, superseded)"
-            fi
-          done; }
+    echo "prune-superseded (apply={{apply}}, keep={{keep}}; lists unless apply=1):"
+    # Pins come from origin/master, not the working tree: a stale local checkout
+    # must never make the prune forget an AMI that master still launches.
+    pins_remote="${PINS_REMOTE:-origin}"
+    workdir=$(mktemp -d)
+    trap 'rm -rf "${workdir}"' EXIT
+    if git -C ../.. fetch -q "${pins_remote}" master && git -C ../.. show FETCH_HEAD:vars/moleculeEnvPPG.groovy > "${workdir}/pins" 2>/dev/null; then
+      echo "  pins from ${pins_remote}/master:vars/moleculeEnvPPG.groovy (fetched)"
+    elif [[ "{{apply}}" = "1" ]]; then
+      echo "refusing to prune: could not fetch ${pins_remote}/master for the current pins" >&2
+      exit 1
+    else
+      cp ../../vars/moleculeEnvPPG.groovy "${workdir}/pins"
+      echo "  pins from the working tree (${pins_remote}/master unavailable, list only)"
+    fi
+    export PINS_FILE="${workdir}/pins"
+    # Images named by open refresh PRs are protected too (script PROTECT_FILES).
+    protect_files=""
+    repo_url=$(git -C ../.. remote get-url "${pins_remote}")
+    if open_heads=$(gh pr list -R "${repo_url}" --base master --state open --limit 500 --json headRefName,headRepositoryOwner \
+         --jq '.[] | select(.headRepositoryOwner.login == "Percona-Lab") | select(.headRefName | test("^ppg-ami-refresh(-[0-9]{8})?$")) | .headRefName'); then
+      for head in ${open_heads}; do
+        if git -C ../.. fetch -q "${pins_remote}" "${head}" && git -C ../.. show FETCH_HEAD:vars/moleculeEnvPPG.groovy > "${workdir}/pins-${head}" 2>/dev/null; then
+          protect_files="${protect_files:+${protect_files}:}${workdir}/pins-${head}"
+          echo "  protecting the pins of open refresh PR branch ${head}"
+        elif [[ "{{apply}}" = "1" ]]; then
+          echo "refusing to prune: could not read the pins of open refresh PR branch ${head}" >&2
+          exit 1
+        fi
+      done
+    elif [[ "{{apply}}" = "1" ]]; then
+      echo "refusing to prune: could not list open refresh PRs (gh)" >&2
+      exit 1
+    else
+      echo "  could not list open refresh PRs (gh), list only"
+    fi
+    export PROTECT_FILES="${protect_files}"
+    combo_failures=0
+    # || keeps the loop going: one combo's describe failure must not skip the
+    # remaining combos; the count still fails the recipe at the end.
+    for os_name in {{os_list}}; do
+      for os_major in {{os_majors}}; do
+        for arch in {{arches}}; do
+          OS_NAME="${os_name}" bash scripts/prune-superseded.sh {{role_prod}} "${os_major}" "${arch}" {{keep}} "{{apply}}" {{region}} {{profile}} \
+            || combo_failures=$((combo_failures + 1))
+        done
+      done
+    done
+    if (( combo_failures > 0 )); then
+      echo "prune-superseded: ${combo_failures} combo(s) failed" >&2
+      exit 1
+    fi
 
 # create the SSM builder instance profile locally (one-time, for local builds).
 # PRODUCTION is terraform-managed: percona-cd-platform terraform/ppg-ami-factory.tf.

--- a/ppg/packer/refresh.pkr.hcl
+++ b/ppg/packer/refresh.pkr.hcl
@@ -191,8 +191,10 @@ source "amazon-ebs" "el" {
   skip_profile_validation = true
   user_data               = local.ssm_bootstrap
 
-  # Native retention: the baked AMI auto-deprecates ~5 weeks out, so superseded
-  # weekly images age out without a custom deregister-old sweep.
+  # Mark the AMI deprecated ~5 weeks out (deprioritizes it in default describe-images
+  # results). Deprecation only MARKS, it never deletes the AMI or its snapshot; superseded
+  # bases are removed by the post-promote prune (scripts/prune-superseded.sh, keep last
+  # KEEP_GENERATIONS) in the workflow, or by `just prune-superseded`.
   deprecate_at = timeadd(timestamp(), "840h")
 
   # Refresh: latest self-owned lineage base (see local.lineage_filters).

--- a/ppg/packer/refresh.pkr.hcl
+++ b/ppg/packer/refresh.pkr.hcl
@@ -195,8 +195,10 @@ source "amazon-ebs" "el" {
   skip_profile_validation = true
   user_data               = local.ssm_bootstrap
 
-  # Native retention: the baked AMI auto-deprecates ~5 weeks out, so superseded
-  # weekly images age out without a custom deregister-old sweep.
+  # Mark the AMI deprecated ~5 weeks out (deprioritizes it in default describe-images
+  # results). Deprecation only MARKS, it never deletes the AMI or its snapshot; superseded
+  # bases are removed by the post-promote prune (scripts/prune-superseded.sh, keep last
+  # KEEP_GENERATIONS) in the workflow, or by `just prune-superseded`.
   deprecate_at = timeadd(timestamp(), "840h")
 
   # Refresh: latest self-owned lineage base (see local.lineage_filters).

--- a/ppg/packer/scripts/prune-superseded.sh
+++ b/ppg/packer/scripts/prune-superseded.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# Post-promote AMI prune - keep the newest KEEP_N promoted bases per
+# (os, os_major, arch) combo, deregister the rest with their snapshots.
+# Shared by the GHA workflow (auto-prune after each promote) and the
+# justfile `prune-superseded` recipe. deprecate_at only MARKS an AMI,
+# it never deletes, so without this the inventory grows every bake.
+#
+#   Usage: prune-superseded.sh ROLE OS_MAJOR ARCH KEEP_N APPLY REGION [PROFILE]
+#     APPLY=1 deregisters. Anything else lists only (dry run).
+#   Env:   OS_NAME (default oraclelinux)
+#          PROMOTED_AMI - refuse to prune unless it is the newest match
+#
+# Fail-safe: only exact role-tag matches with the right NATIVE architecture
+# are candidates (demoted `*-superseded` roles and mistagged AMIs are never
+# seen), the newest KEEP_N always survive, and a describe failure aborts
+# rather than treating images as absent. Ordering is computed locally from a
+# plain projection because the CLI applies --query per page; the only loops
+# are per-AMI mutations, which have no bulk API.
+set -euo pipefail
+
+# Native throttle handling on every call; warn-and-continue below is the
+# after-retries fallback, not the first line of defense.
+export AWS_RETRY_MODE="${AWS_RETRY_MODE:-standard}"
+export AWS_MAX_ATTEMPTS="${AWS_MAX_ATTEMPTS:-8}"
+
+err() {
+  echo "$*" >&2
+}
+
+# Report lines go to stdout AND the workflow step summary when present.
+summary() {
+  echo "$*"
+
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    # ::warning::/::error:: are stdout annotation directives; the step summary
+    # renders markdown, so strip the directive prefix there.
+    local line="$*"
+    line="${line#::warning::}"
+    line="${line#::error::}"
+    echo "${line}" >> "${GITHUB_STEP_SUMMARY}"
+  fi
+}
+
+# Arguments + preflight: refuse to run half-armed.
+ROLE="${1:?ROLE}"
+OS_MAJOR="${2:?OS_MAJOR}"
+ARCH="${3:?ARCH}"
+KEEP_N="${4:?KEEP_N}"
+APPLY="${5:?APPLY (1=delete, else list)}"
+REGION="${6:?REGION}"
+# APPLY=1 must name its OS explicitly: a silent oraclelinux default on a rocky
+# cleanup would deregister the wrong OS's rollback generation.
+if [[ "${APPLY}" == 1 && -z "${OS_NAME:-}" ]]; then
+  err "OS_NAME must be set explicitly (oraclelinux|rocky) when APPLY=1"
+  exit 1
+fi
+
+OS_NAME="${OS_NAME:-oraclelinux}"
+
+# Exact-match whitelist: a wildcard or comma list would widen the tag:os filter
+# and prune across operating systems.
+case "${OS_NAME}" in
+  oraclelinux|rocky) ;;
+  *)
+    err "OS_NAME must be oraclelinux or rocky, got '${OS_NAME}'"
+    exit 1
+    ;;
+esac
+
+PROFILE_ARGS=()
+[[ -n "${7:-}" ]] && PROFILE_ARGS=(--profile "$7")
+
+command -v aws >/dev/null || { err "missing required tool: aws"; exit 1; }
+
+# KEEP_N=0 would deregister the live base the consumer resolves to, and a
+# leading zero would trip Bash's octal arithmetic below. The anchored check
+# also makes KEEP_N safe to interpolate into the array slice.
+if ! [[ "${KEEP_N}" =~ ^[1-9][0-9]*$ ]]; then
+  err "KEEP_N must be a positive integer without leading zeros, got '${KEEP_N}'"
+  exit 1
+fi
+
+# The EC2 native Architecture token is arm64; accept the aarch64 vocabulary too.
+NATIVE_ARCH="${ARCH/aarch64/arm64}"
+
+# Human-facing combo label; oraclelinux and rocky share majors and arches, so
+# every message names the full (os, os_major, arch) combo.
+COMBO="${OS_NAME} ${OS_MAJOR} ${ARCH}"
+
+# Candidate listing: ONE plain-projection fetch, sorted locally. The CLI
+# applies --query independently to each page of a paginated response, so a
+# server-side sort or length() is only page-local and can misorder the list
+# (deleting the wrong rollback) or emit multiple counts. ISO-8601 CreationDate
+# sorts lexicographically, so a plain `sort -r` of the aggregated rows is the
+# global newest-first order. --include-deprecated keeps AMIs past deprecate_at
+# visible so they are pruned too. Native Architecture rides along so a
+# mistagged AMI is excluded AND counted from the same data.
+candidate_rows=$(aws ec2 describe-images "${PROFILE_ARGS[@]}" --region "${REGION}" \
+  --owners self --include-deprecated --output text \
+  --filters Name=tag:role,Values="${ROLE}" Name=tag:os,Values="${OS_NAME}" \
+            Name=tag:os_major,Values="${OS_MAJOR}" Name=tag:arch,Values="${NATIVE_ARCH}" \
+            Name=state,Values=available \
+  --query 'Images[].[CreationDate, ImageId, Architecture]') \
+  || { summary "::error::${COMBO}: describe-images failed, refusing to prune blind"; exit 1; }
+
+sorted_rows=$(sort -r <<< "${candidate_rows}")
+
+mapfile -t ami_ids < <(awk -v native_arch="${NATIVE_ARCH}" '$3 == native_arch {print $2}' <<< "${sorted_rows}")
+
+mismatched_arch=$(awk -v native_arch="${NATIVE_ARCH}" '$2 != "" && $3 != native_arch' <<< "${sorted_rows}" | grep -c . || true)
+
+if (( mismatched_arch > 0 )); then
+  summary "::warning::${COMBO}: ${mismatched_arch} AMI(s) tagged arch=${NATIVE_ARCH} but native Architecture differs, excluded from pruning"
+fi
+
+# Guards. An empty estate right after a promote is an invariant failure when
+# PROMOTED_AMI is known (the just-promoted AMI must be visible): warn loudly
+# and fail so filter drift can never silently disable pruning. Without
+# PROMOTED_AMI (ad-hoc runs) empty stays reportable but benign.
+if [[ "${#ami_ids[@]}" -eq 0 ]]; then
+  if [[ -n "${PROMOTED_AMI:-}" ]]; then
+    summary "::warning::${COMBO}: just-promoted ${PROMOTED_AMI} is not visible in the candidate list (filter drift or eventual consistency), refusing to treat empty as success"
+    exit 1
+  fi
+
+  summary "${COMBO}: no ${ROLE} AMIs found"
+  exit 0
+fi
+
+if [[ -n "${PROMOTED_AMI:-}" ]] && [[ "${ami_ids[0]}" != "${PROMOTED_AMI}" ]]; then
+  summary "::error::${COMBO}: newest visible AMI ${ami_ids[0]} != just-promoted ${PROMOTED_AMI} (eventual consistency or arch mistag?), refusing to prune"
+  exit 1
+fi
+
+if [[ "${#ami_ids[@]}" -le "${KEEP_N}" ]]; then
+  summary "${COMBO}: ${#ami_ids[@]} AMI(s) <= keep ${KEEP_N}, nothing to prune"
+  exit 0
+fi
+
+summary "${COMBO}: ${#ami_ids[@]} ${ROLE} AMIs, keep newest ${KEEP_N}"
+
+# Keep/prune split by array slice; the newest KEEP_N are untouchable.
+keep_ids=("${ami_ids[@]:0:${KEEP_N}}")
+prune_ids=("${ami_ids[@]:${KEEP_N}}")
+
+for ami in "${keep_ids[@]}"; do
+  echo "    KEEP ${ami}"
+done
+
+# Prune loop: warn-and-continue. One failed call (after native retries) must
+# not abort the remaining AMIs (or, via the caller loop, the remaining
+# combos). Snapshot cleanup is native (--delete-associated-snapshots). Any
+# non-success snapshot result is surfaced instead of silently orphaning.
+prune_failures=0
+pruned_count=0
+
+for ami in "${prune_ids[@]}"; do
+  if [[ "${APPLY}" != 1 ]]; then
+    echo "    would deregister ${ami} (superseded)"
+    continue
+  fi
+
+  deregister_err=$(mktemp)
+
+  if ! snapshot_failures=$(aws ec2 deregister-image "${PROFILE_ARGS[@]}" --region "${REGION}" \
+      --image-id "${ami}" --delete-associated-snapshots --output text \
+      --query "DeleteSnapshotResults[?ReturnCode != 'success'].[SnapshotId, ReturnCode]" 2>"${deregister_err}"); then
+    # A concurrent run (workflow leg + ad-hoc justfile) may have removed the AMI
+    # already; that is the desired end state, not a failure. Mirrors _deregister.
+    if grep -qiE "InvalidAMIID.NotFound|InvalidAMIID.Unavailable|does not exist" "${deregister_err}"; then
+      echo "    ${ami} already gone"
+      rm -f "${deregister_err}"
+      pruned_count=$((pruned_count + 1))
+      continue
+    fi
+
+    summary "::warning::${COMBO}: deregister ${ami} failed, continuing"
+    cat "${deregister_err}" >&2
+    rm -f "${deregister_err}"
+    prune_failures=$((prune_failures + 1))
+    continue
+  fi
+
+  rm -f "${deregister_err}"
+
+  echo "    deregistered ${ami} (superseded)"
+  pruned_count=$((pruned_count + 1))
+
+  while IFS= read -r snapshot_result; do
+    [[ -z "${snapshot_result}" ]] && continue
+    summary "::warning::${COMBO}: snapshot cleanup for ${ami}: ${snapshot_result}"
+    prune_failures=$((prune_failures + 1))
+  done <<< "${snapshot_failures}"
+done
+
+# Report: counts always, a loud warning when the combo is still over keep
+# (the signal that the filter drifted or failures piled up).
+residual=$(( ${#ami_ids[@]} - pruned_count ))
+
+if [[ "${APPLY}" == 1 ]]; then
+  summary "${COMBO}: pruned ${pruned_count}, failures ${prune_failures}, remaining ${residual} (keep ${KEEP_N})"
+
+  if (( residual > KEEP_N )); then
+    summary "::warning::${COMBO}: still ${residual} AMIs after pruning (over keep ${KEEP_N})"
+  fi
+fi

--- a/ppg/packer/scripts/prune-superseded.sh
+++ b/ppg/packer/scripts/prune-superseded.sh
@@ -13,7 +13,9 @@
 # Fail-safe: only exact role-tag matches with the right NATIVE architecture
 # are candidates (demoted `*-superseded` roles and mistagged AMIs are never
 # seen), the newest KEEP_N always survive, and a describe failure aborts
-# rather than treating images as absent. Ordering is computed locally from a
+# rather than treating images as absent. An apply run exits non-zero when any
+# prune failed or the combo is still over KEEP_N, so the GHA step and the
+# justfile combo counter see the failure. Ordering is computed locally from a
 # plain projection because the CLI applies --query per page; the only loops
 # are per-AMI mutations, which have no bulk API.
 set -euo pipefail
@@ -193,8 +195,11 @@ for ami in "${prune_ids[@]}"; do
   done <<< "${snapshot_failures}"
 done
 
-# Report: counts always, a loud warning when the combo is still over keep
-# (the signal that the filter drifted or failures piled up).
+# Report, then return the result in the exit status: the GHA step and the
+# justfile combo counter consume the exit code, warnings alone reach neither.
+# The if-form matters, a bare `(( ... )) && exit 1` as the final command would
+# exit 1 when the condition is false. Dry runs stay exit 0 (pruned_count is 0
+# there, so residual exceeds KEEP_N whenever candidates exist).
 residual=$(( ${#ami_ids[@]} - pruned_count ))
 
 if [[ "${APPLY}" == 1 ]]; then
@@ -202,5 +207,9 @@ if [[ "${APPLY}" == 1 ]]; then
 
   if (( residual > KEEP_N )); then
     summary "::warning::${COMBO}: still ${residual} AMIs after pruning (over keep ${KEEP_N})"
+  fi
+
+  if (( prune_failures > 0 || residual > KEEP_N )); then
+    exit 1
   fi
 fi

--- a/ppg/packer/scripts/prune-superseded.sh
+++ b/ppg/packer/scripts/prune-superseded.sh
@@ -1,0 +1,348 @@
+#!/usr/bin/env bash
+# Post-promote AMI prune - keep the newest KEEP_N promoted bases per
+# (os, os_major, arch) combo, deregister the rest with their snapshots.
+# Shared by the GHA workflow (auto-prune after each promote) and the
+# justfile `prune-superseded` recipe. deprecate_at only MARKS an AMI,
+# it never deletes, so without this the inventory grows every bake.
+#
+#   Usage: prune-superseded.sh ROLE OS_MAJOR ARCH KEEP_N APPLY REGION [PROFILE]
+#     APPLY=1 deregisters. Anything else lists only (dry run).
+#   Env:   OS_NAME (default oraclelinux)
+#          PROMOTED_AMI - refuse to prune unless it is the newest match
+#          PINS_FILE - the consumer's static pins on master (required when
+#                      APPLY=1, defaults to ../../vars/moleculeEnvPPG.groovy
+#                      for listing); this combo's pin and everything newer
+#                      survive, and no pinned id of any combo is ever pruned
+#          PROTECT_FILES - colon-separated pins files of open refresh PRs;
+#                      an id named there is never pruned either
+#
+# Fail-safe: only exact role-tag matches with the right NATIVE architecture
+# are candidates (demoted `*-superseded` roles and mistagged AMIs are never
+# seen), the newest KEEP_N always survive, the consumer's pin for the combo and
+# every AMI newer than it survive (the pins are static and lag the newest bake
+# until the weekly refresh PR merges, and an open refresh PR may already name
+# a newer image), and a describe failure, an unparseable pins file, or a pin
+# that is not a candidate aborts rather than treating images as absent. An apply run exits non-zero when any
+# prune failed or the combo is still over KEEP_N, so the GHA step and the
+# justfile combo counter see the failure. Ordering is computed locally from a
+# plain projection because the CLI applies --query per page; the only loops
+# are per-AMI mutations, which have no bulk API.
+set -euo pipefail
+
+# Native throttle handling on every call; warn-and-continue below is the
+# after-retries fallback, not the first line of defense.
+export AWS_RETRY_MODE="${AWS_RETRY_MODE:-standard}"
+export AWS_MAX_ATTEMPTS="${AWS_MAX_ATTEMPTS:-8}"
+
+err() {
+  echo "$*" >&2
+}
+
+# Report lines go to stdout AND the workflow step summary when present.
+summary() {
+  echo "$*"
+
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    # ::warning::/::error:: are stdout annotation directives; the step summary
+    # renders markdown, so strip the directive prefix there.
+    local line="$*"
+    line="${line#::warning::}"
+    line="${line#::error::}"
+    echo "${line}" >> "${GITHUB_STEP_SUMMARY}"
+  fi
+}
+
+# Arguments + preflight: refuse to run half-armed.
+ROLE="${1:?ROLE}"
+OS_MAJOR="${2:?OS_MAJOR}"
+ARCH="${3:?ARCH}"
+KEEP_N="${4:?KEEP_N}"
+APPLY="${5:?APPLY (1=delete, else list)}"
+REGION="${6:?REGION}"
+# APPLY=1 must name its OS explicitly: a silent oraclelinux default on a rocky
+# cleanup would deregister the wrong OS's rollback generation.
+if [[ "${APPLY}" == 1 && -z "${OS_NAME:-}" ]]; then
+  err "OS_NAME must be set explicitly (oraclelinux|rocky) when APPLY=1"
+  exit 1
+fi
+
+OS_NAME="${OS_NAME:-oraclelinux}"
+
+# APPLY=1 must name the pins file explicitly: the working-tree default is fine
+# for listing, but a checkout ahead of master would raise the floor above
+# master's pin and let it be deregistered.
+if [[ "${APPLY}" == 1 && -z "${PINS_FILE:-}" ]]; then
+  err "PINS_FILE must be set explicitly (master's vars/moleculeEnvPPG.groovy) when APPLY=1"
+  exit 1
+fi
+
+# Exact-match whitelist: a wildcard or comma list would widen the tag:os filter
+# and prune across operating systems.
+case "${OS_NAME}" in
+  oraclelinux|rocky) ;;
+  *)
+    err "OS_NAME must be oraclelinux or rocky, got '${OS_NAME}'"
+    exit 1
+    ;;
+esac
+
+PROFILE_ARGS=()
+[[ -n "${7:-}" ]] && PROFILE_ARGS=(--profile "$7")
+
+command -v aws >/dev/null || { err "missing required tool: aws"; exit 1; }
+
+# KEEP_N=0 would deregister the live base the consumer resolves to, and a
+# leading zero would trip Bash's octal arithmetic below. The anchored check
+# also makes KEEP_N safe to interpolate into the array slice.
+if ! [[ "${KEEP_N}" =~ ^[1-9][0-9]*$ ]]; then
+  err "KEEP_N must be a positive integer without leading zeros, got '${KEEP_N}'"
+  exit 1
+fi
+
+# The EC2 native Architecture token is arm64; accept the aarch64 vocabulary too.
+NATIVE_ARCH="${ARCH/aarch64/arm64}"
+
+# Human-facing combo label; oraclelinux and rocky share majors and arches, so
+# every message names the full (os, os_major, arch) combo.
+COMBO="${OS_NAME} ${OS_MAJOR} ${ARCH}"
+
+# Candidate listing: ONE plain-projection fetch, sorted locally. The CLI
+# applies --query independently to each page of a paginated response, so a
+# server-side sort or length() is only page-local and can misorder the list
+# (deleting the wrong rollback) or emit multiple counts. ISO-8601 CreationDate
+# sorts lexicographically, so a plain `sort -r` of the aggregated rows is the
+# global newest-first order. The owner always sees its deprecated AMIs, so
+# --include-deprecated changes nothing here and is kept only to state the
+# intent: images past deprecate_at are pruned too. Native Architecture rides
+# along so a mistagged AMI is excluded AND counted from the same data.
+candidate_rows=$(aws ec2 describe-images "${PROFILE_ARGS[@]}" --region "${REGION}" \
+  --owners self --include-deprecated --output text \
+  --filters Name=tag:role,Values="${ROLE}" Name=tag:os,Values="${OS_NAME}" \
+            Name=tag:os_major,Values="${OS_MAJOR}" Name=tag:arch,Values="${NATIVE_ARCH}" \
+            Name=state,Values=available \
+  --query 'Images[].[CreationDate, ImageId, Architecture]') \
+  || { summary "::error::${COMBO}: describe-images failed, refusing to prune blind"; exit 1; }
+
+sorted_rows=$(sort -r <<< "${candidate_rows}")
+
+mapfile -t ami_ids < <(awk -v native_arch="${NATIVE_ARCH}" '$3 == native_arch {print $2}' <<< "${sorted_rows}")
+
+mismatched_arch=$(awk -v native_arch="${NATIVE_ARCH}" '$2 != "" && $3 != native_arch' <<< "${sorted_rows}" | grep -c . || true)
+
+if (( mismatched_arch > 0 )); then
+  summary "::warning::${COMBO}: ${mismatched_arch} AMI(s) tagged arch=${NATIVE_ARCH} but native Architecture differs, excluded from pruning"
+fi
+
+# Guards. An empty estate right after a promote is an invariant failure when
+# PROMOTED_AMI is known (the just-promoted AMI must be visible): warn loudly
+# and fail so filter drift can never silently disable pruning. Without
+# PROMOTED_AMI (ad-hoc runs) empty stays reportable but benign.
+if [[ "${#ami_ids[@]}" -eq 0 ]]; then
+  if [[ -n "${PROMOTED_AMI:-}" ]]; then
+    summary "::warning::${COMBO}: just-promoted ${PROMOTED_AMI} is not visible in the candidate list (filter drift or eventual consistency), refusing to treat empty as success"
+    exit 1
+  fi
+
+  summary "${COMBO}: no ${ROLE} AMIs found"
+  exit 0
+fi
+
+# The promote tag can lag the describe by a few seconds. Re-list a bounded
+# number of times before treating a not-yet-visible promote as an error.
+if [[ -n "${PROMOTED_AMI:-}" ]]; then
+  for attempt in 1 2 3 4 5 6; do
+    [[ "${ami_ids[0]}" == "${PROMOTED_AMI}" ]] && break
+    echo "    just-promoted ${PROMOTED_AMI} not yet the newest visible match (attempt ${attempt}), waiting 10s"
+    sleep 10
+    candidate_rows=$(aws ec2 describe-images "${PROFILE_ARGS[@]}" --region "${REGION}" \
+      --owners self --include-deprecated --output text \
+      --filters Name=tag:role,Values="${ROLE}" Name=tag:os,Values="${OS_NAME}" \
+                Name=tag:os_major,Values="${OS_MAJOR}" Name=tag:arch,Values="${NATIVE_ARCH}" \
+                Name=state,Values=available \
+      --query 'Images[].[CreationDate, ImageId, Architecture]') \
+      || { summary "::error::${COMBO}: describe-images failed, refusing to prune blind"; exit 1; }
+    sorted_rows=$(sort -r <<< "${candidate_rows}")
+    mapfile -t ami_ids < <(awk -v native_arch="${NATIVE_ARCH}" '$3 == native_arch {print $2}' <<< "${sorted_rows}")
+  done
+  if [[ "${#ami_ids[@]}" -eq 0 || "${ami_ids[0]}" != "${PROMOTED_AMI}" ]]; then
+    summary "::error::${COMBO}: newest visible AMI ${ami_ids[0]:-none} != just-promoted ${PROMOTED_AMI} (eventual consistency or arch mistag?), refusing to prune"
+    exit 1
+  fi
+fi
+
+if [[ "${#ami_ids[@]}" -le "${KEEP_N}" ]]; then
+  summary "${COMBO}: ${#ami_ids[@]} AMI(s) <= keep ${KEEP_N}, nothing to prune"
+  exit 0
+fi
+
+summary "${COMBO}: ${#ami_ids[@]} ${ROLE} AMIs, keep newest ${KEEP_N}"
+
+# Retention floor. For the production role the consumer's pin for THIS combo
+# is the floor: the pin itself and every AMI newer than it survive, because
+# any newer image is a candidate for the next pin (an open refresh PR may
+# already name one). Only images older than the pin are superseded. Each of
+# the 12 OL/Rocky pins must parse exactly once, otherwise the file moved or is
+# ambiguous (the consumer shell takes the last duplicate) and pruning blind
+# could delete the live images. A pin that is not among the candidates
+# (deregistered, retagged) makes the floor unknowable, so that combo refuses.
+# No pinned id of any combo and no id named by an open refresh PR
+# (PROTECT_FILES) is ever pruned, whichever combo it shows up in. The test
+# role has no consumer pins and keeps plain KEEP_N retention.
+PINS_FILE="${PINS_FILE:-../../vars/moleculeEnvPPG.groovy}"
+floor="${KEEP_N}"
+pin_index=-1
+combo_pin=""
+declare -A never_prune
+
+if [[ "${ROLE}" == "ppg-package-test" ]]; then
+  for var_prefix in ol rocky; do
+    for pin_major in 8 9 10; do
+      for pin_arch in x86_64 arm64; do
+        mapfile -t pin_values < <(grep -oE "^ *export ami_${var_prefix}${pin_major}_${pin_arch}=ami-[0-9a-f]+" "${PINS_FILE}" 2>/dev/null | sed -E 's/.*=//' || true)
+        if [[ "${#pin_values[@]}" -ne 1 ]]; then
+          summary "::error::${COMBO}: ami_${var_prefix}${pin_major}_${pin_arch} found ${#pin_values[@]} times in ${PINS_FILE}, expected once, refusing to prune"
+          exit 1
+        fi
+        never_prune["${pin_values[0]}"]="pinned on master"
+      done
+    done
+  done
+
+  pin_prefix=rocky
+  [[ "${OS_NAME}" == oraclelinux ]] && pin_prefix=ol
+  pin_var="ami_${pin_prefix}${OS_MAJOR}_${NATIVE_ARCH}"
+  combo_pin=$(grep -oE "^ *export ${pin_var}=ami-[0-9a-f]+" "${PINS_FILE}" | sed -E 's/.*=//' | head -1 || true)
+
+  if [[ -z "${combo_pin}" ]]; then
+    summary "::error::${COMBO}: no ${pin_var} pin in ${PINS_FILE}, refusing to prune"
+    exit 1
+  fi
+
+  for i in "${!ami_ids[@]}"; do
+    if [[ "${ami_ids[${i}]}" == "${combo_pin}" ]]; then
+      pin_index=${i}
+      break
+    fi
+  done
+
+  if (( pin_index < 0 )); then
+    summary "::error::${COMBO}: pinned ${combo_pin} is not among the ${ROLE} candidates (deregistered or retagged?), refusing to prune"
+    exit 1
+  fi
+
+  # Keep everything down to and including the pin, and never fewer than KEEP_N.
+  if (( pin_index + 1 > floor )); then
+    floor=$(( pin_index + 1 ))
+  fi
+
+  IFS=':' read -r -a protect_files <<< "${PROTECT_FILES:-}"
+  for protect_file in "${protect_files[@]}"; do
+    [[ -z "${protect_file}" ]] && continue
+    if [[ ! -r "${protect_file}" ]]; then
+      summary "::error::${COMBO}: PROTECT_FILES entry ${protect_file} is not readable, refusing to prune"
+      exit 1
+    fi
+    while read -r protected_id; do
+      [[ -z "${protected_id}" ]] && continue
+      never_prune["${protected_id}"]="${never_prune[${protected_id}]:-named by an open refresh PR}"
+    done < <(grep -oE '^ *export ami_(ol|rocky)[0-9]+_(x86_64|arm64)=ami-[0-9a-f]+' "${protect_file}" | sed -E 's/.*=//' || true)
+  done
+fi
+
+keep_ids=("${ami_ids[@]:0:${floor}}")
+prune_ids=("${ami_ids[@]:${floor}}")
+
+for i in "${!keep_ids[@]}"; do
+  ami="${keep_ids[${i}]}"
+  if [[ "${ami}" == "${combo_pin}" ]]; then
+    echo "    KEEP ${ami} (pinned in ${PINS_FILE##*/})"
+  elif (( pin_index >= 0 && i < pin_index )); then
+    echo "    KEEP ${ami} (newer than the pin)"
+  else
+    echo "    KEEP ${ami} (newest ${KEEP_N})"
+  fi
+done
+
+# A protected id below the floor means a mis-tag or a stale refresh PR that
+# must be closed first: refuse the whole combo rather than prune around it.
+for ami in "${prune_ids[@]}"; do
+  if [[ -n "${never_prune[${ami}]:-}" ]]; then
+    summary "::error::${COMBO}: ${ami} is below the floor but ${never_prune[${ami}]}, refusing to prune this combo"
+    exit 1
+  fi
+done
+
+# Prune loop: warn-and-continue. One failed call (after native retries) must
+# not abort the remaining AMIs (or, via the caller loop, the remaining
+# combos). Snapshot cleanup is native (--delete-associated-snapshots). Any
+# non-success snapshot result is surfaced instead of silently orphaning.
+prune_failures=0
+pruned_count=0
+
+for ami in "${prune_ids[@]}"; do
+  if [[ "${APPLY}" != 1 ]]; then
+    echo "    would deregister ${ami} (superseded)"
+    continue
+  fi
+
+  deregister_err=$(mktemp)
+
+  if ! snapshot_failures=$(aws ec2 deregister-image "${PROFILE_ARGS[@]}" --region "${REGION}" \
+      --image-id "${ami}" --delete-associated-snapshots --output text \
+      --query "DeleteSnapshotResults[?ReturnCode != 'success'].[SnapshotId, ReturnCode]" 2>"${deregister_err}"); then
+    # A concurrent run (workflow leg + ad-hoc justfile) may have removed the AMI
+    # already; that is the desired end state, not a failure. Mirrors _deregister.
+    if grep -qiE "InvalidAMIID.NotFound|InvalidAMIID.Unavailable|does not exist" "${deregister_err}"; then
+      echo "    ${ami} already gone"
+      rm -f "${deregister_err}"
+      pruned_count=$((pruned_count + 1))
+      continue
+    fi
+
+    summary "::warning::${COMBO}: deregister ${ami} failed, continuing"
+    cat "${deregister_err}" >&2
+    rm -f "${deregister_err}"
+    prune_failures=$((prune_failures + 1))
+    continue
+  fi
+
+  rm -f "${deregister_err}"
+
+  echo "    deregistered ${ami} (superseded)"
+  pruned_count=$((pruned_count + 1))
+
+  while IFS= read -r snapshot_result; do
+    [[ -z "${snapshot_result}" || "${snapshot_result}" == "None" ]] && continue
+    # skipped (snapshot still used by another AMI) and missing (already gone)
+    # are benign outcomes, only error codes count as failures.
+    case "${snapshot_result}" in
+      *skipped*|*missing*)
+        echo "    snapshot for ${ami}: ${snapshot_result}"
+        ;;
+      *)
+        summary "::warning::${COMBO}: snapshot cleanup for ${ami}: ${snapshot_result}"
+        prune_failures=$((prune_failures + 1))
+        ;;
+    esac
+  done <<< "${snapshot_failures}"
+done
+
+# Report, then return the result in the exit status: the GHA step and the
+# justfile combo counter consume the exit code, warnings alone reach neither.
+# The if-form matters, a bare `(( ... )) && exit 1` as the final command would
+# exit 1 when the condition is false. Dry runs stay exit 0 (pruned_count is 0
+# there, so residual exceeds KEEP_N whenever candidates exist).
+residual=$(( ${#ami_ids[@]} - pruned_count ))
+expected_residual="${#keep_ids[@]}"
+
+if [[ "${APPLY}" == 1 ]]; then
+  summary "${COMBO}: pruned ${pruned_count}, failures ${prune_failures}, remaining ${residual} (keep ${KEEP_N} plus pinned, expected ${expected_residual})"
+
+  if (( residual > expected_residual )); then
+    summary "::warning::${COMBO}: still ${residual} AMIs after pruning (expected ${expected_residual})"
+  fi
+
+  if (( prune_failures > 0 || residual > expected_residual )); then
+    exit 1
+  fi
+fi

--- a/ppg/packer/smoke/smoke.pkr.hcl
+++ b/ppg/packer/smoke/smoke.pkr.hcl
@@ -29,8 +29,20 @@ variable "os" {
     error_message = "Value of os must be oraclelinux or rocky."
   }
 }
-variable "os_major" { type = string }
-variable "arch" { type = string } # x86_64 | arm64
+variable "os_major" {
+  type = string
+  validation {
+    condition     = contains(["8", "9", "10"], var.os_major)
+    error_message = "Value of os_major must be 8, 9, or 10."
+  }
+}
+variable "arch" {
+  type = string # x86_64 | arm64
+  validation {
+    condition     = contains(["x86_64", "arm64"], var.arch)
+    error_message = "Value of arch must be x86_64 or arm64."
+  }
+}
 variable "region" {
   type    = string
   default = "eu-central-1"


### PR DESCRIPTION
**Feature**
- After each prod promote the workflow prunes that (os, os_major, arch) combo down to the newest `KEEP_GENERATIONS=2` promoted bases plus the AMI pinned in `vars/moleculeEnvPPG.groovy` on master and everything newer than it, snapshots included, and `just prune-superseded` shares the same script for ad-hoc runs

**Why**
- `deprecate_at` only marks an AMI, it never deletes, so the inventory grows every bake (the live estate reached 105 promoted OL8/OL9 AMIs)
- The pins are static since [PR 4348](https://github.com/Percona-Lab/jenkins-pipelines/pull/4348) and lag the newest bake until the weekly refresh PR merges, so a keep-N prune alone would deregister the image pg.cd launches or the one an open refresh PR already names
- The prune is OS-scoped and guard-railed: exact `tag:os` whitelist, a bounded wait for the just-promoted AMI to become the newest visible match, keep-N floor, pin floor read from master at prune time with each of the 12 pins parsed exactly once, refusal when a candidate is pinned by any combo or named by an open refresh PR, prod bakes only, warn-and-continue loop with run annotations and step-summary reporting

**Tickets**
- [PG-2353](https://perconadev.atlassian.net/browse/PG-2353) (this), [PKG-1447](https://perconadev.atlassian.net/browse/PKG-1447) (static pins), companion [PR 4445](https://github.com/Percona-Lab/jenkins-pipelines/pull/4445) (dated refresh PRs and the daily pin check)

[PG-2353]: https://perconadev.atlassian.net/browse/PG-2353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ