### PR TITLE
PMM-15374 Ask pmm3-ha-rosa for a fourth worker in the HA e2e suite

### DIFF
--- a/pmm/v3/pmm3-ha-e2e-tests-gha.groovy
+++ b/pmm/v3/pmm3-ha-e2e-tests-gha.groovy
@@ -41,6 +41,7 @@ void runOpenShiftClusterCreate(String OCP_VERSION, DOCKER_VERSION, HELM_CHART_BR
 
     def clusterCreateJob = build job: 'pmm3-ha-rosa', parameters: [
         string(name: 'OCP_VERSION', value: OCP_VERSION),
+        string(name: 'WORKER_COUNT', value: '4'),
         string(name: 'HELM_CHART_BRANCH', value: HELM_CHART_BRANCH),
         string(name: 'PMM_IMAGE_REPOSITORY', value: pmmImageRepo),
         string(name: 'PMM_IMAGE_TAG', value: pmmImageTag),

--- a/pmm/v3/pmm3-ha-rosa.groovy
+++ b/pmm/v3/pmm3-ha-rosa.groovy
@@ -801,7 +801,7 @@ EOF
                         set +e
 
                         # Install pmm-ha chart (creates component service accounts)
-                        # Resource requests reduced for test clusters (defaults are higher for production)
+                        # Resources stay at the chart defaults; raise WORKER_COUNT when pods do not fit
                         helm upgrade --install pmm-ha helm-charts/charts/pmm-ha -n pmm \
                             --timeout 20m \
                             --set secret.create=false \


### PR DESCRIPTION
## What

`pmm3-ha-e2e-tests-gha.groovy` passes `WORKER_COUNT=4` when it provisions the OpenShift cluster, and a stale comment in `pmm3-ha-rosa.groovy` is corrected.

> Rebased onto current `master`, which already exposes `WORKER_COUNT` as a job parameter (default `3`) — the earlier version of this PR hardcoded it in the env block and conflicted. Only the caller needs to change now. Sorry for the force-push over the review suggestion commit: the code it touched no longer exists after the rebase, but its intent (drop the verbose comment) is kept — the new line carries no comment.

## Why

The HA cluster is sized for exactly what the `pmm-ha` chart installs, with no room for one extra pod. Measured on `pmm-ha-rosa-158` ([`pmm3-ha-tests` #29](https://pmm.cd.percona.com/job/pmm3-ha-tests/29/)) while the scaling test was failing:

```
$ kubectl describe pod pmm-ha-3 -n pmm
Warning  FailedScheduling  default-scheduler
  0/3 nodes are available: 3 Insufficient cpu.
  preemption: 0/3 nodes are available: 3 No preemption victims found for incoming pod.

$ kubectl describe nodes | grep cpu      # Allocated resources, requests
  cpu  6280m (83%)
  cpu  6180m (82%)
  cpu  6033m (80%)
```

Each `m7i.2xlarge` has ~7.5 CPU allocatable, so ~1.3 is free per node while a PMM Server pod requests 2 (`pmmResources.requests.cpu: "2"`, the chart default). The three workers cover the three PMM pods plus ClickHouse (3 × 2 CPU), PostgreSQL, VictoriaMetrics, HAProxy and the OpenShift daemonsets — and nothing else. So **no additional PMM replica can be scheduled**, today or for any future test that adds one.

That is what fails PMM-T2124 (`clusterScaleUp.test.ts`, scale `pmm-ha` to five pods): three 10-minute readiness timeouts in run #29. The other six `@pmm-ha` tests passed.

## Why a fourth worker is enough

The chart's pod anti-affinity is `preferredDuringSchedulingIgnoredDuringExecution`, and its selector matches `app.kubernetes.io/name: pmm` while these pods are labelled `app.kubernetes.io/name: pmm-ha` (the chart name) — so it imposes no spreading at all. One spare worker (~6.5 CPU free after daemonsets) takes both new pods at 2 CPU each.

## Why not lower the resource requests instead

`--set pmmResources.requests.cpu=1` would also fit five pods on three workers, for free. Rejected deliberately:

- requests are the scheduler's guarantee, so the suite would run oversubscribed — and the HA tests are timing-sensitive (failover, leader election, readiness probes);
- the nightly would stop exercising the profile users deploy, and a future chart change that genuinely no longer fits would go unnoticed.

The comment above the helm install claimed "Resource requests reduced for test clusters" although no `--set resources.*` was ever passed. It now states what the code actually does.

## Not changed

`pmm3-ha-eks.groovy` keeps `desiredCapacity: 6` (`minSize: 6`, `maxSize: 12`). Its nodes are 4-vCPU instances and I have no measurement from an EKS run; if one shows `pmm-ha-3` Pending, it needs the same treatment.

## Testing

Not executed — a Groovy change can only be verified by running the job, and the job runs from `master`. The equivalent topology was verified by hand: on a 3-node Linode LKE cluster PMM-T2124 fails exactly as here, and on the same cluster with spare capacity it passes in 1.4 min with the whole `@pmm-ha` suite green (7/7).

Tests: percona/pmm-qa#1273. Ticket: [PMM-15374](https://perconadev.atlassian.net/browse/PMM-15374).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013YoGfUzkm1mheSiWtwg6nH

[PMM-15374]: https://perconadev.atlassian.net/browse/PMM-15374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ