### PR TITLE
PMM-15197 Cover the remaining RC executors with on-demand

### DIFF
--- a/pmm/aws-staging-stop.groovy
+++ b/pmm/aws-staging-stop.groovy
@@ -1,8 +1,12 @@
 pipeline {
     agent {
-        label 'cli'
+        label params.USE_ONDEMAND ? 'cli-ondemand' : 'cli'
     }
     parameters {
+        booleanParam(
+            defaultValue: false,
+            description: 'Use on-demand instances instead of spot (for RC/Release testing)',
+            name: 'USE_ONDEMAND')
         string(
             defaultValue: 'list-all-vms',
             description: 'Name or IP of VM to stop. Also you can set "list-all-vms" value, in this case list of current VMs will be shown and pipeline will ask you VM again.',

--- a/pmm/openshift/openshift-cluster-create.yml
+++ b/pmm/openshift/openshift-cluster-create.yml
@@ -102,6 +102,11 @@
                     - "c5.2xlarge"
                 description: "EC2 instance type for master nodes (x86_64)"
 
+          - bool:
+                name: USE_ONDEMAND
+                default: false
+                description: "Use on-demand instances instead of spot (for RC/Release testing)"
+
           # === PMM Configuration ===
           - bool:
                 name: DEPLOY_PMM

--- a/pmm/openshift/openshift-cluster-destroy.yml
+++ b/pmm/openshift/openshift-cluster-destroy.yml
@@ -24,6 +24,10 @@
             - 'us-east-2'
           description: 'AWS region where the cluster is deployed'
       - bool:
+          name: USE_ONDEMAND
+          default: false
+          description: 'Use on-demand instances instead of spot (for RC/Release testing)'
+      - bool:
           name: DRY_RUN
           default: false
           description: 'Perform a dry run without actually destroying resources'

--- a/pmm/openshift/openshift_cluster_create.groovy
+++ b/pmm/openshift/openshift_cluster_create.groovy
@@ -145,7 +145,7 @@ def archiveClusterLogs() {
 
 pipeline {
     agent {
-        label 'agent-amd64'
+        label params.USE_ONDEMAND ? 'agent-amd64-ondemand' : 'agent-amd64'
     }
 
     environment {

--- a/pmm/openshift/openshift_cluster_destroy.groovy
+++ b/pmm/openshift/openshift_cluster_destroy.groovy
@@ -6,7 +6,7 @@ import groovy.json.JsonSlurper
 
 pipeline {
     agent {
-        label 'agent-amd64'
+        label params.USE_ONDEMAND ? 'agent-amd64-ondemand' : 'agent-amd64'
     }
 
     environment {

--- a/pmm/v3/pmm3-ami-staging-start.groovy
+++ b/pmm/v3/pmm3-ami-staging-start.groovy
@@ -3,9 +3,13 @@ String OWNER_SLACK = ''
 
 pipeline {
     agent {
-        label 'cli'
+        label params.USE_ONDEMAND ? 'cli-ondemand' : 'cli'
     }
     parameters {
+        booleanParam(
+            defaultValue: false,
+            description: 'Use on-demand instances instead of spot (for RC/Release testing)',
+            name: 'USE_ONDEMAND')
         string(
             defaultValue: '',
             description: 'Commit hash for the branch',

--- a/pmm/v3/pmm3-ami-staging-stop.groovy
+++ b/pmm/v3/pmm3-ami-staging-stop.groovy
@@ -3,9 +3,13 @@ String OWNER_SLACK = ''
 
 pipeline {
     agent {
-        label 'cli'
+        label params.USE_ONDEMAND ? 'cli-ondemand' : 'cli'
     }
     parameters {
+        booleanParam(
+            defaultValue: false,
+            description: 'Use on-demand instances instead of spot (for RC/Release testing)',
+            name: 'USE_ONDEMAND')
         string(
             defaultValue: '',
             description: 'AMI Instance ID',

--- a/pmm/v3/pmm3-deploy-services.groovy
+++ b/pmm/v3/pmm3-deploy-services.groovy
@@ -107,6 +107,8 @@ pipeline {
   agent none
 
   parameters {
+    booleanParam(name: 'USE_ONDEMAND', defaultValue: false,
+                 description: 'Use on-demand instances instead of spot (for RC/Release testing).')
     // --- SERVER CONFIGURATION ---
     choice(name: 'SERVER_TYPE', choices: ['docker', 'ami', 'helm', 'ha'], description: 'Select PMM Server installation type: docker (Basic Setup), ami (AWS EC2 AMI), helm (OpenShift), ha (High Availability).')
 
@@ -164,7 +166,7 @@ pipeline {
 
   stages {
     stage('Build Environment') {
-      agent { label 'min-noble-x64' }
+      agent { label params.USE_ONDEMAND ? 'min-noble-x64-ondemand' : 'min-noble-x64' }
 
       stages {
         stage('Prepare') {

--- a/pmm/v3/pmm3-deploy-services.groovy
+++ b/pmm/v3/pmm3-deploy-services.groovy
@@ -21,6 +21,7 @@ Map<String, String> clientVMs = [:]
 
 void runStagingServer(String DOCKER_VERSION, CLIENT_VERSION, CLIENTS, CLIENT_INSTANCE, SERVER_IP, PMM_QA_GIT_BRANCH, ADMIN_PASSWORD = "admin", SSH_KEY = "") {
     stagingJob = build job: 'pmm3-aws-staging-start', parameters: [
+        booleanParam(name: 'USE_ONDEMAND', value: params.USE_ONDEMAND),
         string(name: 'DOCKER_VERSION', value: DOCKER_VERSION),
         string(name: 'CLIENT_VERSION', value: CLIENT_VERSION),
         string(name: 'CLIENTS', value: CLIENTS),
@@ -488,6 +489,7 @@ void runClientWithRetry(String clientsString, String filenameLabel) {
         while (count < retries && !success) {
             count++
             def b = build job: 'pmm3-aws-staging-start', propagate: false, parameters: [
+                booleanParam(name: 'USE_ONDEMAND', value: params.USE_ONDEMAND),
                 string(name: 'DOCKER_VERSION', value: params.DOCKER_VERSION),
                 string(name: 'CLIENT_VERSION', value: params.CLIENT_VERSION),
                 string(name: 'CLIENT_INSTANCE', value: 'yes'),

--- a/pmm/v3/pmm3-deploy-services.groovy
+++ b/pmm/v3/pmm3-deploy-services.groovy
@@ -41,6 +41,7 @@ void runStagingServer(String DOCKER_VERSION, CLIENT_VERSION, CLIENTS, CLIENT_INS
 
 void runAMIStagingStart(String AMI_ID) {
     amiStagingJob = build job: 'pmm3-ami-staging-start', parameters: [
+        booleanParam(name: 'USE_ONDEMAND', value: params.USE_ONDEMAND),
         string(name: 'AMI_ID', value: AMI_ID)
     ]
     env.AMI_INSTANCE_ID = amiStagingJob.buildVariables.INSTANCE_ID
@@ -56,6 +57,7 @@ def runOpenshiftClusterCreate(String OPENSHIFT_VERSION, DOCKER_VERSION, ADMIN_PA
     def pmmImageTag = DOCKER_VERSION.split(":")[1]
 
     clusterCreateJob = build job: 'openshift-cluster-create', parameters: [
+        booleanParam(name: 'USE_ONDEMAND', value: params.USE_ONDEMAND),
         string(name: 'CLUSTER_NAME', value: clusterName),
         string(name: 'OPENSHIFT_VERSION', value: OPENSHIFT_VERSION),
         booleanParam(name: 'DEPLOY_PMM', value: true),
@@ -78,6 +80,7 @@ def runHAClusterCreate(String K8S_VERSION, DOCKER_VERSION, HELM_CHART_BRANCH, AD
     def pmmImageTag = DOCKER_VERSION.split(":")[1]
 
     clusterCreateJob = build job: 'pmm3-ha-eks', parameters: [
+        booleanParam(name: 'USE_ONDEMAND', value: params.USE_ONDEMAND),
         string(name: 'K8S_VERSION', value: K8S_VERSION),
         string(name: 'HELM_CHART_BRANCH', value: HELM_CHART_BRANCH),
         string(name: 'PMM_IMAGE_TAG', value: pmmImageTag),
@@ -449,22 +452,24 @@ pipeline {
 void cleanupResources(String slackStatus = 'aborted/failed/cleaned up') {
     // 1. Clean Server based on Type
     if (env.SERVER_TYPE == "ami" && env.AMI_INSTANCE_ID) {
-         build job: 'pmm3-ami-staging-stop', parameters: [ string(name: 'AMI_ID', value: env.AMI_INSTANCE_ID) ]
+         build job: 'pmm3-ami-staging-stop', parameters: [ booleanParam(name: 'USE_ONDEMAND', value: params.USE_ONDEMAND), string(name: 'AMI_ID', value: env.AMI_INSTANCE_ID) ]
     }
     else if (env.SERVER_TYPE == "helm" && env.FINAL_CLUSTER_NAME) {
          build job: 'openshift-cluster-destroy', parameters: [
+            booleanParam(name: 'USE_ONDEMAND', value: params.USE_ONDEMAND),
             string(name: 'CLUSTER_NAME', value: env.FINAL_CLUSTER_NAME),
             string(name: 'DESTROY_REASON', value: 'testing-complete')
          ]
     }
     else if (env.SERVER_TYPE == "ha" && env.CLUSTER_NAME) {
          build job: 'pmm3-ha-eks-cleanup', parameters: [
+            booleanParam(name: 'USE_ONDEMAND', value: params.USE_ONDEMAND),
             string(name: 'ACTION', value: 'DELETE_CLUSTER'),
             string(name: 'CLUSTER_NAME', value: env.CLUSTER_NAME)
          ]
     }
     else if (env.VM_NAME) {
-         build job: 'aws-staging-stop', parameters: [ string(name: 'VM', value: env.VM_NAME) ]
+         build job: 'aws-staging-stop', parameters: [ booleanParam(name: 'USE_ONDEMAND', value: params.USE_ONDEMAND), string(name: 'VM', value: env.VM_NAME) ]
     }
 
     // 2. Clean Clients from the in-memory map populated by runClientWithRetry.
@@ -472,7 +477,7 @@ void cleanupResources(String slackStatus = 'aborted/failed/cleaned up') {
     // agent is gone before this post block runs.
     clientVMs.each { label, ip ->
         echo "Stopping Client VM (${label}) with IP ${ip}"
-        build job: 'aws-staging-stop', parameters: [ string(name: 'VM', value: ip) ]
+        build job: 'aws-staging-stop', parameters: [ booleanParam(name: 'USE_ONDEMAND', value: params.USE_ONDEMAND), string(name: 'VM', value: ip) ]
     }
 
     if (env.SLACK_DM) {

--- a/pmm/v3/pmm3-ha-eks-cleanup.groovy
+++ b/pmm/v3/pmm3-ha-eks-cleanup.groovy
@@ -1,6 +1,6 @@
 pipeline {
     agent {
-        label 'agent-amd64'
+        label params.USE_ONDEMAND ? 'agent-amd64-ondemand' : 'agent-amd64'
     }
 
     triggers {
@@ -8,6 +8,10 @@ pipeline {
     }
 
     parameters {
+        booleanParam(
+            defaultValue: false,
+            description: 'Use on-demand instances instead of spot (for RC/Release testing)',
+            name: 'USE_ONDEMAND')
         choice(
             name: 'ACTION',
             choices: ['LIST_ONLY', 'DELETE_CLUSTER', 'DELETE_ALL'],

--- a/pmm/v3/pmm3-ha-eks.groovy
+++ b/pmm/v3/pmm3-ha-eks.groovy
@@ -87,7 +87,7 @@ def cleanupCluster() {
 
 pipeline {
     agent {
-        label 'agent-amd64'
+        label params.USE_ONDEMAND ? 'agent-amd64-ondemand' : 'agent-amd64'
     }
 
     options {
@@ -96,6 +96,10 @@ pipeline {
     }
 
     parameters {
+        booleanParam(
+            defaultValue: false,
+            description: 'Use on-demand instances instead of spot (for RC/Release testing)',
+            name: 'USE_ONDEMAND')
         choice(
             name: 'K8S_VERSION',
             choices: ['1.35', '1.34', '1.33'],

--- a/pmm/v3/pmm3-openshift-helm-tests.groovy
+++ b/pmm/v3/pmm3-openshift-helm-tests.groovy
@@ -7,6 +7,7 @@ def runOpenshiftClusterCreate(String OPENSHIFT_VERSION) {
     def clusterName = "helm-test-${env.BUILD_NUMBER}"
 
     clusterCreateJob = build job: 'openshift-cluster-create', parameters: [
+        booleanParam(name: 'USE_ONDEMAND', value: params.USE_ONDEMAND),
         string(name: 'CLUSTER_NAME', value: clusterName),
         string(name: 'OPENSHIFT_VERSION', value: OPENSHIFT_VERSION),
         booleanParam(name: 'DEPLOY_PMM', value: false),
@@ -23,6 +24,7 @@ def runOpenshiftClusterCreate(String OPENSHIFT_VERSION) {
 
 def destroyOpenshift(CLUSTER_NAME) {
     build job: 'openshift-cluster-destroy', parameters: [
+        booleanParam(name: 'USE_ONDEMAND', value: params.USE_ONDEMAND),
         string(name: 'CLUSTER_NAME', value: CLUSTER_NAME),
         string(name: 'DESTROY_REASON', value: 'testing-complete'),
     ]

--- a/pmm/v3/pmm3-openshift-helm-tests.groovy
+++ b/pmm/v3/pmm3-openshift-helm-tests.groovy
@@ -30,9 +30,13 @@ def destroyOpenshift(CLUSTER_NAME) {
 
 pipeline {
     agent {
-        label 'min-noble-x64'
+        label params.USE_ONDEMAND ? 'min-noble-x64-ondemand' : 'min-noble-x64'
     }
     parameters {
+        booleanParam(
+            defaultValue: false,
+            description: 'Use on-demand instances instead of spot (for RC/Release testing)',
+            name: 'USE_ONDEMAND')
         string(
             defaultValue: 'main',
             description: 'Tag/Branch for pmm-qa repository',

--- a/pmm/v3/pmm3-package-testing-amd64.groovy
+++ b/pmm/v3/pmm3-package-testing-amd64.groovy
@@ -24,6 +24,7 @@ void runStaging(String DOCKER_VERSION, ADMIN_PASSWORD, CLIENTS, boolean USE_ONDE
 
 void destroyStaging(IP) {
     build job: 'aws-staging-stop', parameters: [
+        booleanParam(name: 'USE_ONDEMAND', value: params.USE_ONDEMAND),
         string(name: 'VM', value: IP),
     ]
 }

--- a/pmm/v3/pmm3-package-testing-arm64.groovy
+++ b/pmm/v3/pmm3-package-testing-arm64.groovy
@@ -24,6 +24,7 @@ void runStaging(String DOCKER_VERSION, ADMIN_PASSWORD, CLIENTS, boolean USE_ONDE
 
 void destroyStaging(IP) {
     build job: 'aws-staging-stop', parameters: [
+        booleanParam(name: 'USE_ONDEMAND', value: params.USE_ONDEMAND),
         string(name: 'VM', value: IP),
     ]
 }

--- a/pmm/v3/pmm3-rc-testing.groovy
+++ b/pmm/v3/pmm3-rc-testing.groovy
@@ -135,218 +135,297 @@ pipeline {
         }
 
         stage('Trigger RC suites') {
-            steps {
-                script {
-                    def branches = [:]
-
-                    branches['nightly (ami)'] = {
-                        stage('nightly (ami)') {
-                            triggerNightlyGhaRc('pmm3-ui-tests-nightly-gha (ami)', [
-                                SERVER_TYPE: 'ami',
-                            ])
+            parallel {
+                stage('Lane 1') {
+                    stages {
+                        stage('nightly (AMI)') {
+                            steps {
+                                script {
+                                    triggerNightlyGhaRc('pmm3-ui-tests-nightly-gha (ami)', [
+                                        SERVER_TYPE: 'ami',
+                                    ])
+                                }
+                            }
                         }
-                    }
-                    branches['nightly (docker)'] = {
-                        stage('nightly (docker)') {
-                            triggerNightlyGhaRc('pmm3-ui-tests-nightly-gha (docker)')
+                        stage('nightly (compat #1)') {
+                            when { expression { env.IS_PATCH_RC != 'true' } }
+                            steps {
+                                script {
+                                    def tags = readFile('compat-tags.txt').trim().split('\n').collect { it.trim() }.findAll { it }
+                                    def ver = tags[0]
+                                    triggerNightlyGhaRc("pmm3-ui-tests-nightly-gha (compat ${ver})", [
+                                        CLIENT_VERSION: ver,
+                                    ])
+                                }
+                            }
                         }
-                    }
-                    branches['nightly (docker, arm64 server)'] = {
-                        stage('nightly (docker, arm64 server)') {
-                            triggerNightlyGhaRc('pmm3-ui-tests-nightly-gha (docker, arm64)', [
-                                SERVER_ARCH: 'arm64',
-                            ])
+                        stage('nightly (compat #2)') {
+                            when { expression { env.IS_PATCH_RC != 'true' } }
+                            steps {
+                                script {
+                                    def tags = readFile('compat-tags.txt').trim().split('\n').collect { it.trim() }.findAll { it }
+                                    def ver = tags[1]
+                                    triggerNightlyGhaRc("pmm3-ui-tests-nightly-gha (compat ${ver})", [
+                                        CLIENT_VERSION: ver,
+                                    ])
+                                }
+                            }
                         }
-                    }
-                    branches['nightly (helm)'] = {
-                        stage('nightly (helm)') {
-                            triggerNightlyGhaRc('pmm3-ui-tests-nightly-gha (helm)', [
-                                SERVER_TYPE    : 'helm',
-                                ADMIN_PASSWORD : 'admin1',
-                            ])
+                        stage('nightly (compat #3)') {
+                            when { expression { env.IS_PATCH_RC != 'true' } }
+                            steps {
+                                script {
+                                    def tags = readFile('compat-tags.txt').trim().split('\n').collect { it.trim() }.findAll { it }
+                                    def ver = tags[2]
+                                    triggerNightlyGhaRc("pmm3-ui-tests-nightly-gha (compat ${ver})", [
+                                        CLIENT_VERSION: ver,
+                                    ])
+                                }
+                            }
                         }
-                    }
-                    branches['nightly (ha)'] = {
-                        stage('nightly (ha)') {
-                            triggerNightlyGhaRc('pmm3-ui-tests-nightly-gha (ha)', [
-                                SERVER_TYPE    : 'ha',
-                                ADMIN_PASSWORD : 'admin1',
-                            ])
+                        stage('nightly (compat #4)') {
+                            when { expression { env.IS_PATCH_RC != 'true' } }
+                            steps {
+                                script {
+                                    def tags = readFile('compat-tags.txt').trim().split('\n').collect { it.trim() }.findAll { it }
+                                    def ver = tags[3]
+                                    triggerNightlyGhaRc("pmm3-ui-tests-nightly-gha (compat ${ver})", [
+                                        CLIENT_VERSION: ver,
+                                    ])
+                                }
+                            }
                         }
-                    }
-
-                    if (env.IS_PATCH_RC != 'true') {
-                        def compatTags = readFile('compat-tags.txt').trim().split('\n').collect { it.trim() }.findAll { it }
-                        compatTags.each { tag ->
-                            branches["nightly (compat ${tag})"] = {
-                                stage("nightly (compat ${tag})") {
-                                    triggerNightlyGhaRc("pmm3-ui-tests-nightly-gha (compat ${tag})", [
-                                        CLIENT_VERSION: tag,
+                        stage('nightly (compat #5)') {
+                            when { expression { env.IS_PATCH_RC != 'true' } }
+                            steps {
+                                script {
+                                    def tags = readFile('compat-tags.txt').trim().split('\n').collect { it.trim() }.findAll { it }
+                                    def ver = tags[4]
+                                    triggerNightlyGhaRc("pmm3-ui-tests-nightly-gha (compat ${ver})", [
+                                        CLIENT_VERSION: ver,
                                     ])
                                 }
                             }
                         }
                     }
+                }
 
-                    branches['nightly (gssapi)'] = {
-                        stage('nightly (gssapi)') {
-                            triggerJenkinsRc('pmm3-ui-tests-nightly-gssapi', 'pmm3-ui-tests-nightly-gssapi', [
-                                string(name: 'PMM_QA_GIT_BRANCH',       value: 'main'),
-                                string(name: 'SERVER_TYPE',             value: 'docker'),
-                                string(name: 'DOCKER_VERSION',          value: env.PMM_SERVER_IMAGE),
-                                string(name: 'CLIENT_VERSION',          value: params.PMM_CLIENT_TARBALL_OL9.trim()),
-                                string(name: 'ENABLE_PULL_MODE',        value: 'no'),
-                                string(name: 'ADMIN_PASSWORD',          value: 'pmm3admin!'),
-                                string(name: 'PSMDB_VERSION',           value: '8.0'),
-                                string(name: 'MODB_VERSION',            value: '8.0'),
-                                booleanParam(name: 'USE_ONDEMAND', value: true),
-                            ])
-                        }
-                    }
-
-                    branches['openshift-helm-tests'] = {
-                        stage('openshift-helm-tests') {
-                            triggerJenkinsRc('openshift-helm-tests', 'openshift-helm-tests', [
-                                string(name: 'PMM_QA_GIT_BRANCH',  value: 'main'),
-                                string(name: 'PMM_CHART_BRANCH',   value: 'latest'),
-                                string(name: 'IMAGE_REPO',         value: env.PMM_SERVER_IMAGE.split(':')[0]),
-                                string(name: 'IMAGE_TAG',          value: env.PMM_SERVER_IMAGE.split(':')[1]),
-                                string(name: 'OPENSHIFT_VERSION',  value: 'latest'),
-                                booleanParam(name: 'USE_ONDEMAND', value: true),
-                            ])
-                        }
-                    }
-
-                    branches['GitHub rc-testing-suite'] = {
-                        stage('GitHub rc-testing-suite') {
-                            try {
-                                def payload = new JsonBuilder([
-                                    ref   : 'main',
-                                    inputs: [
-                                        rc_version             : params.RC_VERSION.trim(),
-                                        pmm_client_tarball_ol8 : params.PMM_CLIENT_TARBALL_OL8.trim(),
-                                        pmm_client_tarball_ol9 : params.PMM_CLIENT_TARBALL_OL9.trim(),
-                                        pmm_qa_branch          : 'main',
-                                        pxc_version            : '8.0',
-                                        pxc_glibc              : '2.35',
-                                        pdpgsql_version        : '17',
-                                        skip_compatibility     : env.IS_PATCH_RC == 'true',
-                                    ],
-                                ]).toString()
-                                writeFile file: 'rc-suite-dispatch.json', text: payload
-                                withCredentials([string(credentialsId: 'GITHUB_API_TOKEN', variable: 'GITHUB_TOKEN')]) {
-                                    sh """
-                                        set -euo pipefail
-                                        curl -fsS -X POST \\
-                                            -H "Accept: application/vnd.github+json" \\
-                                            -H "Authorization: Bearer \${GITHUB_TOKEN}" \\
-                                            -H "X-GitHub-Api-Version: 2022-11-28" \\
-                                            "https://api.github.com/repos/percona/pmm-qa/actions/workflows/rc-testing-suite.yml/dispatches" \\
-                                            --data @rc-suite-dispatch.json
-                                    """
+                stage('Lane 2') {
+                    stages {
+                        stage('nightly (Docker)') {
+                            steps {
+                                script {
+                                    triggerNightlyGhaRc('pmm3-ui-tests-nightly-gha (docker)')
                                 }
-                                slackRcMessage("*Github Release Testing Suite*: https://github.com/percona/pmm-qa/actions/workflows/rc-testing-suite.yml")
-                            } catch (err) {
-                                slackRcMessage("*Github Release Testing Suite* (dispatch failed): ${err.getMessage()}")
+                            }
+                        }
+                        stage('nightly (Helm)') {
+                            steps {
+                                script {
+                                    triggerNightlyGhaRc('pmm3-ui-tests-nightly-gha (helm)', [
+                                        SERVER_TYPE    : 'helm',
+                                        ADMIN_PASSWORD : 'admin1',
+                                    ])
+                                }
+                            }
+                        }
+                        stage('nightly (HA)') {
+                            steps {
+                                script {
+                                    triggerNightlyGhaRc('pmm3-ui-tests-nightly-gha (ha)', [
+                                        SERVER_TYPE    : 'ha',
+                                        ADMIN_PASSWORD : 'admin1',
+                                    ])
+                                }
+                            }
+                        }
+                        stage('nightly (GSSAPI)') {
+                            steps {
+                                script {
+                                    triggerJenkinsRc('pmm3-ui-tests-nightly-gssapi', 'pmm3-ui-tests-nightly-gssapi', [
+                                        string(name: 'PMM_QA_GIT_BRANCH',       value: 'main'),
+                                        string(name: 'SERVER_TYPE',             value: 'docker'),
+                                        string(name: 'DOCKER_VERSION',          value: env.PMM_SERVER_IMAGE),
+                                        string(name: 'CLIENT_VERSION',          value: params.PMM_CLIENT_TARBALL_OL9.trim()),
+                                        string(name: 'ENABLE_PULL_MODE',        value: 'no'),
+                                        string(name: 'ADMIN_PASSWORD',          value: 'pmm3admin!'),
+                                        string(name: 'PSMDB_VERSION',           value: '8.0'),
+                                        string(name: 'MODB_VERSION',            value: '8.0'),
+                                        booleanParam(name: 'USE_ONDEMAND', value: true),
+                                    ])
+                                }
+                            }
+                        }
+                        stage('openshift-helm-tests') {
+                            steps {
+                                script {
+                                    triggerJenkinsRc('openshift-helm-tests', 'openshift-helm-tests', [
+                                        string(name: 'PMM_QA_GIT_BRANCH',  value: 'main'),
+                                        string(name: 'PMM_CHART_BRANCH',   value: 'latest'),
+                                        string(name: 'IMAGE_REPO',         value: env.PMM_SERVER_IMAGE.split(':')[0]),
+                                        string(name: 'IMAGE_TAG',          value: env.PMM_SERVER_IMAGE.split(':')[1]),
+                                        string(name: 'OPENSHIFT_VERSION',  value: 'latest'),
+                                        booleanParam(name: 'USE_ONDEMAND', value: true),
+                                    ])
+                                }
                             }
                         }
                     }
+                }
 
-                    branches['pmm3-ui-tests-matrix'] = {
+                stage('Lane 3') {
+                    stages {
+                        stage('GitHub rc-testing-suite') {
+                            steps {
+                                script {
+                                    try {
+                                        def payload = new JsonBuilder([
+                                            ref   : 'main',
+                                            inputs: [
+                                                rc_version             : params.RC_VERSION.trim(),
+                                                pmm_client_tarball_ol8 : params.PMM_CLIENT_TARBALL_OL8.trim(),
+                                                pmm_client_tarball_ol9 : params.PMM_CLIENT_TARBALL_OL9.trim(),
+                                                pmm_qa_branch          : 'main',
+                                                pxc_version            : '8.0',
+                                                pxc_glibc              : '2.35',
+                                                pdpgsql_version        : '17',
+                                                skip_compatibility     : env.IS_PATCH_RC == 'true',
+                                            ],
+                                        ]).toString()
+                                        writeFile file: 'rc-suite-dispatch.json', text: payload
+                                        withCredentials([string(credentialsId: 'GITHUB_API_TOKEN', variable: 'GITHUB_TOKEN')]) {
+                                            sh """
+                                                set -euo pipefail
+                                                curl -fsS -X POST \\
+                                                    -H "Accept: application/vnd.github+json" \\
+                                                    -H "Authorization: Bearer \${GITHUB_TOKEN}" \\
+                                                    -H "X-GitHub-Api-Version: 2022-11-28" \\
+                                                    "https://api.github.com/repos/percona/pmm-qa/actions/workflows/rc-testing-suite.yml/dispatches" \\
+                                                    --data @rc-suite-dispatch.json
+                                            """
+                                        }
+                                        slackRcMessage("*Github Release Testing Suite*: https://github.com/percona/pmm-qa/actions/workflows/rc-testing-suite.yml")
+                                    } catch (err) {
+                                        slackRcMessage("*Github Release Testing Suite* (dispatch failed): ${err.getMessage()}")
+                                    }
+                                }
+                            }
+                        }
                         stage('pmm3-ui-tests-matrix') {
-                            triggerJenkinsRc('pmm3-ui-tests-matrix', 'pmm3-ui-tests-matrix', [
-                                string(name: 'PMM_QA_GIT_BRANCH', value: 'main'),
-                                string(name: 'GIT_COMMIT_HASH',  value: ''),
-                                string(name: 'DOCKER_VERSION',   value: env.PMM_SERVER_IMAGE),
-                                string(name: 'CLIENT_VERSION',   value: 'pmm3-rc'),
-                                string(name: 'MYSQL_IMAGE',      value: 'percona:5.7'),
-                                string(name: 'POSTGRES_IMAGE',   value: 'perconalab/percona-distribution-postgresql:16.0'),
-                                string(name: 'MONGO_IMAGE',      value: 'percona/percona-server-mongodb:4.4'),
-                                string(name: 'PROXYSQL_IMAGE',   value: 'proxysql/proxysql:2.3.0'),
-                                booleanParam(name: 'USE_ONDEMAND', value: true),
-                            ])
+                            steps {
+                                script {
+                                    triggerJenkinsRc('pmm3-ui-tests-matrix', 'pmm3-ui-tests-matrix', [
+                                        string(name: 'PMM_QA_GIT_BRANCH', value: 'main'),
+                                        string(name: 'GIT_COMMIT_HASH',  value: ''),
+                                        string(name: 'DOCKER_VERSION',   value: env.PMM_SERVER_IMAGE),
+                                        string(name: 'CLIENT_VERSION',   value: 'pmm3-rc'),
+                                        string(name: 'MYSQL_IMAGE',      value: 'percona:5.7'),
+                                        string(name: 'POSTGRES_IMAGE',   value: 'perconalab/percona-distribution-postgresql:16.0'),
+                                        string(name: 'MONGO_IMAGE',      value: 'percona/percona-server-mongodb:4.4'),
+                                        string(name: 'PROXYSQL_IMAGE',   value: 'proxysql/proxysql:2.3.0'),
+                                        booleanParam(name: 'USE_ONDEMAND', value: true),
+                                    ])
+                                }
+                            }
                         }
-                    }
-
-                    branches['pmm3-upgrade-ami-test'] = {
                         stage('pmm3-upgrade-ami-test') {
-                            triggerJenkinsRc('pmm3-upgrade-ami-test', 'pmm3-upgrade-ami-test', [
-                                string(name: 'PMM_QA_GIT_BRANCH',   value: 'main'),
-                                booleanParam(name: 'IS_RC_TESTING', value: true),
-                                booleanParam(name: 'USE_ONDEMAND', value: true),
-                            ])
+                            steps {
+                                script {
+                                    triggerJenkinsRc('pmm3-upgrade-ami-test', 'pmm3-upgrade-ami-test', [
+                                        string(name: 'PMM_QA_GIT_BRANCH',   value: 'main'),
+                                        booleanParam(name: 'IS_RC_TESTING', value: true),
+                                        booleanParam(name: 'USE_ONDEMAND', value: true),
+                                    ])
+                                }
+                            }
                         }
-                    }
-
-                    branches['pmm3-package-testing-matrix'] = {
                         stage('pmm3-package-testing-matrix') {
-                            triggerJenkinsRc('pmm3-package-testing-matrix', 'pmm3-package-testing-matrix', [
-                                string(name: 'GIT_BRANCH',      value: 'main'),
-                                string(name: 'GIT_COMMIT_HASH', value: ''),
-                                string(name: 'DOCKER_VERSION',  value: env.PMM_SERVER_IMAGE),
-                                string(name: 'PMM_VERSION',     value: params.RC_VERSION.trim()),
-                                string(name: 'INSTALL_REPO',    value: 'testing'),
-                                string(name: 'TARBALL',         value: params.PMM_CLIENT_TARBALL.trim()),
-                                string(name: 'METRICS_MODE',    value: 'auto'),
-                                booleanParam(name: 'USE_ONDEMAND', value: true),
-                            ])
+                            steps {
+                                script {
+                                    triggerJenkinsRc('pmm3-package-testing-matrix', 'pmm3-package-testing-matrix', [
+                                        string(name: 'GIT_BRANCH',      value: 'main'),
+                                        string(name: 'GIT_COMMIT_HASH', value: ''),
+                                        string(name: 'DOCKER_VERSION',  value: env.PMM_SERVER_IMAGE),
+                                        string(name: 'PMM_VERSION',     value: params.RC_VERSION.trim()),
+                                        string(name: 'INSTALL_REPO',    value: 'testing'),
+                                        string(name: 'TARBALL',         value: params.PMM_CLIENT_TARBALL.trim()),
+                                        string(name: 'METRICS_MODE',    value: 'auto'),
+                                        booleanParam(name: 'USE_ONDEMAND', value: true),
+                                    ])
+                                }
+                            }
                         }
-                    }
-
-                    branches['pmm3-package-testing-arm-matrix'] = {
                         stage('pmm3-package-testing-arm-matrix') {
-                            triggerJenkinsRc('pmm3-package-testing-arm-matrix', 'pmm3-package-testing-arm-matrix', [
-                                string(name: 'GIT_BRANCH',      value: 'main'),
-                                string(name: 'GIT_COMMIT_HASH', value: ''),
-                                string(name: 'DOCKER_VERSION',  value: env.PMM_SERVER_IMAGE),
-                                string(name: 'SERVER_ARCH',     value: 'arm64'),
-                                string(name: 'PMM_VERSION',     value: params.RC_VERSION.trim()),
-                                string(name: 'INSTALL_REPO',    value: 'testing'),
-                                string(name: 'TARBALL',         value: params.PMM_CLIENT_TARBALL_ARM64.trim()),
-                                string(name: 'METRICS_MODE',    value: 'auto'),
-                                booleanParam(name: 'USE_ONDEMAND', value: true),
-                            ])
+                            steps {
+                                script {
+                                    triggerJenkinsRc('pmm3-package-testing-arm-matrix', 'pmm3-package-testing-arm-matrix', [
+                                        string(name: 'GIT_BRANCH',      value: 'main'),
+                                        string(name: 'GIT_COMMIT_HASH', value: ''),
+                                        string(name: 'DOCKER_VERSION',  value: env.PMM_SERVER_IMAGE),
+                                        string(name: 'SERVER_ARCH',     value: 'arm64'),
+                                        string(name: 'PMM_VERSION',     value: params.RC_VERSION.trim()),
+                                        string(name: 'INSTALL_REPO',    value: 'testing'),
+                                        string(name: 'TARBALL',         value: params.PMM_CLIENT_TARBALL_ARM64.trim()),
+                                        string(name: 'METRICS_MODE',    value: 'auto'),
+                                        booleanParam(name: 'USE_ONDEMAND', value: true),
+                                    ])
+                                }
+                            }
                         }
-                    }
-
-                    branches['pmm3-upgrade-tests-matrix'] = {
                         stage('pmm3-upgrade-tests-matrix') {
-                            triggerJenkinsRc('pmm3-upgrade-tests-matrix', 'pmm3-upgrade-tests-matrix', [
-                                string(name: 'PMM_QA_GIT_BRANCH', value: 'main'),
-                                booleanParam(name: 'USE_ONDEMAND', value: true),
-                            ])
+                            steps {
+                                script {
+                                    triggerJenkinsRc('pmm3-upgrade-tests-matrix', 'pmm3-upgrade-tests-matrix', [
+                                        string(name: 'PMM_QA_GIT_BRANCH', value: 'main'),
+                                        booleanParam(name: 'USE_ONDEMAND', value: true),
+                                    ])
+                                }
+                            }
                         }
-                    }
-
-                    branches['PMM screenshots'] = {
                         stage('PMM screenshots') {
-                            build job: 'pmm3-deploy-services', wait: false, propagate: false, parameters: [
-                                string(name: 'SERVER_TYPE',                    value: 'docker'),
-                                string(name: 'DOCKER_VERSION',                 value: env.PMM_SERVER_IMAGE),
-                                string(name: 'CLIENT_VERSION',                 value: 'pmm3-rc'),
-                                string(name: 'ENABLE_PULL_MODE',               value: 'no'),
-                                string(name: 'ADMIN_PASSWORD',                 value: 'pmm3admin!'),
-                                booleanParam(name: 'DEPLOY_EXTERNAL',          value: true),
-                                booleanParam(name: 'DEPLOY_MYSQL_GROUP',       value: true),
-                                booleanParam(name: 'DEPLOY_POSTGRES_GROUP',    value: true),
-                                booleanParam(name: 'DEPLOY_MONGO_GROUP',       value: true),
-                                booleanParam(name: 'DEPLOY_VALKEY',            value: true),
-                                string(name: 'PXC_VERSION',                    value: '8.0'),
-                                string(name: 'PS_VERSION',                     value: '8.4'),
-                                string(name: 'MS_VERSION',                     value: '8.4'),
-                                string(name: 'PGSQL_VERSION',                  value: '17'),
-                                string(name: 'PDPGSQL_VERSION',                value: '17'),
-                                string(name: 'PSMDB_VERSION',                  value: '8.0'),
-                                string(name: 'MODB_VERSION',                   value: '8.0'),
-                                string(name: 'PMM_QA_GIT_BRANCH',              value: 'main'),
-                                booleanParam(name: 'GENERATE_DASHBOARD_SCREENSHOTS', value: true),
-                                string(name: 'SCREENSHOTS_SLACK_TARGET',       value: env.SLACK_RC_SCREENSHOTS_TARGET),
-                                booleanParam(name: 'USE_ONDEMAND', value: true),
-                            ]
+                            steps {
+                                script {
+                                    build job: 'pmm3-deploy-services', wait: false, propagate: false, parameters: [
+                                        string(name: 'SERVER_TYPE',                    value: 'docker'),
+                                        string(name: 'DOCKER_VERSION',                 value: env.PMM_SERVER_IMAGE),
+                                        string(name: 'CLIENT_VERSION',                 value: 'pmm3-rc'),
+                                        string(name: 'ENABLE_PULL_MODE',               value: 'no'),
+                                        string(name: 'ADMIN_PASSWORD',                 value: 'pmm3admin!'),
+                                        booleanParam(name: 'DEPLOY_EXTERNAL',          value: true),
+                                        booleanParam(name: 'DEPLOY_MYSQL_GROUP',       value: true),
+                                        booleanParam(name: 'DEPLOY_POSTGRES_GROUP',    value: true),
+                                        booleanParam(name: 'DEPLOY_MONGO_GROUP',       value: true),
+                                        booleanParam(name: 'DEPLOY_VALKEY',            value: true),
+                                        string(name: 'PXC_VERSION',                    value: '8.0'),
+                                        string(name: 'PS_VERSION',                     value: '8.4'),
+                                        string(name: 'MS_VERSION',                     value: '8.4'),
+                                        string(name: 'PGSQL_VERSION',                  value: '17'),
+                                        string(name: 'PDPGSQL_VERSION',                value: '17'),
+                                        string(name: 'PSMDB_VERSION',                  value: '8.0'),
+                                        string(name: 'MODB_VERSION',                   value: '8.0'),
+                                        string(name: 'PMM_QA_GIT_BRANCH',              value: 'main'),
+                                        booleanParam(name: 'GENERATE_DASHBOARD_SCREENSHOTS', value: true),
+                                        string(name: 'SCREENSHOTS_SLACK_TARGET',       value: env.SLACK_RC_SCREENSHOTS_TARGET),
+                                        booleanParam(name: 'USE_ONDEMAND', value: true),
+                                    ]
+                                }
+                            }
                         }
                     }
+                }
 
-                    parallel branches
+                stage('Lane 4 (arm64)') {
+                    stages {
+                        stage('nightly (Docker, arm64 server)') {
+                            steps {
+                                script {
+                                    triggerNightlyGhaRc('pmm3-ui-tests-nightly-gha (docker, arm64)', [
+                                        SERVER_ARCH: 'arm64',
+                                    ])
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/pmm/v3/pmm3-rc-testing.groovy
+++ b/pmm/v3/pmm3-rc-testing.groovy
@@ -135,297 +135,188 @@ pipeline {
         }
 
         stage('Trigger RC suites') {
-            parallel {
-                stage('Lane 1') {
-                    stages {
-                        stage('nightly (AMI)') {
-                            steps {
-                                script {
-                                    triggerNightlyGhaRc('pmm3-ui-tests-nightly-gha (ami)', [
-                                        SERVER_TYPE: 'ami',
-                                    ])
-                                }
-                            }
-                        }
-                        stage('nightly (compat #1)') {
-                            when { expression { env.IS_PATCH_RC != 'true' } }
-                            steps {
-                                script {
-                                    def tags = readFile('compat-tags.txt').trim().split('\n').collect { it.trim() }.findAll { it }
-                                    def ver = tags[0]
-                                    triggerNightlyGhaRc("pmm3-ui-tests-nightly-gha (compat ${ver})", [
-                                        CLIENT_VERSION: ver,
-                                    ])
-                                }
-                            }
-                        }
-                        stage('nightly (compat #2)') {
-                            when { expression { env.IS_PATCH_RC != 'true' } }
-                            steps {
-                                script {
-                                    def tags = readFile('compat-tags.txt').trim().split('\n').collect { it.trim() }.findAll { it }
-                                    def ver = tags[1]
-                                    triggerNightlyGhaRc("pmm3-ui-tests-nightly-gha (compat ${ver})", [
-                                        CLIENT_VERSION: ver,
-                                    ])
-                                }
-                            }
-                        }
-                        stage('nightly (compat #3)') {
-                            when { expression { env.IS_PATCH_RC != 'true' } }
-                            steps {
-                                script {
-                                    def tags = readFile('compat-tags.txt').trim().split('\n').collect { it.trim() }.findAll { it }
-                                    def ver = tags[2]
-                                    triggerNightlyGhaRc("pmm3-ui-tests-nightly-gha (compat ${ver})", [
-                                        CLIENT_VERSION: ver,
-                                    ])
-                                }
-                            }
-                        }
-                        stage('nightly (compat #4)') {
-                            when { expression { env.IS_PATCH_RC != 'true' } }
-                            steps {
-                                script {
-                                    def tags = readFile('compat-tags.txt').trim().split('\n').collect { it.trim() }.findAll { it }
-                                    def ver = tags[3]
-                                    triggerNightlyGhaRc("pmm3-ui-tests-nightly-gha (compat ${ver})", [
-                                        CLIENT_VERSION: ver,
-                                    ])
-                                }
-                            }
-                        }
-                        stage('nightly (compat #5)') {
-                            when { expression { env.IS_PATCH_RC != 'true' } }
-                            steps {
-                                script {
-                                    def tags = readFile('compat-tags.txt').trim().split('\n').collect { it.trim() }.findAll { it }
-                                    def ver = tags[4]
-                                    triggerNightlyGhaRc("pmm3-ui-tests-nightly-gha (compat ${ver})", [
-                                        CLIENT_VERSION: ver,
-                                    ])
-                                }
-                            }
-                        }
-                    }
-                }
+            steps {
+                script {
+                    def branches = [:]
 
-                stage('Lane 2') {
-                    stages {
-                        stage('nightly (Docker)') {
-                            steps {
-                                script {
-                                    triggerNightlyGhaRc('pmm3-ui-tests-nightly-gha (docker)')
-                                }
-                            }
-                        }
-                        stage('nightly (Helm)') {
-                            steps {
-                                script {
-                                    triggerNightlyGhaRc('pmm3-ui-tests-nightly-gha (helm)', [
-                                        SERVER_TYPE    : 'helm',
-                                        ADMIN_PASSWORD : 'admin1',
-                                    ])
-                                }
-                            }
-                        }
-                        stage('nightly (HA)') {
-                            steps {
-                                script {
-                                    triggerNightlyGhaRc('pmm3-ui-tests-nightly-gha (ha)', [
-                                        SERVER_TYPE    : 'ha',
-                                        ADMIN_PASSWORD : 'admin1',
-                                    ])
-                                }
-                            }
-                        }
-                        stage('nightly (GSSAPI)') {
-                            steps {
-                                script {
-                                    triggerJenkinsRc('pmm3-ui-tests-nightly-gssapi', 'pmm3-ui-tests-nightly-gssapi', [
-                                        string(name: 'PMM_QA_GIT_BRANCH',       value: 'main'),
-                                        string(name: 'SERVER_TYPE',             value: 'docker'),
-                                        string(name: 'DOCKER_VERSION',          value: env.PMM_SERVER_IMAGE),
-                                        string(name: 'CLIENT_VERSION',          value: params.PMM_CLIENT_TARBALL_OL9.trim()),
-                                        string(name: 'ENABLE_PULL_MODE',        value: 'no'),
-                                        string(name: 'ADMIN_PASSWORD',          value: 'pmm3admin!'),
-                                        string(name: 'PSMDB_VERSION',           value: '8.0'),
-                                        string(name: 'MODB_VERSION',            value: '8.0'),
-                                        booleanParam(name: 'USE_ONDEMAND', value: true),
-                                    ])
-                                }
-                            }
-                        }
-                        stage('openshift-helm-tests') {
-                            steps {
-                                script {
-                                    triggerJenkinsRc('openshift-helm-tests', 'openshift-helm-tests', [
-                                        string(name: 'PMM_QA_GIT_BRANCH',  value: 'main'),
-                                        string(name: 'PMM_CHART_BRANCH',   value: 'latest'),
-                                        string(name: 'IMAGE_REPO',         value: env.PMM_SERVER_IMAGE.split(':')[0]),
-                                        string(name: 'IMAGE_TAG',          value: env.PMM_SERVER_IMAGE.split(':')[1]),
-                                        string(name: 'OPENSHIFT_VERSION',  value: 'latest'),
-                                        booleanParam(name: 'USE_ONDEMAND', value: true),
-                                    ])
-                                }
-                            }
-                        }
+                    branches['nightly (ami)'] = {
+                        triggerNightlyGhaRc('pmm3-ui-tests-nightly-gha (ami)', [
+                            SERVER_TYPE: 'ami',
+                        ])
                     }
-                }
+                    branches['nightly (docker)'] = {
+                        triggerNightlyGhaRc('pmm3-ui-tests-nightly-gha (docker)')
+                    }
+                    branches['nightly (docker, arm64 server)'] = {
+                        triggerNightlyGhaRc('pmm3-ui-tests-nightly-gha (docker, arm64)', [
+                            SERVER_ARCH: 'arm64',
+                        ])
+                    }
+                    branches['nightly (helm)'] = {
+                        triggerNightlyGhaRc('pmm3-ui-tests-nightly-gha (helm)', [
+                            SERVER_TYPE    : 'helm',
+                            ADMIN_PASSWORD : 'admin1',
+                        ])
+                    }
+                    branches['nightly (ha)'] = {
+                        triggerNightlyGhaRc('pmm3-ui-tests-nightly-gha (ha)', [
+                            SERVER_TYPE    : 'ha',
+                            ADMIN_PASSWORD : 'admin1',
+                        ])
+                    }
 
-                stage('Lane 3') {
-                    stages {
-                        stage('GitHub rc-testing-suite') {
-                            steps {
-                                script {
-                                    try {
-                                        def payload = new JsonBuilder([
-                                            ref   : 'main',
-                                            inputs: [
-                                                rc_version             : params.RC_VERSION.trim(),
-                                                pmm_client_tarball_ol8 : params.PMM_CLIENT_TARBALL_OL8.trim(),
-                                                pmm_client_tarball_ol9 : params.PMM_CLIENT_TARBALL_OL9.trim(),
-                                                pmm_qa_branch          : 'main',
-                                                pxc_version            : '8.0',
-                                                pxc_glibc              : '2.35',
-                                                pdpgsql_version        : '17',
-                                                skip_compatibility     : env.IS_PATCH_RC == 'true',
-                                            ],
-                                        ]).toString()
-                                        writeFile file: 'rc-suite-dispatch.json', text: payload
-                                        withCredentials([string(credentialsId: 'GITHUB_API_TOKEN', variable: 'GITHUB_TOKEN')]) {
-                                            sh """
-                                                set -euo pipefail
-                                                curl -fsS -X POST \\
-                                                    -H "Accept: application/vnd.github+json" \\
-                                                    -H "Authorization: Bearer \${GITHUB_TOKEN}" \\
-                                                    -H "X-GitHub-Api-Version: 2022-11-28" \\
-                                                    "https://api.github.com/repos/percona/pmm-qa/actions/workflows/rc-testing-suite.yml/dispatches" \\
-                                                    --data @rc-suite-dispatch.json
-                                            """
-                                        }
-                                        slackRcMessage("*Github Release Testing Suite*: https://github.com/percona/pmm-qa/actions/workflows/rc-testing-suite.yml")
-                                    } catch (err) {
-                                        slackRcMessage("*Github Release Testing Suite* (dispatch failed): ${err.getMessage()}")
-                                    }
-                                }
-                            }
-                        }
-                        stage('pmm3-ui-tests-matrix') {
-                            steps {
-                                script {
-                                    triggerJenkinsRc('pmm3-ui-tests-matrix', 'pmm3-ui-tests-matrix', [
-                                        string(name: 'PMM_QA_GIT_BRANCH', value: 'main'),
-                                        string(name: 'GIT_COMMIT_HASH',  value: ''),
-                                        string(name: 'DOCKER_VERSION',   value: env.PMM_SERVER_IMAGE),
-                                        string(name: 'CLIENT_VERSION',   value: 'pmm3-rc'),
-                                        string(name: 'MYSQL_IMAGE',      value: 'percona:5.7'),
-                                        string(name: 'POSTGRES_IMAGE',   value: 'perconalab/percona-distribution-postgresql:16.0'),
-                                        string(name: 'MONGO_IMAGE',      value: 'percona/percona-server-mongodb:4.4'),
-                                        string(name: 'PROXYSQL_IMAGE',   value: 'proxysql/proxysql:2.3.0'),
-                                        booleanParam(name: 'USE_ONDEMAND', value: true),
-                                    ])
-                                }
-                            }
-                        }
-                        stage('pmm3-upgrade-ami-test') {
-                            steps {
-                                script {
-                                    triggerJenkinsRc('pmm3-upgrade-ami-test', 'pmm3-upgrade-ami-test', [
-                                        string(name: 'PMM_QA_GIT_BRANCH',   value: 'main'),
-                                        booleanParam(name: 'IS_RC_TESTING', value: true),
-                                        booleanParam(name: 'USE_ONDEMAND', value: true),
-                                    ])
-                                }
-                            }
-                        }
-                        stage('pmm3-package-testing-matrix') {
-                            steps {
-                                script {
-                                    triggerJenkinsRc('pmm3-package-testing-matrix', 'pmm3-package-testing-matrix', [
-                                        string(name: 'GIT_BRANCH',      value: 'main'),
-                                        string(name: 'GIT_COMMIT_HASH', value: ''),
-                                        string(name: 'DOCKER_VERSION',  value: env.PMM_SERVER_IMAGE),
-                                        string(name: 'PMM_VERSION',     value: params.RC_VERSION.trim()),
-                                        string(name: 'INSTALL_REPO',    value: 'testing'),
-                                        string(name: 'TARBALL',         value: params.PMM_CLIENT_TARBALL.trim()),
-                                        string(name: 'METRICS_MODE',    value: 'auto'),
-                                        booleanParam(name: 'USE_ONDEMAND', value: true),
-                                    ])
-                                }
-                            }
-                        }
-                        stage('pmm3-package-testing-arm-matrix') {
-                            steps {
-                                script {
-                                    triggerJenkinsRc('pmm3-package-testing-arm-matrix', 'pmm3-package-testing-arm-matrix', [
-                                        string(name: 'GIT_BRANCH',      value: 'main'),
-                                        string(name: 'GIT_COMMIT_HASH', value: ''),
-                                        string(name: 'DOCKER_VERSION',  value: env.PMM_SERVER_IMAGE),
-                                        string(name: 'SERVER_ARCH',     value: 'arm64'),
-                                        string(name: 'PMM_VERSION',     value: params.RC_VERSION.trim()),
-                                        string(name: 'INSTALL_REPO',    value: 'testing'),
-                                        string(name: 'TARBALL',         value: params.PMM_CLIENT_TARBALL_ARM64.trim()),
-                                        string(name: 'METRICS_MODE',    value: 'auto'),
-                                        booleanParam(name: 'USE_ONDEMAND', value: true),
-                                    ])
-                                }
-                            }
-                        }
-                        stage('pmm3-upgrade-tests-matrix') {
-                            steps {
-                                script {
-                                    triggerJenkinsRc('pmm3-upgrade-tests-matrix', 'pmm3-upgrade-tests-matrix', [
-                                        string(name: 'PMM_QA_GIT_BRANCH', value: 'main'),
-                                        booleanParam(name: 'USE_ONDEMAND', value: true),
-                                    ])
-                                }
-                            }
-                        }
-                        stage('PMM screenshots') {
-                            steps {
-                                script {
-                                    build job: 'pmm3-deploy-services', wait: false, propagate: false, parameters: [
-                                        string(name: 'SERVER_TYPE',                    value: 'docker'),
-                                        string(name: 'DOCKER_VERSION',                 value: env.PMM_SERVER_IMAGE),
-                                        string(name: 'CLIENT_VERSION',                 value: 'pmm3-rc'),
-                                        string(name: 'ENABLE_PULL_MODE',               value: 'no'),
-                                        string(name: 'ADMIN_PASSWORD',                 value: 'pmm3admin!'),
-                                        booleanParam(name: 'DEPLOY_EXTERNAL',          value: true),
-                                        booleanParam(name: 'DEPLOY_MYSQL_GROUP',       value: true),
-                                        booleanParam(name: 'DEPLOY_POSTGRES_GROUP',    value: true),
-                                        booleanParam(name: 'DEPLOY_MONGO_GROUP',       value: true),
-                                        booleanParam(name: 'DEPLOY_VALKEY',            value: true),
-                                        string(name: 'PXC_VERSION',                    value: '8.0'),
-                                        string(name: 'PS_VERSION',                     value: '8.4'),
-                                        string(name: 'MS_VERSION',                     value: '8.4'),
-                                        string(name: 'PGSQL_VERSION',                  value: '17'),
-                                        string(name: 'PDPGSQL_VERSION',                value: '17'),
-                                        string(name: 'PSMDB_VERSION',                  value: '8.0'),
-                                        string(name: 'MODB_VERSION',                   value: '8.0'),
-                                        string(name: 'PMM_QA_GIT_BRANCH',              value: 'main'),
-                                        booleanParam(name: 'GENERATE_DASHBOARD_SCREENSHOTS', value: true),
-                                        string(name: 'SCREENSHOTS_SLACK_TARGET',       value: env.SLACK_RC_SCREENSHOTS_TARGET),
-                                        booleanParam(name: 'USE_ONDEMAND', value: true),
-                                    ]
-                                }
+                    if (env.IS_PATCH_RC != 'true') {
+                        def compatTags = readFile('compat-tags.txt').trim().split('\n').collect { it.trim() }.findAll { it }
+                        compatTags.each { tag ->
+                            branches["nightly (compat ${tag})"] = {
+                                triggerNightlyGhaRc("pmm3-ui-tests-nightly-gha (compat ${tag})", [
+                                    CLIENT_VERSION: tag,
+                                ])
                             }
                         }
                     }
-                }
 
-                stage('Lane 4 (arm64)') {
-                    stages {
-                        stage('nightly (Docker, arm64 server)') {
-                            steps {
-                                script {
-                                    triggerNightlyGhaRc('pmm3-ui-tests-nightly-gha (docker, arm64)', [
-                                        SERVER_ARCH: 'arm64',
-                                    ])
-                                }
+                    branches['nightly (gssapi)'] = {
+                        triggerJenkinsRc('pmm3-ui-tests-nightly-gssapi', 'pmm3-ui-tests-nightly-gssapi', [
+                            string(name: 'PMM_QA_GIT_BRANCH',       value: 'main'),
+                            string(name: 'SERVER_TYPE',             value: 'docker'),
+                            string(name: 'DOCKER_VERSION',          value: env.PMM_SERVER_IMAGE),
+                            string(name: 'CLIENT_VERSION',          value: params.PMM_CLIENT_TARBALL_OL9.trim()),
+                            string(name: 'ENABLE_PULL_MODE',        value: 'no'),
+                            string(name: 'ADMIN_PASSWORD',          value: 'pmm3admin!'),
+                            string(name: 'PSMDB_VERSION',           value: '8.0'),
+                            string(name: 'MODB_VERSION',            value: '8.0'),
+                            booleanParam(name: 'USE_ONDEMAND', value: true),
+                        ])
+                    }
+
+                    branches['openshift-helm-tests'] = {
+                        triggerJenkinsRc('openshift-helm-tests', 'openshift-helm-tests', [
+                            string(name: 'PMM_QA_GIT_BRANCH',  value: 'main'),
+                            string(name: 'PMM_CHART_BRANCH',   value: 'latest'),
+                            string(name: 'IMAGE_REPO',         value: env.PMM_SERVER_IMAGE.split(':')[0]),
+                            string(name: 'IMAGE_TAG',          value: env.PMM_SERVER_IMAGE.split(':')[1]),
+                            string(name: 'OPENSHIFT_VERSION',  value: 'latest'),
+                            booleanParam(name: 'USE_ONDEMAND', value: true),
+                        ])
+                    }
+
+                    branches['GitHub rc-testing-suite'] = {
+                        try {
+                            def payload = new JsonBuilder([
+                                ref   : 'main',
+                                inputs: [
+                                    rc_version             : params.RC_VERSION.trim(),
+                                    pmm_client_tarball_ol8 : params.PMM_CLIENT_TARBALL_OL8.trim(),
+                                    pmm_client_tarball_ol9 : params.PMM_CLIENT_TARBALL_OL9.trim(),
+                                    pmm_qa_branch          : 'main',
+                                    pxc_version            : '8.0',
+                                    pxc_glibc              : '2.35',
+                                    pdpgsql_version        : '17',
+                                    skip_compatibility     : env.IS_PATCH_RC == 'true',
+                                ],
+                            ]).toString()
+                            writeFile file: 'rc-suite-dispatch.json', text: payload
+                            withCredentials([string(credentialsId: 'GITHUB_API_TOKEN', variable: 'GITHUB_TOKEN')]) {
+                                sh """
+                                    set -euo pipefail
+                                    curl -fsS -X POST \\
+                                        -H "Accept: application/vnd.github+json" \\
+                                        -H "Authorization: Bearer \${GITHUB_TOKEN}" \\
+                                        -H "X-GitHub-Api-Version: 2022-11-28" \\
+                                        "https://api.github.com/repos/percona/pmm-qa/actions/workflows/rc-testing-suite.yml/dispatches" \\
+                                        --data @rc-suite-dispatch.json
+                                """
                             }
+                            slackRcMessage("*Github Release Testing Suite*: https://github.com/percona/pmm-qa/actions/workflows/rc-testing-suite.yml")
+                        } catch (err) {
+                            slackRcMessage("*Github Release Testing Suite* (dispatch failed): ${err.getMessage()}")
                         }
                     }
+
+                    branches['pmm3-ui-tests-matrix'] = {
+                        triggerJenkinsRc('pmm3-ui-tests-matrix', 'pmm3-ui-tests-matrix', [
+                            string(name: 'PMM_QA_GIT_BRANCH', value: 'main'),
+                            string(name: 'GIT_COMMIT_HASH',  value: ''),
+                            string(name: 'DOCKER_VERSION',   value: env.PMM_SERVER_IMAGE),
+                            string(name: 'CLIENT_VERSION',   value: 'pmm3-rc'),
+                            string(name: 'MYSQL_IMAGE',      value: 'percona:5.7'),
+                            string(name: 'POSTGRES_IMAGE',   value: 'perconalab/percona-distribution-postgresql:16.0'),
+                            string(name: 'MONGO_IMAGE',      value: 'percona/percona-server-mongodb:4.4'),
+                            string(name: 'PROXYSQL_IMAGE',   value: 'proxysql/proxysql:2.3.0'),
+                            booleanParam(name: 'USE_ONDEMAND', value: true),
+                        ])
+                    }
+
+                    branches['pmm3-upgrade-ami-test'] = {
+                        triggerJenkinsRc('pmm3-upgrade-ami-test', 'pmm3-upgrade-ami-test', [
+                            string(name: 'PMM_QA_GIT_BRANCH',   value: 'main'),
+                            booleanParam(name: 'IS_RC_TESTING', value: true),
+                            booleanParam(name: 'USE_ONDEMAND', value: true),
+                        ])
+                    }
+
+                    branches['pmm3-package-testing-matrix'] = {
+                        triggerJenkinsRc('pmm3-package-testing-matrix', 'pmm3-package-testing-matrix', [
+                            string(name: 'GIT_BRANCH',      value: 'main'),
+                            string(name: 'GIT_COMMIT_HASH', value: ''),
+                            string(name: 'DOCKER_VERSION',  value: env.PMM_SERVER_IMAGE),
+                            string(name: 'PMM_VERSION',     value: params.RC_VERSION.trim()),
+                            string(name: 'INSTALL_REPO',    value: 'testing'),
+                            string(name: 'TARBALL',         value: params.PMM_CLIENT_TARBALL.trim()),
+                            string(name: 'METRICS_MODE',    value: 'auto'),
+                            booleanParam(name: 'USE_ONDEMAND', value: true),
+                        ])
+                    }
+
+                    branches['pmm3-package-testing-arm-matrix'] = {
+                        triggerJenkinsRc('pmm3-package-testing-arm-matrix', 'pmm3-package-testing-arm-matrix', [
+                            string(name: 'GIT_BRANCH',      value: 'main'),
+                            string(name: 'GIT_COMMIT_HASH', value: ''),
+                            string(name: 'DOCKER_VERSION',  value: env.PMM_SERVER_IMAGE),
+                            string(name: 'SERVER_ARCH',     value: 'arm64'),
+                            string(name: 'PMM_VERSION',     value: params.RC_VERSION.trim()),
+                            string(name: 'INSTALL_REPO',    value: 'testing'),
+                            string(name: 'TARBALL',         value: params.PMM_CLIENT_TARBALL_ARM64.trim()),
+                            string(name: 'METRICS_MODE',    value: 'auto'),
+                            booleanParam(name: 'USE_ONDEMAND', value: true),
+                        ])
+                    }
+
+                    branches['pmm3-upgrade-tests-matrix'] = {
+                        triggerJenkinsRc('pmm3-upgrade-tests-matrix', 'pmm3-upgrade-tests-matrix', [
+                            string(name: 'PMM_QA_GIT_BRANCH', value: 'main'),
+                            booleanParam(name: 'USE_ONDEMAND', value: true),
+                        ])
+                    }
+
+                    branches['PMM screenshots'] = {
+                        build job: 'pmm3-deploy-services', wait: false, propagate: false, parameters: [
+                            string(name: 'SERVER_TYPE',                    value: 'docker'),
+                            string(name: 'DOCKER_VERSION',                 value: env.PMM_SERVER_IMAGE),
+                            string(name: 'CLIENT_VERSION',                 value: 'pmm3-rc'),
+                            string(name: 'ENABLE_PULL_MODE',               value: 'no'),
+                            string(name: 'ADMIN_PASSWORD',                 value: 'pmm3admin!'),
+                            booleanParam(name: 'DEPLOY_EXTERNAL',          value: true),
+                            booleanParam(name: 'DEPLOY_MYSQL_GROUP',       value: true),
+                            booleanParam(name: 'DEPLOY_POSTGRES_GROUP',    value: true),
+                            booleanParam(name: 'DEPLOY_MONGO_GROUP',       value: true),
+                            booleanParam(name: 'DEPLOY_VALKEY',            value: true),
+                            string(name: 'PXC_VERSION',                    value: '8.0'),
+                            string(name: 'PS_VERSION',                     value: '8.4'),
+                            string(name: 'MS_VERSION',                     value: '8.4'),
+                            string(name: 'PGSQL_VERSION',                  value: '17'),
+                            string(name: 'PDPGSQL_VERSION',                value: '17'),
+                            string(name: 'PSMDB_VERSION',                  value: '8.0'),
+                            string(name: 'MODB_VERSION',                   value: '8.0'),
+                            string(name: 'PMM_QA_GIT_BRANCH',              value: 'main'),
+                            booleanParam(name: 'GENERATE_DASHBOARD_SCREENSHOTS', value: true),
+                            string(name: 'SCREENSHOTS_SLACK_TARGET',       value: env.SLACK_RC_SCREENSHOTS_TARGET),
+                            booleanParam(name: 'USE_ONDEMAND', value: true),
+                        ]
+                    }
+
+                    parallel branches
                 }
             }
         }

--- a/pmm/v3/pmm3-rc-testing.groovy
+++ b/pmm/v3/pmm3-rc-testing.groovy
@@ -140,180 +140,210 @@ pipeline {
                     def branches = [:]
 
                     branches['nightly (ami)'] = {
-                        triggerNightlyGhaRc('pmm3-ui-tests-nightly-gha (ami)', [
-                            SERVER_TYPE: 'ami',
-                        ])
+                        stage('nightly (ami)') {
+                            triggerNightlyGhaRc('pmm3-ui-tests-nightly-gha (ami)', [
+                                SERVER_TYPE: 'ami',
+                            ])
+                        }
                     }
                     branches['nightly (docker)'] = {
-                        triggerNightlyGhaRc('pmm3-ui-tests-nightly-gha (docker)')
+                        stage('nightly (docker)') {
+                            triggerNightlyGhaRc('pmm3-ui-tests-nightly-gha (docker)')
+                        }
                     }
                     branches['nightly (docker, arm64 server)'] = {
-                        triggerNightlyGhaRc('pmm3-ui-tests-nightly-gha (docker, arm64)', [
-                            SERVER_ARCH: 'arm64',
-                        ])
+                        stage('nightly (docker, arm64 server)') {
+                            triggerNightlyGhaRc('pmm3-ui-tests-nightly-gha (docker, arm64)', [
+                                SERVER_ARCH: 'arm64',
+                            ])
+                        }
                     }
                     branches['nightly (helm)'] = {
-                        triggerNightlyGhaRc('pmm3-ui-tests-nightly-gha (helm)', [
-                            SERVER_TYPE    : 'helm',
-                            ADMIN_PASSWORD : 'admin1',
-                        ])
+                        stage('nightly (helm)') {
+                            triggerNightlyGhaRc('pmm3-ui-tests-nightly-gha (helm)', [
+                                SERVER_TYPE    : 'helm',
+                                ADMIN_PASSWORD : 'admin1',
+                            ])
+                        }
                     }
                     branches['nightly (ha)'] = {
-                        triggerNightlyGhaRc('pmm3-ui-tests-nightly-gha (ha)', [
-                            SERVER_TYPE    : 'ha',
-                            ADMIN_PASSWORD : 'admin1',
-                        ])
+                        stage('nightly (ha)') {
+                            triggerNightlyGhaRc('pmm3-ui-tests-nightly-gha (ha)', [
+                                SERVER_TYPE    : 'ha',
+                                ADMIN_PASSWORD : 'admin1',
+                            ])
+                        }
                     }
 
                     if (env.IS_PATCH_RC != 'true') {
                         def compatTags = readFile('compat-tags.txt').trim().split('\n').collect { it.trim() }.findAll { it }
                         compatTags.each { tag ->
                             branches["nightly (compat ${tag})"] = {
-                                triggerNightlyGhaRc("pmm3-ui-tests-nightly-gha (compat ${tag})", [
-                                    CLIENT_VERSION: tag,
-                                ])
+                                stage("nightly (compat ${tag})") {
+                                    triggerNightlyGhaRc("pmm3-ui-tests-nightly-gha (compat ${tag})", [
+                                        CLIENT_VERSION: tag,
+                                    ])
+                                }
                             }
                         }
                     }
 
                     branches['nightly (gssapi)'] = {
-                        triggerJenkinsRc('pmm3-ui-tests-nightly-gssapi', 'pmm3-ui-tests-nightly-gssapi', [
-                            string(name: 'PMM_QA_GIT_BRANCH',       value: 'main'),
-                            string(name: 'SERVER_TYPE',             value: 'docker'),
-                            string(name: 'DOCKER_VERSION',          value: env.PMM_SERVER_IMAGE),
-                            string(name: 'CLIENT_VERSION',          value: params.PMM_CLIENT_TARBALL_OL9.trim()),
-                            string(name: 'ENABLE_PULL_MODE',        value: 'no'),
-                            string(name: 'ADMIN_PASSWORD',          value: 'pmm3admin!'),
-                            string(name: 'PSMDB_VERSION',           value: '8.0'),
-                            string(name: 'MODB_VERSION',            value: '8.0'),
-                            booleanParam(name: 'USE_ONDEMAND', value: true),
-                        ])
+                        stage('nightly (gssapi)') {
+                            triggerJenkinsRc('pmm3-ui-tests-nightly-gssapi', 'pmm3-ui-tests-nightly-gssapi', [
+                                string(name: 'PMM_QA_GIT_BRANCH',       value: 'main'),
+                                string(name: 'SERVER_TYPE',             value: 'docker'),
+                                string(name: 'DOCKER_VERSION',          value: env.PMM_SERVER_IMAGE),
+                                string(name: 'CLIENT_VERSION',          value: params.PMM_CLIENT_TARBALL_OL9.trim()),
+                                string(name: 'ENABLE_PULL_MODE',        value: 'no'),
+                                string(name: 'ADMIN_PASSWORD',          value: 'pmm3admin!'),
+                                string(name: 'PSMDB_VERSION',           value: '8.0'),
+                                string(name: 'MODB_VERSION',            value: '8.0'),
+                                booleanParam(name: 'USE_ONDEMAND', value: true),
+                            ])
+                        }
                     }
 
                     branches['openshift-helm-tests'] = {
-                        triggerJenkinsRc('openshift-helm-tests', 'openshift-helm-tests', [
-                            string(name: 'PMM_QA_GIT_BRANCH',  value: 'main'),
-                            string(name: 'PMM_CHART_BRANCH',   value: 'latest'),
-                            string(name: 'IMAGE_REPO',         value: env.PMM_SERVER_IMAGE.split(':')[0]),
-                            string(name: 'IMAGE_TAG',          value: env.PMM_SERVER_IMAGE.split(':')[1]),
-                            string(name: 'OPENSHIFT_VERSION',  value: 'latest'),
-                            booleanParam(name: 'USE_ONDEMAND', value: true),
-                        ])
+                        stage('openshift-helm-tests') {
+                            triggerJenkinsRc('openshift-helm-tests', 'openshift-helm-tests', [
+                                string(name: 'PMM_QA_GIT_BRANCH',  value: 'main'),
+                                string(name: 'PMM_CHART_BRANCH',   value: 'latest'),
+                                string(name: 'IMAGE_REPO',         value: env.PMM_SERVER_IMAGE.split(':')[0]),
+                                string(name: 'IMAGE_TAG',          value: env.PMM_SERVER_IMAGE.split(':')[1]),
+                                string(name: 'OPENSHIFT_VERSION',  value: 'latest'),
+                                booleanParam(name: 'USE_ONDEMAND', value: true),
+                            ])
+                        }
                     }
 
                     branches['GitHub rc-testing-suite'] = {
-                        try {
-                            def payload = new JsonBuilder([
-                                ref   : 'main',
-                                inputs: [
-                                    rc_version             : params.RC_VERSION.trim(),
-                                    pmm_client_tarball_ol8 : params.PMM_CLIENT_TARBALL_OL8.trim(),
-                                    pmm_client_tarball_ol9 : params.PMM_CLIENT_TARBALL_OL9.trim(),
-                                    pmm_qa_branch          : 'main',
-                                    pxc_version            : '8.0',
-                                    pxc_glibc              : '2.35',
-                                    pdpgsql_version        : '17',
-                                    skip_compatibility     : env.IS_PATCH_RC == 'true',
-                                ],
-                            ]).toString()
-                            writeFile file: 'rc-suite-dispatch.json', text: payload
-                            withCredentials([string(credentialsId: 'GITHUB_API_TOKEN', variable: 'GITHUB_TOKEN')]) {
-                                sh """
-                                    set -euo pipefail
-                                    curl -fsS -X POST \\
-                                        -H "Accept: application/vnd.github+json" \\
-                                        -H "Authorization: Bearer \${GITHUB_TOKEN}" \\
-                                        -H "X-GitHub-Api-Version: 2022-11-28" \\
-                                        "https://api.github.com/repos/percona/pmm-qa/actions/workflows/rc-testing-suite.yml/dispatches" \\
-                                        --data @rc-suite-dispatch.json
-                                """
+                        stage('GitHub rc-testing-suite') {
+                            try {
+                                def payload = new JsonBuilder([
+                                    ref   : 'main',
+                                    inputs: [
+                                        rc_version             : params.RC_VERSION.trim(),
+                                        pmm_client_tarball_ol8 : params.PMM_CLIENT_TARBALL_OL8.trim(),
+                                        pmm_client_tarball_ol9 : params.PMM_CLIENT_TARBALL_OL9.trim(),
+                                        pmm_qa_branch          : 'main',
+                                        pxc_version            : '8.0',
+                                        pxc_glibc              : '2.35',
+                                        pdpgsql_version        : '17',
+                                        skip_compatibility     : env.IS_PATCH_RC == 'true',
+                                    ],
+                                ]).toString()
+                                writeFile file: 'rc-suite-dispatch.json', text: payload
+                                withCredentials([string(credentialsId: 'GITHUB_API_TOKEN', variable: 'GITHUB_TOKEN')]) {
+                                    sh """
+                                        set -euo pipefail
+                                        curl -fsS -X POST \\
+                                            -H "Accept: application/vnd.github+json" \\
+                                            -H "Authorization: Bearer \${GITHUB_TOKEN}" \\
+                                            -H "X-GitHub-Api-Version: 2022-11-28" \\
+                                            "https://api.github.com/repos/percona/pmm-qa/actions/workflows/rc-testing-suite.yml/dispatches" \\
+                                            --data @rc-suite-dispatch.json
+                                    """
+                                }
+                                slackRcMessage("*Github Release Testing Suite*: https://github.com/percona/pmm-qa/actions/workflows/rc-testing-suite.yml")
+                            } catch (err) {
+                                slackRcMessage("*Github Release Testing Suite* (dispatch failed): ${err.getMessage()}")
                             }
-                            slackRcMessage("*Github Release Testing Suite*: https://github.com/percona/pmm-qa/actions/workflows/rc-testing-suite.yml")
-                        } catch (err) {
-                            slackRcMessage("*Github Release Testing Suite* (dispatch failed): ${err.getMessage()}")
                         }
                     }
 
                     branches['pmm3-ui-tests-matrix'] = {
-                        triggerJenkinsRc('pmm3-ui-tests-matrix', 'pmm3-ui-tests-matrix', [
-                            string(name: 'PMM_QA_GIT_BRANCH', value: 'main'),
-                            string(name: 'GIT_COMMIT_HASH',  value: ''),
-                            string(name: 'DOCKER_VERSION',   value: env.PMM_SERVER_IMAGE),
-                            string(name: 'CLIENT_VERSION',   value: 'pmm3-rc'),
-                            string(name: 'MYSQL_IMAGE',      value: 'percona:5.7'),
-                            string(name: 'POSTGRES_IMAGE',   value: 'perconalab/percona-distribution-postgresql:16.0'),
-                            string(name: 'MONGO_IMAGE',      value: 'percona/percona-server-mongodb:4.4'),
-                            string(name: 'PROXYSQL_IMAGE',   value: 'proxysql/proxysql:2.3.0'),
-                            booleanParam(name: 'USE_ONDEMAND', value: true),
-                        ])
+                        stage('pmm3-ui-tests-matrix') {
+                            triggerJenkinsRc('pmm3-ui-tests-matrix', 'pmm3-ui-tests-matrix', [
+                                string(name: 'PMM_QA_GIT_BRANCH', value: 'main'),
+                                string(name: 'GIT_COMMIT_HASH',  value: ''),
+                                string(name: 'DOCKER_VERSION',   value: env.PMM_SERVER_IMAGE),
+                                string(name: 'CLIENT_VERSION',   value: 'pmm3-rc'),
+                                string(name: 'MYSQL_IMAGE',      value: 'percona:5.7'),
+                                string(name: 'POSTGRES_IMAGE',   value: 'perconalab/percona-distribution-postgresql:16.0'),
+                                string(name: 'MONGO_IMAGE',      value: 'percona/percona-server-mongodb:4.4'),
+                                string(name: 'PROXYSQL_IMAGE',   value: 'proxysql/proxysql:2.3.0'),
+                                booleanParam(name: 'USE_ONDEMAND', value: true),
+                            ])
+                        }
                     }
 
                     branches['pmm3-upgrade-ami-test'] = {
-                        triggerJenkinsRc('pmm3-upgrade-ami-test', 'pmm3-upgrade-ami-test', [
-                            string(name: 'PMM_QA_GIT_BRANCH',   value: 'main'),
-                            booleanParam(name: 'IS_RC_TESTING', value: true),
-                            booleanParam(name: 'USE_ONDEMAND', value: true),
-                        ])
+                        stage('pmm3-upgrade-ami-test') {
+                            triggerJenkinsRc('pmm3-upgrade-ami-test', 'pmm3-upgrade-ami-test', [
+                                string(name: 'PMM_QA_GIT_BRANCH',   value: 'main'),
+                                booleanParam(name: 'IS_RC_TESTING', value: true),
+                                booleanParam(name: 'USE_ONDEMAND', value: true),
+                            ])
+                        }
                     }
 
                     branches['pmm3-package-testing-matrix'] = {
-                        triggerJenkinsRc('pmm3-package-testing-matrix', 'pmm3-package-testing-matrix', [
-                            string(name: 'GIT_BRANCH',      value: 'main'),
-                            string(name: 'GIT_COMMIT_HASH', value: ''),
-                            string(name: 'DOCKER_VERSION',  value: env.PMM_SERVER_IMAGE),
-                            string(name: 'PMM_VERSION',     value: params.RC_VERSION.trim()),
-                            string(name: 'INSTALL_REPO',    value: 'testing'),
-                            string(name: 'TARBALL',         value: params.PMM_CLIENT_TARBALL.trim()),
-                            string(name: 'METRICS_MODE',    value: 'auto'),
-                            booleanParam(name: 'USE_ONDEMAND', value: true),
-                        ])
+                        stage('pmm3-package-testing-matrix') {
+                            triggerJenkinsRc('pmm3-package-testing-matrix', 'pmm3-package-testing-matrix', [
+                                string(name: 'GIT_BRANCH',      value: 'main'),
+                                string(name: 'GIT_COMMIT_HASH', value: ''),
+                                string(name: 'DOCKER_VERSION',  value: env.PMM_SERVER_IMAGE),
+                                string(name: 'PMM_VERSION',     value: params.RC_VERSION.trim()),
+                                string(name: 'INSTALL_REPO',    value: 'testing'),
+                                string(name: 'TARBALL',         value: params.PMM_CLIENT_TARBALL.trim()),
+                                string(name: 'METRICS_MODE',    value: 'auto'),
+                                booleanParam(name: 'USE_ONDEMAND', value: true),
+                            ])
+                        }
                     }
 
                     branches['pmm3-package-testing-arm-matrix'] = {
-                        triggerJenkinsRc('pmm3-package-testing-arm-matrix', 'pmm3-package-testing-arm-matrix', [
-                            string(name: 'GIT_BRANCH',      value: 'main'),
-                            string(name: 'GIT_COMMIT_HASH', value: ''),
-                            string(name: 'DOCKER_VERSION',  value: env.PMM_SERVER_IMAGE),
-                            string(name: 'SERVER_ARCH',     value: 'arm64'),
-                            string(name: 'PMM_VERSION',     value: params.RC_VERSION.trim()),
-                            string(name: 'INSTALL_REPO',    value: 'testing'),
-                            string(name: 'TARBALL',         value: params.PMM_CLIENT_TARBALL_ARM64.trim()),
-                            string(name: 'METRICS_MODE',    value: 'auto'),
-                            booleanParam(name: 'USE_ONDEMAND', value: true),
-                        ])
+                        stage('pmm3-package-testing-arm-matrix') {
+                            triggerJenkinsRc('pmm3-package-testing-arm-matrix', 'pmm3-package-testing-arm-matrix', [
+                                string(name: 'GIT_BRANCH',      value: 'main'),
+                                string(name: 'GIT_COMMIT_HASH', value: ''),
+                                string(name: 'DOCKER_VERSION',  value: env.PMM_SERVER_IMAGE),
+                                string(name: 'SERVER_ARCH',     value: 'arm64'),
+                                string(name: 'PMM_VERSION',     value: params.RC_VERSION.trim()),
+                                string(name: 'INSTALL_REPO',    value: 'testing'),
+                                string(name: 'TARBALL',         value: params.PMM_CLIENT_TARBALL_ARM64.trim()),
+                                string(name: 'METRICS_MODE',    value: 'auto'),
+                                booleanParam(name: 'USE_ONDEMAND', value: true),
+                            ])
+                        }
                     }
 
                     branches['pmm3-upgrade-tests-matrix'] = {
-                        triggerJenkinsRc('pmm3-upgrade-tests-matrix', 'pmm3-upgrade-tests-matrix', [
-                            string(name: 'PMM_QA_GIT_BRANCH', value: 'main'),
-                            booleanParam(name: 'USE_ONDEMAND', value: true),
-                        ])
+                        stage('pmm3-upgrade-tests-matrix') {
+                            triggerJenkinsRc('pmm3-upgrade-tests-matrix', 'pmm3-upgrade-tests-matrix', [
+                                string(name: 'PMM_QA_GIT_BRANCH', value: 'main'),
+                                booleanParam(name: 'USE_ONDEMAND', value: true),
+                            ])
+                        }
                     }
 
                     branches['PMM screenshots'] = {
-                        build job: 'pmm3-deploy-services', wait: false, propagate: false, parameters: [
-                            string(name: 'SERVER_TYPE',                    value: 'docker'),
-                            string(name: 'DOCKER_VERSION',                 value: env.PMM_SERVER_IMAGE),
-                            string(name: 'CLIENT_VERSION',                 value: 'pmm3-rc'),
-                            string(name: 'ENABLE_PULL_MODE',               value: 'no'),
-                            string(name: 'ADMIN_PASSWORD',                 value: 'pmm3admin!'),
-                            booleanParam(name: 'DEPLOY_EXTERNAL',          value: true),
-                            booleanParam(name: 'DEPLOY_MYSQL_GROUP',       value: true),
-                            booleanParam(name: 'DEPLOY_POSTGRES_GROUP',    value: true),
-                            booleanParam(name: 'DEPLOY_MONGO_GROUP',       value: true),
-                            booleanParam(name: 'DEPLOY_VALKEY',            value: true),
-                            string(name: 'PXC_VERSION',                    value: '8.0'),
-                            string(name: 'PS_VERSION',                     value: '8.4'),
-                            string(name: 'MS_VERSION',                     value: '8.4'),
-                            string(name: 'PGSQL_VERSION',                  value: '17'),
-                            string(name: 'PDPGSQL_VERSION',                value: '17'),
-                            string(name: 'PSMDB_VERSION',                  value: '8.0'),
-                            string(name: 'MODB_VERSION',                   value: '8.0'),
-                            string(name: 'PMM_QA_GIT_BRANCH',              value: 'main'),
-                            booleanParam(name: 'GENERATE_DASHBOARD_SCREENSHOTS', value: true),
-                            string(name: 'SCREENSHOTS_SLACK_TARGET',       value: env.SLACK_RC_SCREENSHOTS_TARGET),
-                            booleanParam(name: 'USE_ONDEMAND', value: true),
-                        ]
+                        stage('PMM screenshots') {
+                            build job: 'pmm3-deploy-services', wait: false, propagate: false, parameters: [
+                                string(name: 'SERVER_TYPE',                    value: 'docker'),
+                                string(name: 'DOCKER_VERSION',                 value: env.PMM_SERVER_IMAGE),
+                                string(name: 'CLIENT_VERSION',                 value: 'pmm3-rc'),
+                                string(name: 'ENABLE_PULL_MODE',               value: 'no'),
+                                string(name: 'ADMIN_PASSWORD',                 value: 'pmm3admin!'),
+                                booleanParam(name: 'DEPLOY_EXTERNAL',          value: true),
+                                booleanParam(name: 'DEPLOY_MYSQL_GROUP',       value: true),
+                                booleanParam(name: 'DEPLOY_POSTGRES_GROUP',    value: true),
+                                booleanParam(name: 'DEPLOY_MONGO_GROUP',       value: true),
+                                booleanParam(name: 'DEPLOY_VALKEY',            value: true),
+                                string(name: 'PXC_VERSION',                    value: '8.0'),
+                                string(name: 'PS_VERSION',                     value: '8.4'),
+                                string(name: 'MS_VERSION',                     value: '8.4'),
+                                string(name: 'PGSQL_VERSION',                  value: '17'),
+                                string(name: 'PDPGSQL_VERSION',                value: '17'),
+                                string(name: 'PSMDB_VERSION',                  value: '8.0'),
+                                string(name: 'MODB_VERSION',                   value: '8.0'),
+                                string(name: 'PMM_QA_GIT_BRANCH',              value: 'main'),
+                                booleanParam(name: 'GENERATE_DASHBOARD_SCREENSHOTS', value: true),
+                                string(name: 'SCREENSHOTS_SLACK_TARGET',       value: env.SLACK_RC_SCREENSHOTS_TARGET),
+                                booleanParam(name: 'USE_ONDEMAND', value: true),
+                            ]
+                        }
                     }
 
                     parallel branches

--- a/pmm/v3/pmm3-rc-testing.groovy
+++ b/pmm/v3/pmm3-rc-testing.groovy
@@ -40,6 +40,7 @@ def triggerNightlyGhaRc(String shortName, Map cfg = [:]) {
         PTS_CONFIDENCE    : '100',
     ]
     def params = (defaults + cfg).collect { k, v -> string(name: k, value: v.toString()) }
+    params << booleanParam(name: 'USE_ONDEMAND', value: true)
     triggerJenkinsRc(shortName, 'pmm3-ui-tests-nightly-gha', params)
 }
 
@@ -47,7 +48,7 @@ def triggerNightlyGhaRc(String shortName, Map cfg = [:]) {
 
 pipeline {
     agent {
-        label 'cli'
+        label 'cli-ondemand'
     }
     options {
         disableConcurrentBuilds()
@@ -250,6 +251,7 @@ pipeline {
                                         string(name: 'ADMIN_PASSWORD',          value: 'pmm3admin!'),
                                         string(name: 'PSMDB_VERSION',           value: '8.0'),
                                         string(name: 'MODB_VERSION',            value: '8.0'),
+                                        booleanParam(name: 'USE_ONDEMAND', value: true),
                                     ])
                                 }
                             }
@@ -263,6 +265,7 @@ pipeline {
                                         string(name: 'IMAGE_REPO',         value: env.PMM_SERVER_IMAGE.split(':')[0]),
                                         string(name: 'IMAGE_TAG',          value: env.PMM_SERVER_IMAGE.split(':')[1]),
                                         string(name: 'OPENSHIFT_VERSION',  value: 'latest'),
+                                        booleanParam(name: 'USE_ONDEMAND', value: true),
                                     ])
                                 }
                             }
@@ -320,6 +323,7 @@ pipeline {
                                         string(name: 'POSTGRES_IMAGE',   value: 'perconalab/percona-distribution-postgresql:16.0'),
                                         string(name: 'MONGO_IMAGE',      value: 'percona/percona-server-mongodb:4.4'),
                                         string(name: 'PROXYSQL_IMAGE',   value: 'proxysql/proxysql:2.3.0'),
+                                        booleanParam(name: 'USE_ONDEMAND', value: true),
                                     ])
                                 }
                             }
@@ -330,6 +334,7 @@ pipeline {
                                     triggerJenkinsRc('pmm3-upgrade-ami-test', 'pmm3-upgrade-ami-test', [
                                         string(name: 'PMM_QA_GIT_BRANCH',   value: 'main'),
                                         booleanParam(name: 'IS_RC_TESTING', value: true),
+                                        booleanParam(name: 'USE_ONDEMAND', value: true),
                                     ])
                                 }
                             }
@@ -401,6 +406,7 @@ pipeline {
                                         string(name: 'PMM_QA_GIT_BRANCH',              value: 'main'),
                                         booleanParam(name: 'GENERATE_DASHBOARD_SCREENSHOTS', value: true),
                                         string(name: 'SCREENSHOTS_SLACK_TARGET',       value: env.SLACK_RC_SCREENSHOTS_TARGET),
+                                        booleanParam(name: 'USE_ONDEMAND', value: true),
                                     ]
                                 }
                             }

--- a/pmm/v3/pmm3-ui-tests-matrix.groovy
+++ b/pmm/v3/pmm3-ui-tests-matrix.groovy
@@ -4,6 +4,7 @@ library changelog: false, identifier: 'lib@master', retriever: modernSCM([
 ]) _
 void runUITestsJob(String GIT_COMMIT_HASH, DOCKER_VERSION, CLIENT_VERSION, TAG, MYSQL_IMAGE, POSTGRES_IMAGE, MONGO_IMAGE, PROXYSQL_IMAGE, PMM_QA_GIT_BRANCH, CLIENTS) {
     build job: 'pmm3-ui-tests', parameters: [
+        booleanParam(name: 'USE_ONDEMAND', value: params.USE_ONDEMAND),
         string(name: 'GIT_COMMIT_HASH', value: GIT_COMMIT_HASH),
         string(name: 'DOCKER_VERSION', value: DOCKER_VERSION),
         string(name: 'CLIENT_VERSION', value: CLIENT_VERSION),
@@ -19,9 +20,13 @@ void runUITestsJob(String GIT_COMMIT_HASH, DOCKER_VERSION, CLIENT_VERSION, TAG, 
 
 pipeline {
     agent {
-        label 'agent-amd64'
+        label params.USE_ONDEMAND ? 'agent-amd64-ondemand' : 'agent-amd64'
     }
     parameters {
+        booleanParam(
+            defaultValue: false,
+            description: 'Use on-demand instances instead of spot (for RC/Release testing)',
+            name: 'USE_ONDEMAND')
         string(
             defaultValue: 'main',
             description: 'Tag/Branch for pmm-qa repository',

--- a/pmm/v3/pmm3-ui-tests-nightly-gha.groovy
+++ b/pmm/v3/pmm3-ui-tests-nightly-gha.groovy
@@ -87,6 +87,7 @@ def runHAClusterCreate(String K8S_VERSION, DOCKER_VERSION, HELM_CHART_BRANCH, AD
 
 void runAMIStagingStart(String AMI_ID) {
     amiStagingJob = build job: 'pmm3-ami-staging-start', parameters: [
+        booleanParam(name: 'USE_ONDEMAND', value: params.USE_ONDEMAND),
         string(name: 'AMI_ID', value: AMI_ID)
     ]
     env.AMI_INSTANCE_ID = amiStagingJob.buildVariables.INSTANCE_ID
@@ -100,15 +101,20 @@ void runAMIStagingStart(String AMI_ID) {
 
 void destroyStaging(IP) {
     build job: 'aws-staging-stop', parameters: [
+        booleanParam(name: 'USE_ONDEMAND', value: params.USE_ONDEMAND),
         string(name: 'VM', value: IP),
     ]
 }
 
 pipeline {
     agent {
-        label 'cli'
+        label params.USE_ONDEMAND ? 'cli-ondemand' : 'cli'
     }
     parameters {
+        booleanParam(
+            defaultValue: false,
+            description: 'Use on-demand instances instead of spot (for RC/Release testing)',
+            name: 'USE_ONDEMAND')
         string(
             defaultValue: 'main',
             description: 'Tag/Branch for pmm-qa repository (used both for the GH workflow ref and the client setup checkout inside the workers).',
@@ -292,6 +298,7 @@ pipeline {
                 // match this build's outcome regardless of GH workflow result.
                 if (env.SERVER_TYPE == "ami" && env.AMI_INSTANCE_ID) {
                     build job: 'pmm3-ami-staging-stop', parameters: [
+                        booleanParam(name: 'USE_ONDEMAND', value: params.USE_ONDEMAND),
                         string(name: 'AMI_ID', value: env.AMI_INSTANCE_ID),
                     ]
                 }

--- a/pmm/v3/pmm3-ui-tests-nightly-gha.groovy
+++ b/pmm/v3/pmm3-ui-tests-nightly-gha.groovy
@@ -7,6 +7,7 @@ def defaultAmiId = pmmVersion('v3-ami').values()[-1]
 
 void runStagingServer(String DOCKER_VERSION, CLIENT_VERSION, CLIENTS, CLIENT_INSTANCE, SERVER_IP, PMM_QA_GIT_BRANCH, ADMIN_PASSWORD = "admin", SERVER_ARCH = "amd64") {
     stagingJob = build job: 'pmm3-aws-staging-start', parameters: [
+        booleanParam(name: 'USE_ONDEMAND', value: params.USE_ONDEMAND),
         string(name: 'DOCKER_VERSION', value: DOCKER_VERSION),
         string(name: 'SERVER_ARCH', value: SERVER_ARCH),
         string(name: 'CLIENT_VERSION', value: CLIENT_VERSION),

--- a/pmm/v3/pmm3-ui-tests-nightly-gha.groovy
+++ b/pmm/v3/pmm3-ui-tests-nightly-gha.groovy
@@ -40,6 +40,7 @@ def runOpenshiftClusterCreate(String OPENSHIFT_VERSION, DOCKER_VERSION, ADMIN_PA
     def pmmImageTag = DOCKER_VERSION.split(":")[1]
 
     clusterCreateJob = build job: 'openshift-cluster-create', parameters: [
+        booleanParam(name: 'USE_ONDEMAND', value: params.USE_ONDEMAND),
         string(name: 'CLUSTER_NAME', value: clusterName),
         string(name: 'OPENSHIFT_VERSION', value: OPENSHIFT_VERSION),
         booleanParam(name: 'DEPLOY_PMM', value: true),
@@ -66,6 +67,7 @@ def runHAClusterCreate(String K8S_VERSION, DOCKER_VERSION, HELM_CHART_BRANCH, AD
     def pmmImageRepo = DOCKER_VERSION.split(":")[0]
 
     clusterCreateJob = build job: 'pmm3-ha-eks', parameters: [
+        booleanParam(name: 'USE_ONDEMAND', value: params.USE_ONDEMAND),
         string(name: 'K8S_VERSION', value: K8S_VERSION),
         string(name: 'HELM_CHART_BRANCH', value: HELM_CHART_BRANCH),
         string(name: 'PMM_IMAGE_REPOSITORY', value: pmmImageRepo),
@@ -305,6 +307,7 @@ pipeline {
                 }
                 if (env.SERVER_TYPE == "helm" && env.FINAL_CLUSTER_NAME) {
                     build job: 'openshift-cluster-destroy', parameters: [
+                        booleanParam(name: 'USE_ONDEMAND', value: params.USE_ONDEMAND),
                         string(name: 'CLUSTER_NAME', value: env.FINAL_CLUSTER_NAME),
                         string(name: 'DESTROY_REASON', value: 'testing-complete'),
                         booleanParam(name: 'FORCE_MODE', value: true),
@@ -312,6 +315,7 @@ pipeline {
                 }
                 if (env.SERVER_TYPE == "ha" && env.CLUSTER_NAME) {
                     build job: 'pmm3-ha-eks-cleanup', parameters: [
+                        booleanParam(name: 'USE_ONDEMAND', value: params.USE_ONDEMAND),
                         string(name: 'ACTION', value: 'DELETE_CLUSTER'),
                         string(name: 'CLUSTER_NAME', value: env.CLUSTER_NAME),
                     ]

--- a/pmm/v3/pmm3-ui-tests-nightly-gssapi.groovy
+++ b/pmm/v3/pmm3-ui-tests-nightly-gssapi.groovy
@@ -59,7 +59,6 @@ void runStagingClient(String DOCKER_VERSION, CLIENT_VERSION, CLIENTS, CLIENT_INS
 
 void destroyStaging(IP) {
     build job: 'aws-staging-stop', parameters: [
-        booleanParam(name: 'USE_ONDEMAND', value: params.USE_ONDEMAND),
         string(name: 'VM', value: IP),
     ]
 }
@@ -83,7 +82,7 @@ void checkClientNodesAgentStatus(String VM_CLIENT_IP, PMM_QA_GIT_BRANCH) {
 
 pipeline {
     agent {
-        label params.USE_ONDEMAND ? 'min-noble-x64-ondemand' : 'min-noble-x64'
+        label 'min-noble-x64'
     }
     environment {
         REMOTE_AWS_MYSQL_USER=credentials('pmm-dev-mysql-remote-user')
@@ -132,10 +131,6 @@ pipeline {
         ZEPHYR_PMM_API_KEY=credentials('ZEPHYR_PMM_API_KEY');
     }
     parameters {
-        booleanParam(
-            defaultValue: false,
-            description: 'Use on-demand instances instead of spot (for RC/Release testing)',
-            name: 'USE_ONDEMAND')
         string(
             defaultValue: 'main',
             description: 'Tag/Branch for pmm-qa repository',
@@ -285,7 +280,6 @@ pipeline {
             script {
                 if (env.SERVER_TYPE == "ami") {
                     amiStagingStopJob = build job: 'pmm3-ami-staging-stop', parameters: [
-                        booleanParam(name: 'USE_ONDEMAND', value: params.USE_ONDEMAND),
                         string(name: 'AMI_ID', value: env.AMI_INSTANCE_ID),
                     ]
                 }

--- a/pmm/v3/pmm3-ui-tests-nightly-gssapi.groovy
+++ b/pmm/v3/pmm3-ui-tests-nightly-gssapi.groovy
@@ -59,6 +59,7 @@ void runStagingClient(String DOCKER_VERSION, CLIENT_VERSION, CLIENTS, CLIENT_INS
 
 void destroyStaging(IP) {
     build job: 'aws-staging-stop', parameters: [
+        booleanParam(name: 'USE_ONDEMAND', value: params.USE_ONDEMAND),
         string(name: 'VM', value: IP),
     ]
 }
@@ -82,7 +83,7 @@ void checkClientNodesAgentStatus(String VM_CLIENT_IP, PMM_QA_GIT_BRANCH) {
 
 pipeline {
     agent {
-        label 'min-noble-x64'
+        label params.USE_ONDEMAND ? 'min-noble-x64-ondemand' : 'min-noble-x64'
     }
     environment {
         REMOTE_AWS_MYSQL_USER=credentials('pmm-dev-mysql-remote-user')
@@ -131,6 +132,10 @@ pipeline {
         ZEPHYR_PMM_API_KEY=credentials('ZEPHYR_PMM_API_KEY');
     }
     parameters {
+        booleanParam(
+            defaultValue: false,
+            description: 'Use on-demand instances instead of spot (for RC/Release testing)',
+            name: 'USE_ONDEMAND')
         string(
             defaultValue: 'main',
             description: 'Tag/Branch for pmm-qa repository',
@@ -280,6 +285,7 @@ pipeline {
             script {
                 if (env.SERVER_TYPE == "ami") {
                     amiStagingStopJob = build job: 'pmm3-ami-staging-stop', parameters: [
+                        booleanParam(name: 'USE_ONDEMAND', value: params.USE_ONDEMAND),
                         string(name: 'AMI_ID', value: env.AMI_INSTANCE_ID),
                     ]
                 }

--- a/pmm/v3/pmm3-ui-tests.groovy
+++ b/pmm/v3/pmm3-ui-tests.groovy
@@ -10,7 +10,7 @@ library changelog: false, identifier: 'v3lib@master', retriever: modernSCM(
 
 pipeline {
     agent {
-        label 'agent-amd64'
+        label params.USE_ONDEMAND ? 'agent-amd64-ondemand' : 'agent-amd64'
     }
     environment {
         AZURE_CLIENT_ID=credentials('AZURE_CLIENT_ID');
@@ -120,6 +120,10 @@ pipeline {
         ZEPHYR_PMM_API_KEY=credentials('ZEPHYR_PMM_API_KEY')
     }
     parameters {
+        booleanParam(
+            defaultValue: false,
+            description: 'Use on-demand instances instead of spot (for RC/Release testing)',
+            name: 'USE_ONDEMAND')
         string(
             defaultValue: 'main',
             description: 'Tag/Branch for pmm-qa repository',


### PR DESCRIPTION
## Why

#4325 moved the package and upgrade **test** agents off spot. The executors that orchestrate them stayed on it, and that is where a reclaim hurts most — `pmm3-package-testing-matrix` #129:

```
Agent EC2 (ec2-Docker Farm AWS-Dev b) - CLI (sir-ih1fkrkq) was deleted; cancelling node body
```

One evicted orchestrator cancelled the whole matrix. Two executors dominate the exposure:

- **`pmm3-rc-testing`** holds one for the entire cycle (48h timeout, ~8h in practice). Lose it and the run dies with no results and no Slack report.
- **`pmm3-ui-tests-nightly-gha`** holds one per lane (9 lanes in an RC) while `wait-for-gh-run-completion.sh` follows the GitHub run — and its `post { always }` owns the teardown of the AMI instance, EKS cluster or OpenShift cluster. An eviction there **leaks the resource**.

## What changed

`USE_ONDEMAND` added where it was missing, plus the label ternary, threaded down to the staging and teardown jobs so the value actually arrives:

| File | Label |
|---|---|
| `pmm3-rc-testing.groovy` | `cli` → **`cli-ondemand` unconditionally** — the job only ever runs for an RC; also passes `USE_ONDEMAND: true` to every job that now accepts it |
| `pmm3-ui-tests-nightly-gha.groovy` | `cli` ⇄ `cli-ondemand` |
| `pmm3-ui-tests-matrix.groovy` → `pmm3-ui-tests.groovy` | `agent-amd64` ⇄ `-ondemand` |
| `pmm3-openshift-helm-tests.groovy` | `min-noble-x64` ⇄ `-ondemand` |
| `pmm3-ami-staging-start.groovy` / `-stop.groovy` | `cli` ⇄ `cli-ondemand` |
| `aws-staging-stop.groovy` | `cli` ⇄ `cli-ondemand` |
| `pmm3-deploy-services.groovy` | stage-level `min-noble-x64` ⇄ `-ondemand`; pipeline-level `agent none` untouched, so the 24h Hold still releases the executor |

Everything defaults to `false`, so nightly and manual runs stay on spot. The short-lived `*-staging-stop` jobs are included on purpose: they run for a minute or two, but they are what releases the VM, so losing one leaks it.

A pass-through bug was caught by run #32 and fixed: `runStagingServer` in `pmm3-ui-tests-nightly-gha.groovy` and both `pmm3-aws-staging-start` calls in `pmm3-deploy-services.groovy` were not forwarding `USE_ONDEMAND`, so the arm64 lane still asked for a `t4g.xlarge` spot and failed with `Could not get a spot instance of type t4g.xlarge after 5 attempts`. All call sites in the diff were then audited for the same pattern.

**The lane structure of `pmm3-rc-testing` is unchanged in this PR.** Flattening it into one parallel fan-out was tried here and moved out to #4418, which is blocked on executor capacity — see that PR for the deadlock it exposed.

## Three RC jobs are not here, on purpose

They do not read their Jenkinsfile from master, so a change here would have no effect on them and would collide with their branch's version at merge time. Each was covered by a commit on the branch it actually reads:

| Job | Branch it reads |
|---|---|
| `pmm3-upgrade-ami-test`, `pmm3-upgrade-ami-test-runner` | `PMM-7-fix-ami-upgrade` |
| `pmm3-ui-tests-nightly-gssapi` | `PMM-7-fix-nightly-gssapi-3_8_0` |

`pmm3-rc-testing` still passes `USE_ONDEMAND: true` to all three, which is correct whichever side lands first.

## Note for whoever merges

Jenkins drops a parameter the target job has not registered yet, and a job only registers a new `parameters {}` entry after it runs the new Jenkinsfile once. So the **first** build of each of these after merge still routes to spot; the second honours the flag. `openshift-helm-tests`, `aws-staging-stop`, `pmm3-ami-staging-start`/`-stop`, `pmm3-ui-tests-matrix`, `pmm3-ui-tests` and `pmm3-deploy-services` are worth one manual no-op build before the next RC.

## Validation

Run from this branch against RC 3.9.1:

- every `-ondemand` label used here provisioned and ran: `cli-ondemand` (`pmm3-rc-testing` #31, `aws-staging-stop` #80862, `pmm3-ami-staging-start` #3255, `-stop` #3138 — all `i-06abe9eae974a5a00`), `agent-amd64-ondemand` (`pmm3-ui-tests` #11005 → `i-0057e047e376d5dbc`), `min-noble-x64-ondemand` (`pmm3-deploy-services` #130 → `i-0ccb6ddf696c59aa4`, first ever launch of that template);
- builds with the flag unset still landed on `sir-` spot ids;
- the arm64 pass-through fix verified live: `pmm3-aws-staging-start` #25325 received `USE_ONDEMAND: true` and logged `aws ec2 run-instances --instance-type t4g.xlarge`;
- teardown on abort works — cancelling #32 ran every child's `post { always }`, and `pmm3-ami-staging-stop` #3139 and `aws-staging-stop` #80865 both returned SUCCESS with no leaked instances.

Capacity note, independent of this PR: `agent-amd64-ondemand` has 5 executors (1 per node) and `cli-ondemand` has 5 on a single node. That is enough for the current lane structure, and it is what blocks #4418.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAA4rTkQmjq8kkYvn2TWeh