### PR TITLE
Use table parsing instead of xml for pre-release GKE

### DIFF
--- a/cloud/scripts/generate_release_images_file.py
+++ b/cloud/scripts/generate_release_images_file.py
@@ -7,7 +7,6 @@ from datetime import datetime
 from packaging.version import parse as parse_version
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from urllib.parse import urljoin
-from xml.etree import ElementTree as ET
 
 PMM_CLIENT = "2.44.1-1"
 PMM_SERVER = "2.44.1"
@@ -28,8 +27,6 @@ MONTH_MAP = {
     "nov": 11,
     "dec": 12,
 }
-
-GKE_VERSION_RE = r"\d+\.\d+\.\d+-gke\.\d+"
 
 _session = requests.Session()
 
@@ -380,52 +377,25 @@ def get_eks():
     return sort_vers(filter_active(resp.json(), datetime.now().date()))
 
 
-def gke_release_entries(xml_text):
-    try:
-        root = ET.fromstring(xml_text)
-    except ET.ParseError:
-        return re.findall(r"<!\[CDATA\[(.*?)\]\]>", xml_text, re.DOTALL)
-
-    entries = []
-    for entry in root.iter():
-        if entry.tag.rsplit("}", 1)[-1] not in {"entry", "item"}:
-            continue
-        for child in entry:
-            if child.tag.rsplit("}", 1)[-1] in {"content", "description", "summary"}:
-                content = "".join(child.itertext()).strip()
-                if content:
-                    entries.append(content)
-                break
-    return entries
-
-
-def gke_removed_versions(html):
-    removed = set()
-    for block in re.findall(
-        r"no longer available in the Stable channel:.*?</ul>",
-        html,
-        re.DOTALL | re.IGNORECASE,
-    ):
-        removed.update(re.findall(GKE_VERSION_RE, block))
-    return removed
-
-
 def get_gke():
+    """Return [MAX, MIN] Stable-channel minor versions from the current versions table."""
     resp = _session.get(
-        "https://docs.cloud.google.com/feeds/kubernetes-engine-stable-channel-release-notes.xml",
-        timeout=10,
+        "https://docs.cloud.google.com/kubernetes-engine/docs/release-notes",
+        timeout=15,
     )
     resp.raise_for_status()
-    available = set()
-    for entry in reversed(gke_release_entries(resp.text)):
-        removed = gke_removed_versions(entry)
-        available.update(set(re.findall(GKE_VERSION_RE, entry)) - removed)
-        available.difference_update(removed)
-
-    if available:
-        minors = sort_vers(list({".".join(v.split(".")[:2]) for v in available}))
-        return [minors[0], minors[-1]]
-    return None
+    # Columns: Rapid | Regular | Stable | Extended | No Channel
+    match = re.search(
+        r"Available minor versions</td>\s*"
+        r"<td>\d+\.\d+ to \d+\.\d+</td>\s*"  # Rapid
+        r"<td>\d+\.\d+ to \d+\.\d+</td>\s*"  # Regular
+        r"<td>(\d+\.\d+) to (\d+\.\d+)</td>",  # Stable
+        resp.text,
+        re.IGNORECASE,
+    )
+    if not match:
+        return None
+    return sort_vers([match.group(1), match.group(2)])
 
 
 def get_rancher():


### PR DESCRIPTION
Hi,
Current approach to get min & max GKE versions still result in having versions that are not supported in STABLE channel. Upgdated to get RN and parse table 