### PR TITLE
Disable concurrent builds for pxc-package-testing pipeline

### DIFF
--- a/pxc/jenkins/pxc-package-testing.groovy
+++ b/pxc/jenkins/pxc-package-testing.groovy
@@ -975,6 +975,7 @@ pipeline {
     options {
         buildDiscarder(logRotator(numToKeepStr: '100'))
         timeout(time: 6, unit: 'HOURS')
+        disableConcurrentBuilds()
     }
 
     environment {

--- a/pxc/jenkins/pxc-package-testing.groovy
+++ b/pxc/jenkins/pxc-package-testing.groovy
@@ -1,6 +1,6 @@
-library changelog: false, identifier: 'lib@master', retriever: modernSCM([
+library changelog: false, identifier: 'lib@fix-pxc-maj-upgrade-concurrent-builds', retriever: modernSCM([
     $class: 'GitSCMSource',
-    remote: 'https://github.com/Percona-Lab/jenkins-pipelines.git'
+    remote: 'https://github.com/kaushikpuneet07/jenkins-pipelines.git'
 ]) _
 
 import groovy.transform.Field


### PR DESCRIPTION
The Molecule ephemeral directory / SSH key cache path used for post-build log backup (e.g. /home/admin/.cache/molecule/<product>- bootstrap-<test_type>/<node_to_test>/ssh_key-<region>) is not scoped by BUILD_NUMBER. When two builds for the same product/node/test_type run concurrently on the same agent, a newer build's molecule create step recreates that shared directory (and SSH key) out from under an older build's still-running post{} log backup step, causing "Permission denied (publickey)" / missing key file failures (seen on pxc97 maj_upgrade debian-12-arm). Disable concurrent builds to remove the race.