### PR TITLE
PXB-3745: Preserve test results during helper cleanup

### DIFF
--- a/pxb/v2/docker/run-test
+++ b/pxb/v2/docker/run-test
@@ -2,10 +2,16 @@
 
 set -o errexit
 set -o xtrace
+helper_containers=()
 trap cleanup EXIT
 
 function cleanup (){
-  docker rm --force vault s3 kmip
+  local test_status=$?
+  trap - EXIT
+  if (( ${#helper_containers[@]} > 0 )); then
+    docker rm --force "${helper_containers[@]}" || echo "Warning: helper-container cleanup failed" >&2
+  fi
+  exit "${test_status}"
 }
 ROOT_DIR=$(cd $(dirname $0)/../sources; pwd -P)
 SCRIPTS_DIR=$(cd $(dirname $0)/../local; pwd -P)
@@ -27,9 +33,10 @@ fi
 
 if [[ ${WITH_XBCLOUD_TESTS} == "true" ]]; then
   check_pxb_network
-  docker run -d --security-opt seccomp=unconfined --cap-add=NET_ADMIN \
+  S3_CONTAINER_ID=$(docker run -d --security-opt seccomp=unconfined --cap-add=NET_ADMIN \
   --env PASSWORD=someStrongPWD --env USER=myuser -p 9000:9000 --rm \
-  -p 9001:9001 ${DOCKER_NETWORK_FLAG} --name s3 satyapercona/minio:latest
+  -p 9001:9001 ${DOCKER_NETWORK_FLAG} --name s3 satyapercona/minio:latest)
+  helper_containers+=("${S3_CONTAINER_ID}")
 
   export S3_SERVER_IP=$(docker inspect s3 | egrep "\"IPAddress\": \"([0-9]{1,3}\.){3}[0-9]{1,3}" | awk -F'"' '{print $4}' | head -n 1)
   export XBCLOUD_CREDENTIALS="--storage=s3 --s3-endpoint='http://${S3_SERVER_IP}:9000' --s3-access-key=myuser --s3-secret-key=someStrongPWD --s3-bucket=newbucket"
@@ -44,7 +51,8 @@ fi
 
 if [[ ${WITH_VAULT_TESTS} == "true" ]]; then
     check_pxb_network
-    docker run -d --security-opt seccomp=unconfined --cap-add=NET_ADMIN --rm -p 8200:8200 ${DOCKER_NETWORK_FLAG} --name vault satyapercona/vault:latest
+    VAULT_CONTAINER_ID=$(docker run -d --security-opt seccomp=unconfined --cap-add=NET_ADMIN --rm -p 8200:8200 ${DOCKER_NETWORK_FLAG} --name vault satyapercona/vault:latest)
+    helper_containers+=("${VAULT_CONTAINER_ID}")
     docker cp vault:/opt/vault/tls/tls.crt ${ROOT_DIR}/vault.crt
     export VAULT_SERVER_IP=$(docker inspect vault | egrep "\"IPAddress\": \"([0-9]{1,3}\.){3}[0-9]{1,3}" | awk -F'"' '{print $4}' | head -n 1)
     export TOKEN=$(docker logs vault | grep 'export VAULT_TOKEN' | awk -F'=' '{print $2}')
@@ -65,7 +73,8 @@ fi
 if [[ ${WITH_KMIP_TESTS} == "true" ]]; then
     check_pxb_network
     # The certificate expires on Sep 23 15:02:39 2025 GMT and then docker image should be rebuilt.
-    docker run -d --security-opt seccomp=unconfined --cap-add=NET_ADMIN --rm -p 5696:5696 ${DOCKER_NETWORK_FLAG} --name kmip satyapercona/kmip:latest
+    KMIP_CONTAINER_ID=$(docker run -d --security-opt seccomp=unconfined --cap-add=NET_ADMIN --rm -p 5696:5696 ${DOCKER_NETWORK_FLAG} --name kmip satyapercona/kmip:latest)
+    helper_containers+=("${KMIP_CONTAINER_ID}")
 
     docker cp kmip:/opt/certs/root_certificate.pem ${ROOT_DIR}
     docker cp kmip:/opt/certs/client_key_jane_doe.pem ${ROOT_DIR}

--- a/pxb/v2/tests/cleanup-fixtures/docker.py
+++ b/pxb/v2/tests/cleanup-fixtures/docker.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Docker boundary for the real run-test cleanup contract tests."""
+import json
+import os
+from pathlib import Path
+import sys
+
+
+state_path = Path(os.environ['PXB_CLEANUP_FIXTURE'])
+state = json.loads(state_path.read_text())
+args = sys.argv[1:]
+result = 0
+if args[:2] == ['run', '--rm']:
+    state['main_runs'] += 1
+    result = state['main_exit']
+elif args[:2] == ['network', 'list']:
+    print('fixture pxb_network bridge local')
+elif args[:2] == ['run', '-d']:
+    name = args[args.index('--name') + 1]
+    if any(container['name'] == name for container in state['containers'].values()):
+        result = 125
+    else:
+        identifier = {'s3': 'a', 'vault': 'd', 'kmip': 'e'}[name] * 64
+        state['containers'][identifier] = {'name': name}
+        print(identifier)
+elif args[0] == 'inspect':
+    print('    "IPAddress": "192.0.2.10",')
+elif args[0] == 'cp':
+    pass
+elif args[0] == 'logs':
+    print('export VAULT_TOKEN=fixture-token')
+elif args[:2] == ['rm', '--force']:
+    state['cleanup_targets'].extend(args[2:])
+    if state.get('cleanup_exit'):
+        result = state['cleanup_exit']
+    else:
+        for target in args[2:]:
+            identifier = target if target in state['containers'] else next(
+                (key for key, value in state['containers'].items() if value['name'] == target), None)
+            if identifier is None:
+                result = 1
+            else:
+                del state['containers'][identifier]
+else:
+    raise AssertionError(f'Unexpected Docker command: {args}')
+state_path.write_text(json.dumps(state))
+sys.exit(result)

--- a/pxb/v2/tests/test_run_test_cleanup.py
+++ b/pxb/v2/tests/test_run_test_cleanup.py
@@ -1,0 +1,116 @@
+"""Execute the real runner with a fake Docker CLI, without creating containers.
+
+Run from the repository root:
+    uv run --no-project python pxb/v2/tests/test_run_test_cleanup.py
+"""
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[3]
+RUN_TEST = ROOT / 'pxb/v2/docker/run-test'
+DOCKER = Path(__file__).with_name('cleanup-fixtures') / 'docker.py'
+
+
+class RunTestCleanup(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory(prefix='pxb-run-test-cleanup-')
+        self.addCleanup(self.temporary.cleanup)
+        self.work = Path(self.temporary.name)
+        runner_root = self.work / 'pxb/v2'
+        for name in ('docker', 'local', 'sources'):
+            (runner_root / name).mkdir(parents=True)
+        self.runner = runner_root / 'docker/run-test'
+        shutil.copy2(RUN_TEST, self.runner)
+        self.commands = self.work / 'bin'
+        self.commands.mkdir()
+        shutil.copy2(DOCKER, self.commands / 'docker')
+        (self.commands / 'docker').chmod(0o755)
+        self.state_path = self.work / 'docker-state.json'
+        self.state = {'containers': {}, 'main_exit': 0, 'main_runs': 0, 'cleanup_targets': []}
+        self.environment = dict(os.environ,
+                                PATH=str(self.commands) + os.pathsep + os.environ['PATH'],
+                                PXB_CLEANUP_FIXTURE=str(self.state_path),
+                                XTRABACKUP_TARGET='innodb80', INNODB80_VERSION='8.0.35',
+                                CMAKE_BUILD_TYPE='RelWithDebInfo',
+                                WITH_XBCLOUD_TESTS='false', WITH_VAULT_TESTS='false',
+                                WITH_KMIP_TESTS='false', WITH_AZURITE='false')
+
+    def run_runner(self):
+        self.state_path.write_text(json.dumps(self.state))
+        result = subprocess.run(['bash', str(self.runner), 'oraclelinux:9', 'x86_64'],
+                                env=self.environment, text=True, stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE, timeout=10, check=False)
+        self.state = json.loads(self.state_path.read_text())
+        return result
+
+    def test_disabled_services_do_not_turn_success_into_failure(self):
+        result = self.run_runner()
+        self.assertEqual(self.state['main_runs'], 1)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_cleanup_failure_preserves_the_original_test_failure(self):
+        self.environment['WITH_XBCLOUD_TESTS'] = 'true'
+        self.state.update(main_exit=17, cleanup_exit=23)
+        result = self.run_runner()
+        self.assertEqual(self.state['main_runs'], 1)
+        self.assertTrue(self.state['cleanup_targets'])
+        self.assertEqual(result.returncode, 17, result.stderr)
+
+    def test_cleanup_removes_only_the_container_created_by_this_run(self):
+        self.environment['WITH_XBCLOUD_TESTS'] = 'true'
+        existing = {'b' * 64: {'name': 'vault'}, 'c' * 64: {'name': 'kmip'}}
+        self.state['containers'] = dict(existing)
+        result = self.run_runner()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(self.state['containers'], existing)
+        self.assertEqual(self.state['cleanup_targets'], ['a' * 64])
+
+    def test_cleanup_failure_does_not_replace_success(self):
+        self.environment['WITH_XBCLOUD_TESTS'] = 'true'
+        self.state['cleanup_exit'] = 23
+        result = self.run_runner()
+        self.assertEqual(self.state['main_runs'], 1)
+        self.assertEqual(self.state['cleanup_targets'], ['a' * 64])
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn('Warning: helper-container cleanup failed', result.stderr)
+
+    def test_all_enabled_helpers_are_cleaned_by_their_created_ids(self):
+        for name in ('WITH_XBCLOUD_TESTS', 'WITH_VAULT_TESTS', 'WITH_KMIP_TESTS'):
+            self.environment[name] = 'true'
+        existing = {'f' * 64: {'name': 'another-job'}}
+        self.state['containers'] = dict(existing)
+        result = self.run_runner()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(self.state['main_runs'], 1)
+        self.assertEqual(self.state['containers'], existing)
+        self.assertEqual(self.state['cleanup_targets'], ['a' * 64, 'd' * 64, 'e' * 64])
+
+    def test_startup_name_conflict_does_not_remove_the_existing_container(self):
+        self.environment['WITH_XBCLOUD_TESTS'] = 'true'
+        existing = {'f' * 64: {'name': 's3'}}
+        self.state['containers'] = dict(existing)
+        result = self.run_runner()
+        self.assertEqual(result.returncode, 125, result.stderr)
+        self.assertEqual(self.state['main_runs'], 0)
+        self.assertEqual(self.state['containers'], existing)
+        self.assertEqual(self.state['cleanup_targets'], [])
+
+    def test_later_startup_failure_cleans_only_previously_created_helpers(self):
+        self.environment.update(WITH_XBCLOUD_TESTS='true', WITH_VAULT_TESTS='true')
+        existing = {'f' * 64: {'name': 'vault'}}
+        self.state['containers'] = dict(existing)
+        result = self.run_runner()
+        self.assertEqual(result.returncode, 125, result.stderr)
+        self.assertEqual(self.state['main_runs'], 0)
+        self.assertEqual(self.state['containers'], existing)
+        self.assertEqual(self.state['cleanup_targets'], ['a' * 64])
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
**Bug**

- Helper cleanup can replace a PXB test result or remove containers this run did not create.

**Fix**

- Track only helper IDs created by this run and preserve the original exit status.

**Tickets**

- [PXB-3745](https://perconadev.atlassian.net/browse/PXB-3745) (Separate runner defect found during validation).


[PXB-3745]: https://perconadev.atlassian.net/browse/PXB-3745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ