### PR TITLE
Fix broken Launchable build recording for multi-arch pmm-server images

### DIFF
--- a/pmm/v3/pmm3-server-autobuild.groovy
+++ b/pmm/v3/pmm3-server-autobuild.groovy
@@ -84,7 +84,7 @@ pipeline {
         }
         stage('Push pmm3 server multi-arch images') {
             steps {
-                withCredentials([usernamePassword(credentialsId: 'hub.docker.com', passwordVariable: 'PASS', usernameVariable: 'USER')]) {
+                withCredentials([usernamePassword(credentialsId: 'hub.docker.com', passwordVariable: 'PASS', usernameVariable: 'USER'), string(credentialsId: 'LAUNCHABLE_TOKEN', variable: 'LAUNCHABLE_TOKEN')]) {
                     sh '''
                         echo "${PASS}" | docker login -u "${USER}" --password-stdin
                         set -o xtrace
@@ -109,6 +109,10 @@ pipeline {
                                 perconalab/pmm-server:${DOCKER_LATEST_TAG}-arm64
                             echo "${DOCKER_LATEST_TAG}" > DOCKER_TAG
                         fi
+
+                        pip3 install --user --upgrade launchable~=1.0 || true
+                        launchable record build --lineage "perconalab/pmm-server:$(cat DOCKER_TAG)" \
+                            --name "$(docker buildx imagetools inspect perconalab/pmm-server:$(cat DOCKER_TAG) --format '{{.Manifest.Digest}}')" || true
                     '''
                 }
                 script {


### PR DESCRIPTION
## What's broken

pmm-qa's nightly e2e suite runs **zero tests** and still reports green.

[Run 292](https://github.com/percona/pmm-qa/actions/runs/34000528606) (Sept 6): all 14 setup jobs provisioned databases, then every test step was skipped.

## Why

The test workflows ask Launchable which tests to run, identifying the server by its image digest:

```
docker inspect -f '{{index .RepoDigests 0}}' perconalab/pmm-server:3-dev-latest
```

Launchable answers "I've never heard of that build", returns an empty subset, and the workflow skips everything:

```
Build sha256:47a4c34ed88e... was not found. Make sure to run `launchable record build ...`
Launchable subset is empty. Test execution will be skipped.
```

That digest never gets recorded any more. #4383 (arm64 support) changed two things at once:

1. this job now assembles `3-dev-latest` with `docker buildx imagetools create`, and its `launchable record build` step was removed;
2. the only surviving `record build` went into `pmm3-server-autobuild-amd`, where it names the **per-arch** image (`3-dev-latest-amd64`) — a different digest.

So the tag that gets tested is the one nobody records.

Before the split, this same job pushed the tag *and* recorded it, matching exactly — [build #2712](https://pmm.cd.percona.com/job/pmm3-server-autobuild/2712/):

```
exporting manifest list sha256:bd465260619a...
3-dev-latest: digest: sha256:bd465260619a...
+ launchable record build --name sha256:bd465260619a... --lineage perconalab/pmm-server:3-dev-latest
Launchable recorded build ... to workspace percona/workshop
```

That's why nightly run 291 (Sept 4, pre-split image) ran its tests normally and run 292 did not.

## The fix

Record the build again, here, from the digest of the tag this job actually pushes. Four lines: the token added to the existing `withCredentials`, and the record itself at the end of the existing `sh`.

`docker inspect -f {{.Id}}` (the old code) can't be reused — `imagetools create` assembles the index registry-side, so the multi-arch image is never in the local store. `docker buildx imagetools inspect --format '{{.Manifest.Digest}}'` reads it from the registry and returns the same value the test runners look up.

Uses `$(cat DOCKER_TAG)`, so it covers both the `3-dev-latest` and `-rc` branches above it.

## Verifying

After the next `pmm3-server-autobuild` run, the console (it runs under `set -o xtrace`) shows the recorded digest — it should equal what a `docker pull perconalab/pmm-server:3-dev-latest` reports as `RepoDigests[0]`. The following nightly should then log `Launchable subset is not empty. Continue with tests.` instead of skipping.

## Not covered here

pmm-qa treats "Launchable is broken" and "Launchable selected no tests" identically, which is why this went unnoticed for two nights of green runs. Worth a separate guard in the pmm-qa workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LBJecHqfo94L3SMwV3eat7

---
_Generated by [Claude Code](https://claude.ai/code/session_01LBJecHqfo94L3SMwV3eat7)_