### PR TITLE
PMM-15460 Remove Debian 11 Bullseye as it is already EOL.

### DIFF
--- a/pmm/v3/pmm3-client-autobuild-amd.groovy
+++ b/pmm/v3/pmm3-client-autobuild-amd.groovy
@@ -229,11 +229,6 @@ pipeline {
                                 sh "${PATH_TO_SCRIPTS}/build-client-deb debian:bookworm"
                             }
                         }
-                        stage('Build client binary deb Bullseye') {
-                            steps {
-                                sh "${PATH_TO_SCRIPTS}/build-client-deb debian:bullseye"
-                            }
-                        }
                         stage('Build client binary deb Jammy') {
                             steps {
                                 sh "${PATH_TO_SCRIPTS}/build-client-deb ubuntu:jammy"

--- a/pmm/v3/pmm3-client-autobuild-arm.groovy
+++ b/pmm/v3/pmm3-client-autobuild-arm.groovy
@@ -186,11 +186,6 @@ pipeline {
                         sh "${PATH_TO_SCRIPTS}/build-client-deb debian:bookworm"
                     }
                 }
-                stage('Build client binary deb Bullseye') {
-                    steps {
-                        sh "${PATH_TO_SCRIPTS}/build-client-deb debian:bullseye"
-                    }
-                }
                 stage('Build client binary deb Jammy') {
                     steps {
                         sh "${PATH_TO_SCRIPTS}/build-client-deb ubuntu:jammy"

--- a/pmm/v3/pmm3-package-testing-amd64.groovy
+++ b/pmm/v3/pmm3-package-testing-amd64.groovy
@@ -231,15 +231,6 @@ pipeline {
                         run_package_tests(GIT_BRANCH, TESTS, INSTALL_REPO, TARBALL)
                     }
                 }
-                stage('Debian 11 Bullseye - AMD64') {
-                    agent {
-                        label params.USE_ONDEMAND ? 'min-bullseye-x64-ondemand' : 'min-bullseye-x64'
-                    }
-                    steps{
-                        setup_debian_package_tests()
-                        run_package_tests(GIT_BRANCH, TESTS, INSTALL_REPO, TARBALL)
-                    }
-                }
                 stage('Debian 12 Bookworm - AMD64') {
                     agent {
                         label params.USE_ONDEMAND ? 'min-bookworm-x64-ondemand' : 'min-bookworm-x64'

--- a/pmm/v3/pmm3-package-testing-arm64.groovy
+++ b/pmm/v3/pmm3-package-testing-arm64.groovy
@@ -234,15 +234,6 @@ pipeline {
                         run_package_tests(GIT_BRANCH, TESTS, INSTALL_REPO, TARBALL)
                     }
                 }
-                stage('Debian 11 Bullseye - ARM64') {
-                    agent {
-                        label params.USE_ONDEMAND ? 'min-bullseye-arm64-ondemand' : 'min-bullseye-arm64'
-                    }
-                    steps{
-                        setup_debian_package_tests()
-                        run_package_tests(GIT_BRANCH, TESTS, INSTALL_REPO, TARBALL)
-                    }
-                }
                 stage('Debian 12 Bookworm - ARM64') {
                     agent {
                         label params.USE_ONDEMAND ? 'min-bookworm-arm64-ondemand' : 'min-bookworm-arm64'


### PR DESCRIPTION
PMM-15460 Remove Debian 11 Bullseye as it is already EOL.

Debian 11 LTS ended 31 Aug 2026 (https://www.debian.org/News/2026/20260831). The bullseye-security pool is being pruned while its index stays frozen, so apt 404s mid-install and the Bullseye deb stage fails, taking the other five deb branches with it via parallelsAlwaysFailFast(). Red since 2026-09-04.

Removes the Bullseye deb stage from pmm3-client-autobuild-{arm,amd} and the Debian 11 stage from pmm3-package-testing-{arm64,amd64}.