### PR TITLE
PMM-15334 Use a ROSA service account instead of the offline token in the PMM HA cluster jobs.

### DIFF
--- a/pmm/v3/pmm3-ha-rosa-cleanup.groovy
+++ b/pmm/v3/pmm3-ha-rosa-cleanup.groovy
@@ -39,7 +39,9 @@ pipeline {
     stages {
         stage('Install Tools') {
             steps {
-                withCredentials([string(credentialsId: 'REDHAT_OFFLINE_TOKEN', variable: 'ROSA_TOKEN')]) {
+                withCredentials([usernamePassword(credentialsId: 'ROSA_SERVICE_ACCOUNT',
+                                                 usernameVariable: 'ROSA_CLIENT_ID',
+                                                 passwordVariable: 'ROSA_CLIENT_SECRET')]) {
                     sh '''
                         mkdir -p $HOME/.local/bin
                         export PATH="$HOME/.local/bin:$PATH"
@@ -55,7 +57,7 @@ pipeline {
                         rosa version
 
                         # Login once for the entire pipeline
-                        rosa login --token="${ROSA_TOKEN}"
+                        rosa login --client-id="${ROSA_CLIENT_ID}" --client-secret="${ROSA_CLIENT_SECRET}"
                     '''
                 }
             }

--- a/pmm/v3/pmm3-ha-rosa-scale.groovy
+++ b/pmm/v3/pmm3-ha-rosa-scale.groovy
@@ -33,7 +33,9 @@ pipeline {
     stages {
         stage('Install Tools') {
             steps {
-                withCredentials([string(credentialsId: 'REDHAT_OFFLINE_TOKEN', variable: 'ROSA_TOKEN')]) {
+                withCredentials([usernamePassword(credentialsId: 'ROSA_SERVICE_ACCOUNT',
+                                                 usernameVariable: 'ROSA_CLIENT_ID',
+                                                 passwordVariable: 'ROSA_CLIENT_SECRET')]) {
                     sh '''
                         mkdir -p $HOME/.local/bin
 
@@ -51,7 +53,7 @@ pipeline {
                             rm -f oc.tar.gz
                         fi
 
-                        rosa login --token="${ROSA_TOKEN}"
+                        rosa login --client-id="${ROSA_CLIENT_ID}" --client-secret="${ROSA_CLIENT_SECRET}"
                     '''
                 }
             }

--- a/pmm/v3/pmm3-ha-rosa.groovy
+++ b/pmm/v3/pmm3-ha-rosa.groovy
@@ -68,12 +68,14 @@ EOF
 
 def cleanupCluster() {
     withCredentials([aws(credentialsId: 'pmm-staging-slave'),
-                     string(credentialsId: 'REDHAT_OFFLINE_TOKEN', variable: 'ROSA_TOKEN')]) {
+                     usernamePassword(credentialsId: 'ROSA_SERVICE_ACCOUNT',
+                                      usernameVariable: 'ROSA_CLIENT_ID',
+                                      passwordVariable: 'ROSA_CLIENT_SECRET')]) {
         sh '''
             export AWS_RETRY_MODE=adaptive
             export AWS_MAX_ATTEMPTS=10
 
-            rosa login --token="${ROSA_TOKEN}"
+            rosa login --client-id="${ROSA_CLIENT_ID}" --client-secret="${ROSA_CLIENT_SECRET}"
 
             # Read before the delete below, while the cluster still exists. Empty if it never did.
             CLUSTER_ID=$(rosa describe cluster --cluster="${CLUSTER_NAME}" --region="${REGION}" \
@@ -253,7 +255,9 @@ pipeline {
                     // via buildVariables to any caller using build job: 'pmm3-ha-rosa'.
                     env.CLUSTER_NAME = env.CLUSTER_NAME
                 }
-                withCredentials([string(credentialsId: 'REDHAT_OFFLINE_TOKEN', variable: 'ROSA_TOKEN')]) {
+                withCredentials([usernamePassword(credentialsId: 'ROSA_SERVICE_ACCOUNT',
+                                                 usernameVariable: 'ROSA_CLIENT_ID',
+                                                 passwordVariable: 'ROSA_CLIENT_SECRET')]) {
                     sh '''
                         mkdir -p $HOME/.local/bin
 
@@ -275,7 +279,7 @@ pipeline {
                         oc version --client
                         
                         # Login once for the entire pipeline
-                        rosa login --token="${ROSA_TOKEN}"
+                        rosa login --client-id="${ROSA_CLIENT_ID}" --client-secret="${ROSA_CLIENT_SECRET}"
                     '''
                 }
             }
@@ -513,6 +517,7 @@ pipeline {
                             --version "${RESOLVED_VERSION}" \
                             --hosted-cp \
                             --sts \
+                            --billing-account "${AWS_ACCOUNT_ID}" \
                             --role-arn "arn:aws:iam::${AWS_ACCOUNT_ID}:role/ManagedOpenShift-HCP-ROSA-Installer-Role" \
                             --support-role-arn "arn:aws:iam::${AWS_ACCOUNT_ID}:role/ManagedOpenShift-HCP-ROSA-Support-Role" \
                             --worker-iam-role "arn:aws:iam::${AWS_ACCOUNT_ID}:role/ManagedOpenShift-HCP-ROSA-Worker-Role" \


### PR DESCRIPTION
Red Hat is retiring the offline token used by `rosa login`, so the PMM HA cluster jobs now authenticate with a ROSA service account instead.

Requires the `ROSA_SERVICE_ACCOUNT` username/password credential in Jenkins.

Tested in [pmm3-ha-rosa #194](https://pmm.cd.percona.com/job/pmm3-ha-rosa/194/): login and cluster creation both succeeded (`AWS Billing Account: 119175775298`, `State: ready`).