### PR TITLE
PXB-3609 : Provide the MinIO client to the xbcloud tests

### DIFF
--- a/pxb/v2/docker/run-test
+++ b/pxb/v2/docker/run-test
@@ -33,6 +33,13 @@ if [[ ${WITH_XBCLOUD_TESTS} == "true" ]]; then
 
   export S3_SERVER_IP=$(docker inspect s3 | egrep "\"IPAddress\": \"([0-9]{1,3}\.){3}[0-9]{1,3}" | awk -F'"' '{print $4}' | head -n 1)
   export XBCLOUD_CREDENTIALS="--storage=s3 --s3-endpoint='http://${S3_SERVER_IP}:9000' --s3-access-key=myuser --s3-secret-key=someStrongPWD --s3-bucket=newbucket"
+
+  # The test container has no docker, so tests cannot reach into the s3
+  # container. Copy the MinIO client out of the image instead: mc is a static
+  # binary and talks to MinIO over pxb_network like any other client, which is
+  # all the tests need to list objects and manage IAM users.
+  docker cp s3:/usr/bin/mc ${ROOT_DIR}/mc
+  export XBCLOUD_MC=/tmp/pxb/mc
 fi
 
 if [[ ${WITH_VAULT_TESTS} == "true" ]]; then
@@ -86,6 +93,7 @@ docker run --rm \
     export WITH_AZURITE='${WITH_AZURITE}'
     export LANG=en_AU.UTF-8
     export XBCLOUD_CREDENTIALS='${XBCLOUD_CREDENTIALS}'
+    export XBCLOUD_MC='${XBCLOUD_MC}'
     export VAULT_IP='${VAULT_SERVER_IP}'
     export VAULT_URL=https://local.vault.com:8200
     export VAULT_CACERT=/tmp/pxb/vault.crt


### PR DESCRIPTION
## Problem

The xbcloud tests run inside the `pxc-build` container, started as a sibling of the `s3` (MinIO) container on `pxb_network`. That container has **no docker binary and no docker socket**:

| tool | in `pxc-build:oraclelinux-9` |
|---|---|
| `docker` | missing |
| `mc` / `aws` | missing |
| `/var/run/docker.sock` | not mounted |

So a test cannot reach into the `s3` container to run `mc`. Tests that need to check individual object names, or what a restricted IAM user is permitted to do, have no way to ask xbcloud for that — they need an S3 client of their own.

## Change

Copy `mc` out of the MinIO image and pass its path to the tests:

```bash
docker cp s3:/usr/bin/mc ${ROOT_DIR}/mc
export XBCLOUD_MC=/tmp/pxb/mc
```

`${ROOT_DIR}` is already bind-mounted into the test container at `/tmp/pxb`, so the binary appears there. `mc` is a static binary and talks to MinIO over `pxb_network` like any other client, so:

- nothing has to be installed in the shared `pxc-build` image
- no docker socket is exposed to the test container (which would grant it root on the agent)

This mirrors what the vault and kmip blocks already do when they `docker cp` certificates out of their containers.

## Scope

Confined to `if [[ ${WITH_XBCLOUD_TESTS} == "true" ]]`, so jobs that don't run xbcloud tests are unaffected. Tests skip cleanly when `XBCLOUD_MC` is unset, so this can land before or after the tests that use it.

## Verified

`mc` copied from the MinIO image was run inside `public.ecr.aws/e7j3v3n0/pxc-build:oraclelinux-9` with no docker present — remote bucket listing and remote IAM user create/remove both work over the network.

Needed by the PXB-3609 tests (`md5_delete`, `md5_delete_permissions`, `md5_delete_prefix_scope`), which currently skip in CI with *"requires docker to run mc against MinIO"*.
