### PR TITLE
PS-11259: Stop arm64 package-test AMI bakes failing on AZ capacity

### DIFF
--- a/ppg/packer/README.md
+++ b/ppg/packer/README.md
@@ -36,7 +36,11 @@ bootstrap/re-image machinery.
 So we bake our own, on a schedule, in the CI build account (eu-central-1). The
 same Packer templates + scripts run whether driven locally (`justfile`) or by the
 GitHub Actions workflow. Builds connect over AWS Session Manager (no inbound SSH)
-and authenticate via GitHub OIDC (no static keys).
+and authenticate via GitHub OIDC (no static keys). Builders launch in a random
+default-VPC subnet across the region's AZs (`t3.large` x86_64, `m7g.large`
+arm64). Packer picks the subnet once per build and does not reselect on a
+capacity error, so this lowers the odds that one capacity-constrained AZ takes
+every lane, it does not guarantee failover. Set `-var subnet_id=...` to pin one.
 
 ## Build paths
 

--- a/ppg/packer/bootstrap/finalize-ol10.pkr.hcl
+++ b/ppg/packer/bootstrap/finalize-ol10.pkr.hcl
@@ -31,8 +31,9 @@ variable "region" {
   default = "eu-central-1"
 }
 variable "subnet_id" {
-  type    = string
-  default = "subnet-068170595951ab3a9"
+  type        = string
+  default     = ""
+  description = "Pin the builder to one subnet. Empty (default) spreads launches across the default VPC's per-AZ subnets (see subnet_filter)."
 }
 variable "builder_instance_profile" {
   type    = string
@@ -52,7 +53,7 @@ variable "env" {
 }
 
 locals {
-  instance_type  = var.arch == "arm64" ? "t4g.large" : "t3.large"
+  instance_type  = var.arch == "arm64" ? "m7g.large" : "t3.large"
   ssm_arch       = var.arch == "arm64" ? "arm64" : "amd64"
   ts             = formatdate("YYYYMMDD-hhmmss", timestamp())
   candidate_role = var.env == "test" ? "ppg-test-candidate" : "ppg-ol10-candidate"
@@ -79,9 +80,16 @@ source "amazon-ebs" "finalize" {
   iam_instance_profile        = var.builder_instance_profile
   skip_profile_validation     = true
   user_data                   = local.ssm_bootstrap
-  subnet_id                   = var.subnet_id
   associate_public_ip_address = true
   deprecate_at                = timeadd(timestamp(), "840h")
+  # Same multi-AZ placement as refresh.pkr.hcl (subnet_id overrides the filter).
+  subnet_id = var.subnet_id
+  subnet_filter {
+    filters = {
+      "default-for-az" = "true"
+    }
+    random = true
+  }
 
   security_group_filter {
     filters = {

--- a/ppg/packer/justfile
+++ b/ppg/packer/justfile
@@ -58,7 +58,13 @@ _bucket:
 
 # map arch -> "<uname-arch> <instance-type>" (single source for the arch dimension)
 _arch-meta arch:
-    @[ "{{arch}}" = "arm64" ] && echo "aarch64 t4g.large" || echo "x86_64 t3.large"
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [[ "{{arch}}" == "arm64" ]]; then
+      echo "aarch64 m7g.large"
+    else
+      echo "x86_64 t3.large"
+    fi
 
 # tag an AMI with a role (promotion / retag), retried; a transient create-tags
 # failure must never leave a smoke-passed AMI unpromoted or trigger a deregister.

--- a/ppg/packer/refresh.pkr.hcl
+++ b/ppg/packer/refresh.pkr.hcl
@@ -36,8 +36,9 @@ variable "region" {
 }
 
 variable "subnet_id" {
-  type    = string
-  default = "subnet-068170595951ab3a9" # default-VPC public subnet, eu-central-1a
+  type        = string
+  default     = ""
+  description = "Pin the builder to one subnet. Empty (default) spreads launches across the default VPC's per-AZ subnets (see subnet_filter)."
 }
 
 variable "os_major" {
@@ -103,7 +104,10 @@ variable "env" {
 }
 
 locals {
-  instance_type    = var.arch == "arm64" ? "t4g.large" : "t3.large"
+  # m7g.large rather than t4g.large: the burstable Graviton pool ran dry in one
+  # AZ for weeks (InsufficientInstanceCapacity) while m7g launched in both
+  # default-VPC AZs when probed. Same 2 vCPU / 8 GiB.
+  instance_type    = var.arch == "arm64" ? "m7g.large" : "t3.large"
   uname_arch       = var.arch == "arm64" ? "aarch64" : "x86_64"
   ssm_arch         = var.arch == "arm64" ? "arm64" : "amd64"
   root_volume_size = var.volume_size
@@ -204,7 +208,17 @@ source "amazon-ebs" "el" {
     include_deprecated = var.seed # Rocky 8's official images are past their AWS DeprecationTime
   }
 
-  subnet_id                   = var.subnet_id
+  # Spread builders across the default VPC's per-AZ subnets instead of pinning
+  # one AZ. The pick happens once per build (no reselect on a capacity error),
+  # so one dry pool no longer takes every lane with certainty. A non-empty
+  # subnet_id overrides the filter.
+  subnet_id = var.subnet_id
+  subnet_filter {
+    filters = {
+      "default-for-az" = "true"
+    }
+    random = true
+  }
   associate_public_ip_address = true
 
   # Pre-created no-ingress SG (terraform-managed, egress-only). Supplying a SG

--- a/ppg/packer/reimage/reimage-ol10.pkr.hcl
+++ b/ppg/packer/reimage/reimage-ol10.pkr.hcl
@@ -23,8 +23,9 @@ variable "region" {
   default = "eu-central-1"
 }
 variable "subnet_id" {
-  type    = string
-  default = "subnet-068170595951ab3a9"
+  type        = string
+  default     = ""
+  description = "Pin the builder to one subnet. Empty (default) spreads launches across the default VPC's per-AZ subnets (see subnet_filter)."
 }
 variable "builder_instance_profile" {
   type    = string
@@ -44,7 +45,7 @@ variable "volume_size" {
 }
 
 locals {
-  instance_type  = var.arch == "arm64" ? "t4g.large" : "t3.large"
+  instance_type  = var.arch == "arm64" ? "m7g.large" : "t3.large"
   boot_mode      = var.arch == "arm64" ? "uefi" : "legacy-bios"
   ts             = formatdate("YYYYMMDD-hhmmss", timestamp())
   candidate_role = var.env == "test" ? "ppg-reimage-test-candidate" : "ppg-reimage-candidate"
@@ -67,9 +68,16 @@ source "amazon-ebssurrogate" "reimage" {
   ssh_clear_authorized_keys   = true
   iam_instance_profile        = var.builder_instance_profile
   skip_profile_validation     = true
-  subnet_id                   = var.subnet_id
   associate_public_ip_address = true
   deprecate_at                = timeadd(timestamp(), "168h") # a candidate; verify promotes it within hours
+  # Same multi-AZ placement as refresh.pkr.hcl (subnet_id overrides the filter).
+  subnet_id = var.subnet_id
+  subnet_filter {
+    filters = {
+      "default-for-az" = "true"
+    }
+    random = true
+  }
 
   # Source = the booted, verified full-size prebase (role=ppg-ol10-prebase) for THIS arch.
   source_ami_filter {

--- a/ppg/packer/smoke/smoke.pkr.hcl
+++ b/ppg/packer/smoke/smoke.pkr.hcl
@@ -36,8 +36,9 @@ variable "region" {
   default = "eu-central-1"
 }
 variable "subnet_id" {
-  type    = string
-  default = "subnet-068170595951ab3a9"
+  type        = string
+  default     = ""
+  description = "Pin the builder to one subnet. Empty (default) spreads launches across the default VPC's per-AZ subnets (see subnet_filter)."
 }
 variable "builder_instance_profile" {
   type    = string
@@ -49,7 +50,7 @@ variable "builder_security_group_name" {
 }
 
 locals {
-  instance_type = var.arch == "arm64" ? "t4g.large" : "t3.large"
+  instance_type = var.arch == "arm64" ? "m7g.large" : "t3.large"
   uname_arch    = var.arch == "arm64" ? "aarch64" : "x86_64"
   # Identity via /etc/os-release ID (release-file names cannot tell EL distros
   # apart once more are added: every clone ships /etc/redhat-release).
@@ -73,8 +74,15 @@ source "amazon-ebs" "smoke" {
   ssh_timeout                 = "10m"
   iam_instance_profile        = var.builder_instance_profile
   skip_profile_validation     = true # OIDC role has PassRole only, not iam:GetInstanceProfile
-  subnet_id                   = var.subnet_id
   associate_public_ip_address = true
+  # Same multi-AZ placement as refresh.pkr.hcl (subnet_id overrides the filter).
+  subnet_id = var.subnet_id
+  subnet_filter {
+    filters = {
+      "default-for-az" = "true"
+    }
+    random = true
+  }
   # Same pre-created no-ingress SG as the builder (disables Packer's temp SG).
   security_group_filter {
     filters = {


### PR DESCRIPTION
**Bug**
- Every weekly factory run for four weeks lost arm64 lanes: `t4g.large` has no capacity in eu-central-1a and every builder was pinned to that one subnet. The latest run failed 5 of 6 arm64 lanes, so the arm64 OL and Rocky pins keep aging.

**Fix**
- Builders spread across the default VPC's per-AZ subnets through `subnet_filter` (one random pick per build, no reselect on a capacity error, so one dry AZ no longer takes every lane with certainty), with `subnet_id` kept as an explicit override.
- The arm64 builders run on `m7g.large` (same 2 vCPU and 8 GiB, a non-burstable pool that launched in both default-VPC AZs when probed) in the refresh, smoke, reimage and bootstrap templates.

**Tickets**
- [PS-11259](https://perconadev.atlassian.net/browse/PS-11259) (this), [PKG-1342](https://perconadev.atlassian.net/browse/PKG-1342) (Rocky epic), [PG-2353](https://perconadev.atlassian.net/browse/PG-2353) (factory origin)


[PS-11259]: https://perconadev.atlassian.net/browse/PS-11259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-1342]: https://perconadev.atlassian.net/browse/PKG-1342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PG-2353]: https://perconadev.atlassian.net/browse/PG-2353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ