### PR TITLE
PMM-15197 Flatten the RC lanes into one parallel fan-out

### DIFF
--- a/pmm/v3/pmm3-rc-testing.groovy
+++ b/pmm/v3/pmm3-rc-testing.groovy
@@ -135,297 +135,218 @@ pipeline {
         }
 
         stage('Trigger RC suites') {
-            parallel {
-                stage('Lane 1') {
-                    stages {
-                        stage('nightly (AMI)') {
-                            steps {
-                                script {
-                                    triggerNightlyGhaRc('pmm3-ui-tests-nightly-gha (ami)', [
-                                        SERVER_TYPE: 'ami',
-                                    ])
-                                }
-                            }
+            steps {
+                script {
+                    def branches = [:]
+
+                    branches['nightly (ami)'] = {
+                        stage('nightly (ami)') {
+                            triggerNightlyGhaRc('pmm3-ui-tests-nightly-gha (ami)', [
+                                SERVER_TYPE: 'ami',
+                            ])
                         }
-                        stage('nightly (compat #1)') {
-                            when { expression { env.IS_PATCH_RC != 'true' } }
-                            steps {
-                                script {
-                                    def tags = readFile('compat-tags.txt').trim().split('\n').collect { it.trim() }.findAll { it }
-                                    def ver = tags[0]
-                                    triggerNightlyGhaRc("pmm3-ui-tests-nightly-gha (compat ${ver})", [
-                                        CLIENT_VERSION: ver,
-                                    ])
-                                }
-                            }
+                    }
+                    branches['nightly (docker)'] = {
+                        stage('nightly (docker)') {
+                            triggerNightlyGhaRc('pmm3-ui-tests-nightly-gha (docker)')
                         }
-                        stage('nightly (compat #2)') {
-                            when { expression { env.IS_PATCH_RC != 'true' } }
-                            steps {
-                                script {
-                                    def tags = readFile('compat-tags.txt').trim().split('\n').collect { it.trim() }.findAll { it }
-                                    def ver = tags[1]
-                                    triggerNightlyGhaRc("pmm3-ui-tests-nightly-gha (compat ${ver})", [
-                                        CLIENT_VERSION: ver,
-                                    ])
-                                }
-                            }
+                    }
+                    branches['nightly (docker, arm64 server)'] = {
+                        stage('nightly (docker, arm64 server)') {
+                            triggerNightlyGhaRc('pmm3-ui-tests-nightly-gha (docker, arm64)', [
+                                SERVER_ARCH: 'arm64',
+                            ])
                         }
-                        stage('nightly (compat #3)') {
-                            when { expression { env.IS_PATCH_RC != 'true' } }
-                            steps {
-                                script {
-                                    def tags = readFile('compat-tags.txt').trim().split('\n').collect { it.trim() }.findAll { it }
-                                    def ver = tags[2]
-                                    triggerNightlyGhaRc("pmm3-ui-tests-nightly-gha (compat ${ver})", [
-                                        CLIENT_VERSION: ver,
-                                    ])
-                                }
-                            }
+                    }
+                    branches['nightly (helm)'] = {
+                        stage('nightly (helm)') {
+                            triggerNightlyGhaRc('pmm3-ui-tests-nightly-gha (helm)', [
+                                SERVER_TYPE    : 'helm',
+                                ADMIN_PASSWORD : 'admin1',
+                            ])
                         }
-                        stage('nightly (compat #4)') {
-                            when { expression { env.IS_PATCH_RC != 'true' } }
-                            steps {
-                                script {
-                                    def tags = readFile('compat-tags.txt').trim().split('\n').collect { it.trim() }.findAll { it }
-                                    def ver = tags[3]
-                                    triggerNightlyGhaRc("pmm3-ui-tests-nightly-gha (compat ${ver})", [
-                                        CLIENT_VERSION: ver,
-                                    ])
-                                }
-                            }
+                    }
+                    branches['nightly (ha)'] = {
+                        stage('nightly (ha)') {
+                            triggerNightlyGhaRc('pmm3-ui-tests-nightly-gha (ha)', [
+                                SERVER_TYPE    : 'ha',
+                                ADMIN_PASSWORD : 'admin1',
+                            ])
                         }
-                        stage('nightly (compat #5)') {
-                            when { expression { env.IS_PATCH_RC != 'true' } }
-                            steps {
-                                script {
-                                    def tags = readFile('compat-tags.txt').trim().split('\n').collect { it.trim() }.findAll { it }
-                                    def ver = tags[4]
-                                    triggerNightlyGhaRc("pmm3-ui-tests-nightly-gha (compat ${ver})", [
-                                        CLIENT_VERSION: ver,
+                    }
+
+                    if (env.IS_PATCH_RC != 'true') {
+                        def compatTags = readFile('compat-tags.txt').trim().split('\n').collect { it.trim() }.findAll { it }
+                        compatTags.each { tag ->
+                            branches["nightly (compat ${tag})"] = {
+                                stage("nightly (compat ${tag})") {
+                                    triggerNightlyGhaRc("pmm3-ui-tests-nightly-gha (compat ${tag})", [
+                                        CLIENT_VERSION: tag,
                                     ])
                                 }
                             }
                         }
                     }
-                }
 
-                stage('Lane 2') {
-                    stages {
-                        stage('nightly (Docker)') {
-                            steps {
-                                script {
-                                    triggerNightlyGhaRc('pmm3-ui-tests-nightly-gha (docker)')
-                                }
-                            }
+                    branches['nightly (gssapi)'] = {
+                        stage('nightly (gssapi)') {
+                            triggerJenkinsRc('pmm3-ui-tests-nightly-gssapi', 'pmm3-ui-tests-nightly-gssapi', [
+                                string(name: 'PMM_QA_GIT_BRANCH',       value: 'main'),
+                                string(name: 'SERVER_TYPE',             value: 'docker'),
+                                string(name: 'DOCKER_VERSION',          value: env.PMM_SERVER_IMAGE),
+                                string(name: 'CLIENT_VERSION',          value: params.PMM_CLIENT_TARBALL_OL9.trim()),
+                                string(name: 'ENABLE_PULL_MODE',        value: 'no'),
+                                string(name: 'ADMIN_PASSWORD',          value: 'pmm3admin!'),
+                                string(name: 'PSMDB_VERSION',           value: '8.0'),
+                                string(name: 'MODB_VERSION',            value: '8.0'),
+                                booleanParam(name: 'USE_ONDEMAND', value: true),
+                            ])
                         }
-                        stage('nightly (Helm)') {
-                            steps {
-                                script {
-                                    triggerNightlyGhaRc('pmm3-ui-tests-nightly-gha (helm)', [
-                                        SERVER_TYPE    : 'helm',
-                                        ADMIN_PASSWORD : 'admin1',
-                                    ])
-                                }
-                            }
-                        }
-                        stage('nightly (HA)') {
-                            steps {
-                                script {
-                                    triggerNightlyGhaRc('pmm3-ui-tests-nightly-gha (ha)', [
-                                        SERVER_TYPE    : 'ha',
-                                        ADMIN_PASSWORD : 'admin1',
-                                    ])
-                                }
-                            }
-                        }
-                        stage('nightly (GSSAPI)') {
-                            steps {
-                                script {
-                                    triggerJenkinsRc('pmm3-ui-tests-nightly-gssapi', 'pmm3-ui-tests-nightly-gssapi', [
-                                        string(name: 'PMM_QA_GIT_BRANCH',       value: 'main'),
-                                        string(name: 'SERVER_TYPE',             value: 'docker'),
-                                        string(name: 'DOCKER_VERSION',          value: env.PMM_SERVER_IMAGE),
-                                        string(name: 'CLIENT_VERSION',          value: params.PMM_CLIENT_TARBALL_OL9.trim()),
-                                        string(name: 'ENABLE_PULL_MODE',        value: 'no'),
-                                        string(name: 'ADMIN_PASSWORD',          value: 'pmm3admin!'),
-                                        string(name: 'PSMDB_VERSION',           value: '8.0'),
-                                        string(name: 'MODB_VERSION',            value: '8.0'),
-                                        booleanParam(name: 'USE_ONDEMAND', value: true),
-                                    ])
-                                }
-                            }
-                        }
+                    }
+
+                    branches['openshift-helm-tests'] = {
                         stage('openshift-helm-tests') {
-                            steps {
-                                script {
-                                    triggerJenkinsRc('openshift-helm-tests', 'openshift-helm-tests', [
-                                        string(name: 'PMM_QA_GIT_BRANCH',  value: 'main'),
-                                        string(name: 'PMM_CHART_BRANCH',   value: 'latest'),
-                                        string(name: 'IMAGE_REPO',         value: env.PMM_SERVER_IMAGE.split(':')[0]),
-                                        string(name: 'IMAGE_TAG',          value: env.PMM_SERVER_IMAGE.split(':')[1]),
-                                        string(name: 'OPENSHIFT_VERSION',  value: 'latest'),
-                                        booleanParam(name: 'USE_ONDEMAND', value: true),
-                                    ])
-                                }
-                            }
+                            triggerJenkinsRc('openshift-helm-tests', 'openshift-helm-tests', [
+                                string(name: 'PMM_QA_GIT_BRANCH',  value: 'main'),
+                                string(name: 'PMM_CHART_BRANCH',   value: 'latest'),
+                                string(name: 'IMAGE_REPO',         value: env.PMM_SERVER_IMAGE.split(':')[0]),
+                                string(name: 'IMAGE_TAG',          value: env.PMM_SERVER_IMAGE.split(':')[1]),
+                                string(name: 'OPENSHIFT_VERSION',  value: 'latest'),
+                                booleanParam(name: 'USE_ONDEMAND', value: true),
+                            ])
                         }
                     }
-                }
 
-                stage('Lane 3') {
-                    stages {
+                    branches['GitHub rc-testing-suite'] = {
                         stage('GitHub rc-testing-suite') {
-                            steps {
-                                script {
-                                    try {
-                                        def payload = new JsonBuilder([
-                                            ref   : 'main',
-                                            inputs: [
-                                                rc_version             : params.RC_VERSION.trim(),
-                                                pmm_client_tarball_ol8 : params.PMM_CLIENT_TARBALL_OL8.trim(),
-                                                pmm_client_tarball_ol9 : params.PMM_CLIENT_TARBALL_OL9.trim(),
-                                                pmm_qa_branch          : 'main',
-                                                pxc_version            : '8.0',
-                                                pxc_glibc              : '2.35',
-                                                pdpgsql_version        : '17',
-                                                skip_compatibility     : env.IS_PATCH_RC == 'true',
-                                            ],
-                                        ]).toString()
-                                        writeFile file: 'rc-suite-dispatch.json', text: payload
-                                        withCredentials([string(credentialsId: 'GITHUB_API_TOKEN', variable: 'GITHUB_TOKEN')]) {
-                                            sh """
-                                                set -euo pipefail
-                                                curl -fsS -X POST \\
-                                                    -H "Accept: application/vnd.github+json" \\
-                                                    -H "Authorization: Bearer \${GITHUB_TOKEN}" \\
-                                                    -H "X-GitHub-Api-Version: 2022-11-28" \\
-                                                    "https://api.github.com/repos/percona/pmm-qa/actions/workflows/rc-testing-suite.yml/dispatches" \\
-                                                    --data @rc-suite-dispatch.json
-                                            """
-                                        }
-                                        slackRcMessage("*Github Release Testing Suite*: https://github.com/percona/pmm-qa/actions/workflows/rc-testing-suite.yml")
-                                    } catch (err) {
-                                        slackRcMessage("*Github Release Testing Suite* (dispatch failed): ${err.getMessage()}")
-                                    }
+                            try {
+                                def payload = new JsonBuilder([
+                                    ref   : 'main',
+                                    inputs: [
+                                        rc_version             : params.RC_VERSION.trim(),
+                                        pmm_client_tarball_ol8 : params.PMM_CLIENT_TARBALL_OL8.trim(),
+                                        pmm_client_tarball_ol9 : params.PMM_CLIENT_TARBALL_OL9.trim(),
+                                        pmm_qa_branch          : 'main',
+                                        pxc_version            : '8.0',
+                                        pxc_glibc              : '2.35',
+                                        pdpgsql_version        : '17',
+                                        skip_compatibility     : env.IS_PATCH_RC == 'true',
+                                    ],
+                                ]).toString()
+                                writeFile file: 'rc-suite-dispatch.json', text: payload
+                                withCredentials([string(credentialsId: 'GITHUB_API_TOKEN', variable: 'GITHUB_TOKEN')]) {
+                                    sh """
+                                        set -euo pipefail
+                                        curl -fsS -X POST \\
+                                            -H "Accept: application/vnd.github+json" \\
+                                            -H "Authorization: Bearer \${GITHUB_TOKEN}" \\
+                                            -H "X-GitHub-Api-Version: 2022-11-28" \\
+                                            "https://api.github.com/repos/percona/pmm-qa/actions/workflows/rc-testing-suite.yml/dispatches" \\
+                                            --data @rc-suite-dispatch.json
+                                    """
                                 }
-                            }
-                        }
-                        stage('pmm3-ui-tests-matrix') {
-                            steps {
-                                script {
-                                    triggerJenkinsRc('pmm3-ui-tests-matrix', 'pmm3-ui-tests-matrix', [
-                                        string(name: 'PMM_QA_GIT_BRANCH', value: 'main'),
-                                        string(name: 'GIT_COMMIT_HASH',  value: ''),
-                                        string(name: 'DOCKER_VERSION',   value: env.PMM_SERVER_IMAGE),
-                                        string(name: 'CLIENT_VERSION',   value: 'pmm3-rc'),
-                                        string(name: 'MYSQL_IMAGE',      value: 'percona:5.7'),
-                                        string(name: 'POSTGRES_IMAGE',   value: 'perconalab/percona-distribution-postgresql:16.0'),
-                                        string(name: 'MONGO_IMAGE',      value: 'percona/percona-server-mongodb:4.4'),
-                                        string(name: 'PROXYSQL_IMAGE',   value: 'proxysql/proxysql:2.3.0'),
-                                        booleanParam(name: 'USE_ONDEMAND', value: true),
-                                    ])
-                                }
-                            }
-                        }
-                        stage('pmm3-upgrade-ami-test') {
-                            steps {
-                                script {
-                                    triggerJenkinsRc('pmm3-upgrade-ami-test', 'pmm3-upgrade-ami-test', [
-                                        string(name: 'PMM_QA_GIT_BRANCH',   value: 'main'),
-                                        booleanParam(name: 'IS_RC_TESTING', value: true),
-                                        booleanParam(name: 'USE_ONDEMAND', value: true),
-                                    ])
-                                }
-                            }
-                        }
-                        stage('pmm3-package-testing-matrix') {
-                            steps {
-                                script {
-                                    triggerJenkinsRc('pmm3-package-testing-matrix', 'pmm3-package-testing-matrix', [
-                                        string(name: 'GIT_BRANCH',      value: 'main'),
-                                        string(name: 'GIT_COMMIT_HASH', value: ''),
-                                        string(name: 'DOCKER_VERSION',  value: env.PMM_SERVER_IMAGE),
-                                        string(name: 'PMM_VERSION',     value: params.RC_VERSION.trim()),
-                                        string(name: 'INSTALL_REPO',    value: 'testing'),
-                                        string(name: 'TARBALL',         value: params.PMM_CLIENT_TARBALL.trim()),
-                                        string(name: 'METRICS_MODE',    value: 'auto'),
-                                        booleanParam(name: 'USE_ONDEMAND', value: true),
-                                    ])
-                                }
-                            }
-                        }
-                        stage('pmm3-package-testing-arm-matrix') {
-                            steps {
-                                script {
-                                    triggerJenkinsRc('pmm3-package-testing-arm-matrix', 'pmm3-package-testing-arm-matrix', [
-                                        string(name: 'GIT_BRANCH',      value: 'main'),
-                                        string(name: 'GIT_COMMIT_HASH', value: ''),
-                                        string(name: 'DOCKER_VERSION',  value: env.PMM_SERVER_IMAGE),
-                                        string(name: 'SERVER_ARCH',     value: 'arm64'),
-                                        string(name: 'PMM_VERSION',     value: params.RC_VERSION.trim()),
-                                        string(name: 'INSTALL_REPO',    value: 'testing'),
-                                        string(name: 'TARBALL',         value: params.PMM_CLIENT_TARBALL_ARM64.trim()),
-                                        string(name: 'METRICS_MODE',    value: 'auto'),
-                                        booleanParam(name: 'USE_ONDEMAND', value: true),
-                                    ])
-                                }
-                            }
-                        }
-                        stage('pmm3-upgrade-tests-matrix') {
-                            steps {
-                                script {
-                                    triggerJenkinsRc('pmm3-upgrade-tests-matrix', 'pmm3-upgrade-tests-matrix', [
-                                        string(name: 'PMM_QA_GIT_BRANCH', value: 'main'),
-                                        booleanParam(name: 'USE_ONDEMAND', value: true),
-                                    ])
-                                }
-                            }
-                        }
-                        stage('PMM screenshots') {
-                            steps {
-                                script {
-                                    build job: 'pmm3-deploy-services', wait: false, propagate: false, parameters: [
-                                        string(name: 'SERVER_TYPE',                    value: 'docker'),
-                                        string(name: 'DOCKER_VERSION',                 value: env.PMM_SERVER_IMAGE),
-                                        string(name: 'CLIENT_VERSION',                 value: 'pmm3-rc'),
-                                        string(name: 'ENABLE_PULL_MODE',               value: 'no'),
-                                        string(name: 'ADMIN_PASSWORD',                 value: 'pmm3admin!'),
-                                        booleanParam(name: 'DEPLOY_EXTERNAL',          value: true),
-                                        booleanParam(name: 'DEPLOY_MYSQL_GROUP',       value: true),
-                                        booleanParam(name: 'DEPLOY_POSTGRES_GROUP',    value: true),
-                                        booleanParam(name: 'DEPLOY_MONGO_GROUP',       value: true),
-                                        booleanParam(name: 'DEPLOY_VALKEY',            value: true),
-                                        string(name: 'PXC_VERSION',                    value: '8.0'),
-                                        string(name: 'PS_VERSION',                     value: '8.4'),
-                                        string(name: 'MS_VERSION',                     value: '8.4'),
-                                        string(name: 'PGSQL_VERSION',                  value: '17'),
-                                        string(name: 'PDPGSQL_VERSION',                value: '17'),
-                                        string(name: 'PSMDB_VERSION',                  value: '8.0'),
-                                        string(name: 'MODB_VERSION',                   value: '8.0'),
-                                        string(name: 'PMM_QA_GIT_BRANCH',              value: 'main'),
-                                        booleanParam(name: 'GENERATE_DASHBOARD_SCREENSHOTS', value: true),
-                                        string(name: 'SCREENSHOTS_SLACK_TARGET',       value: env.SLACK_RC_SCREENSHOTS_TARGET),
-                                        booleanParam(name: 'USE_ONDEMAND', value: true),
-                                    ]
-                                }
+                                slackRcMessage("*Github Release Testing Suite*: https://github.com/percona/pmm-qa/actions/workflows/rc-testing-suite.yml")
+                            } catch (err) {
+                                slackRcMessage("*Github Release Testing Suite* (dispatch failed): ${err.getMessage()}")
                             }
                         }
                     }
-                }
 
-                stage('Lane 4 (arm64)') {
-                    stages {
-                        stage('nightly (Docker, arm64 server)') {
-                            steps {
-                                script {
-                                    triggerNightlyGhaRc('pmm3-ui-tests-nightly-gha (docker, arm64)', [
-                                        SERVER_ARCH: 'arm64',
-                                    ])
-                                }
-                            }
+                    branches['pmm3-ui-tests-matrix'] = {
+                        stage('pmm3-ui-tests-matrix') {
+                            triggerJenkinsRc('pmm3-ui-tests-matrix', 'pmm3-ui-tests-matrix', [
+                                string(name: 'PMM_QA_GIT_BRANCH', value: 'main'),
+                                string(name: 'GIT_COMMIT_HASH',  value: ''),
+                                string(name: 'DOCKER_VERSION',   value: env.PMM_SERVER_IMAGE),
+                                string(name: 'CLIENT_VERSION',   value: 'pmm3-rc'),
+                                string(name: 'MYSQL_IMAGE',      value: 'percona:5.7'),
+                                string(name: 'POSTGRES_IMAGE',   value: 'perconalab/percona-distribution-postgresql:16.0'),
+                                string(name: 'MONGO_IMAGE',      value: 'percona/percona-server-mongodb:4.4'),
+                                string(name: 'PROXYSQL_IMAGE',   value: 'proxysql/proxysql:2.3.0'),
+                                booleanParam(name: 'USE_ONDEMAND', value: true),
+                            ])
                         }
                     }
+
+                    branches['pmm3-upgrade-ami-test'] = {
+                        stage('pmm3-upgrade-ami-test') {
+                            triggerJenkinsRc('pmm3-upgrade-ami-test', 'pmm3-upgrade-ami-test', [
+                                string(name: 'PMM_QA_GIT_BRANCH',   value: 'main'),
+                                booleanParam(name: 'IS_RC_TESTING', value: true),
+                                booleanParam(name: 'USE_ONDEMAND', value: true),
+                            ])
+                        }
+                    }
+
+                    branches['pmm3-package-testing-matrix'] = {
+                        stage('pmm3-package-testing-matrix') {
+                            triggerJenkinsRc('pmm3-package-testing-matrix', 'pmm3-package-testing-matrix', [
+                                string(name: 'GIT_BRANCH',      value: 'main'),
+                                string(name: 'GIT_COMMIT_HASH', value: ''),
+                                string(name: 'DOCKER_VERSION',  value: env.PMM_SERVER_IMAGE),
+                                string(name: 'PMM_VERSION',     value: params.RC_VERSION.trim()),
+                                string(name: 'INSTALL_REPO',    value: 'testing'),
+                                string(name: 'TARBALL',         value: params.PMM_CLIENT_TARBALL.trim()),
+                                string(name: 'METRICS_MODE',    value: 'auto'),
+                                booleanParam(name: 'USE_ONDEMAND', value: true),
+                            ])
+                        }
+                    }
+
+                    branches['pmm3-package-testing-arm-matrix'] = {
+                        stage('pmm3-package-testing-arm-matrix') {
+                            triggerJenkinsRc('pmm3-package-testing-arm-matrix', 'pmm3-package-testing-arm-matrix', [
+                                string(name: 'GIT_BRANCH',      value: 'main'),
+                                string(name: 'GIT_COMMIT_HASH', value: ''),
+                                string(name: 'DOCKER_VERSION',  value: env.PMM_SERVER_IMAGE),
+                                string(name: 'SERVER_ARCH',     value: 'arm64'),
+                                string(name: 'PMM_VERSION',     value: params.RC_VERSION.trim()),
+                                string(name: 'INSTALL_REPO',    value: 'testing'),
+                                string(name: 'TARBALL',         value: params.PMM_CLIENT_TARBALL_ARM64.trim()),
+                                string(name: 'METRICS_MODE',    value: 'auto'),
+                                booleanParam(name: 'USE_ONDEMAND', value: true),
+                            ])
+                        }
+                    }
+
+                    branches['pmm3-upgrade-tests-matrix'] = {
+                        stage('pmm3-upgrade-tests-matrix') {
+                            triggerJenkinsRc('pmm3-upgrade-tests-matrix', 'pmm3-upgrade-tests-matrix', [
+                                string(name: 'PMM_QA_GIT_BRANCH', value: 'main'),
+                                booleanParam(name: 'USE_ONDEMAND', value: true),
+                            ])
+                        }
+                    }
+
+                    branches['PMM screenshots'] = {
+                        stage('PMM screenshots') {
+                            build job: 'pmm3-deploy-services', wait: false, propagate: false, parameters: [
+                                string(name: 'SERVER_TYPE',                    value: 'docker'),
+                                string(name: 'DOCKER_VERSION',                 value: env.PMM_SERVER_IMAGE),
+                                string(name: 'CLIENT_VERSION',                 value: 'pmm3-rc'),
+                                string(name: 'ENABLE_PULL_MODE',               value: 'no'),
+                                string(name: 'ADMIN_PASSWORD',                 value: 'pmm3admin!'),
+                                booleanParam(name: 'DEPLOY_EXTERNAL',          value: true),
+                                booleanParam(name: 'DEPLOY_MYSQL_GROUP',       value: true),
+                                booleanParam(name: 'DEPLOY_POSTGRES_GROUP',    value: true),
+                                booleanParam(name: 'DEPLOY_MONGO_GROUP',       value: true),
+                                booleanParam(name: 'DEPLOY_VALKEY',            value: true),
+                                string(name: 'PXC_VERSION',                    value: '8.0'),
+                                string(name: 'PS_VERSION',                     value: '8.4'),
+                                string(name: 'MS_VERSION',                     value: '8.4'),
+                                string(name: 'PGSQL_VERSION',                  value: '17'),
+                                string(name: 'PDPGSQL_VERSION',                value: '17'),
+                                string(name: 'PSMDB_VERSION',                  value: '8.0'),
+                                string(name: 'MODB_VERSION',                   value: '8.0'),
+                                string(name: 'PMM_QA_GIT_BRANCH',              value: 'main'),
+                                booleanParam(name: 'GENERATE_DASHBOARD_SCREENSHOTS', value: true),
+                                string(name: 'SCREENSHOTS_SLACK_TARGET',       value: env.SLACK_RC_SCREENSHOTS_TARGET),
+                                booleanParam(name: 'USE_ONDEMAND', value: true),
+                            ]
+                        }
+                    }
+
+                    parallel branches
                 }
             }
         }


### PR DESCRIPTION
> **Draft — blocked on executor capacity. Do not merge yet.** Run #33 executed this and deadlocked; details below.

Split out of #4417 so the on-demand work there can land on its own. Based on that branch, so this diff is the flattening alone.

## Why

The four lanes serialised jobs that have no dependency on each other. Measured on run #30 (7h57m total):

| Lane | Sum of its jobs |
|---|---|
| Lane 1 (AMI + 5 compat) | 8m |
| Lane 2 (docker, helm, HA, gssapi, openshift) | 6h31m |
| **Lane 3** (gh, ui-matrix, upgrade-ami, pkg amd, pkg arm, upgrade-matrix, screenshots) | **7h56m** |
| Lane 4 (arm64) | 3m |

Lane 3 alone was 7h56m of the 7h57m run. The lanes were the critical path, not the work.

## What changed

`Lane 1..4` become a single `parallel` map keyed by job name, each branch wrapped in `stage()` so the stage view keeps its per-job breakdown. The run then finishes with its slowest **single** job (`pmm3-upgrade-tests-matrix`, 2h54m in #30) rather than its slowest lane. The five copy-pasted compat stages collapse into a loop over `compat-tags.txt`.

Also cheaper, not more expensive: same test instance-hours, but `pmm3-rc-testing` holds its `cli-ondemand` executor ~3h instead of ~8h, likewise the three matrix orchestrators.

## Why it is blocked

Run #33 ran this end to end. The fan-out itself worked — all 17 branches triggered within 12 seconds, and `openshift-helm-tests` (5h27m into run #30) and `pmm3-upgrade-tests-matrix` (5h into #30) both started at minute five. It also confirmed `docker-ondemand` works, which had never been exercised (`pmm3-upgrade-tests` #2307-2312).

Then it deadlocked. `agent-amd64-ondemand` has **5 executors, 1 per node**, and all five ended up held by parents blocked on a child that needs the same label:

| Node | Held by | Waiting on |
|---|---|---|
| `i-0b582219a748a0330` | `pmm3-package-testing-arm #6930` | `pmm3-aws-staging-start` |
| `i-09a71f9b730929de3` | `pmm3-package-testing-arm #6932` | `pmm3-aws-staging-start` |
| `i-0f1a738291baaf910` | `pmm3-package-testing-arm #6934` | `pmm3-aws-staging-start` |
| `i-03040e27a77e3d561` | `pmm3-package-testing-arm #6935` | `pmm3-aws-staging-start` |
| `i-06190c2268b5b0f31` | `pmm3-ui-tests-matrix #2264` | `pmm3-ui-tests` |

`pmm3-aws-staging-start` and `pmm3-ui-tests` both run on `agent-amd64-ondemand`. Eight staging-start builds (#25326-25333) sat at `duration: 0` for 28 minutes with `All nodes of label 'agent-amd64-ondemand' are offline` and no possible way to get an executor. `cli-ondemand` was simultaneously 5/5, with `pmm3-package-testing-arm-matrix #589` there blocked on the same starved children — the two pools deadlocked against each other.

The lanes had been implicitly capping how many parents could be in that waiting state at once. Flattening removed that cap.

Raising the caps alone does not fix this in principle: the number of blocked parents scales with the fan-out, so any finite cap can be exhausted. Swapping labels between the two existing pools only moves which one deadlocks.

## What this needs before merge

One of:

1. **A dedicated label for `pmm3-aws-staging-start`** that no caller uses (e.g. `staging-ondemand`) — the structural fix, since a job everyone blocks on must never compete with its callers. Requires a new template in the UI-only `ec2-Docker Farm AWS-Dev` cloud.
2. **Caps sized for the real peak** — ~25 concurrent on `agent-amd64-ondemand`, not incrementally more.
3. **An explicit concurrency limit** on the fan-out (`lock`/`throttle`), accepting a ceiling below full parallelism.

## Not exercised

3.9.1 is a patch RC, so `IS_PATCH_RC=true` and the five compat branches are skipped. The compat loop that replaced them stays unproven until a minor RC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAA4rTkQmjq8kkYvn2TWeh

---
_Generated by [Claude Code](https://claude.ai/code/session_01JAA4rTkQmjq8kkYvn2TWeh)_