### PR TITLE
Copy Molecule SSH keys into workspace for post-build log backup

### DIFF
--- a/pxc/jenkins/pxc-package-testing.groovy
+++ b/pxc/jenkins/pxc-package-testing.groovy
@@ -283,6 +283,19 @@ def runMoleculeAction(String action, String product_to_test, String scenario, St
                     cd ${product_to_test}-common-${param_test_type}
                     molecule ${action} -s ${scenario}
                     cd -
+
+                    if [ "${action}" = "create" ]; then
+                        # Copy the Molecule-generated SSH keys into the Jenkins workspace so that
+                        # later steps (e.g. the post-build log backup) don't depend on Molecule's
+                        # ephemeral cache directory under /home/admin/.cache, which can be
+                        # recreated or removed by another build before this build's post{} steps run.
+                        mkdir -p "${WORKSPACE}/${product_to_test}-bootstrap/${scenario}/${param_test_type}/"
+                        mkdir -p "${WORKSPACE}/${product_to_test}-common/${scenario}/${param_test_type}/"
+                        cp "/home/admin/.cache/molecule/${product_to_test}-bootstrap-${param_test_type}/${scenario}/ssh_key-us-west-1" "${WORKSPACE}/${product_to_test}-bootstrap/${scenario}/${param_test_type}/ssh_key-us-west-1"
+                        chmod 600 "${WORKSPACE}/${product_to_test}-bootstrap/${scenario}/${param_test_type}/ssh_key-us-west-1"
+                        cp "/home/admin/.cache/molecule/${product_to_test}-common-${param_test_type}/${scenario}/ssh_key-us-west-1" "${WORKSPACE}/${product_to_test}-common/${scenario}/${param_test_type}/ssh_key-us-west-1"
+                        chmod 600 "${WORKSPACE}/${product_to_test}-common/${scenario}/${param_test_type}/ssh_key-us-west-1"
+                    fi
                 """
             }else{
 
@@ -434,8 +447,11 @@ void setInventories(String param_test_type){
                     def KEYPATH_COMMON
                     def SSH_USER
 
-                    KEYPATH_BOOTSTRAP="/home/admin/.cache/molecule/${product_to_test}-bootstrap-${param_test_type}/${params.node_to_test}/ssh_key-us-west-1"
-                    KEYPATH_COMMON="/home/admin/.cache/molecule/${product_to_test}-common-${param_test_type}/${params.node_to_test}/ssh_key-us-west-1"
+                    // Use the workspace copy of the SSH key made right after "molecule create"
+                    // (see runMoleculeAction) instead of Molecule's ephemeral cache directory,
+                    // which is shared across builds and can be recreated/removed by another build.
+                    KEYPATH_BOOTSTRAP="${WORKSPACE}/${product_to_test}-bootstrap/${params.node_to_test}/${param_test_type}/ssh_key-us-west-1"
+                    KEYPATH_COMMON="${WORKSPACE}/${product_to_test}-common/${params.node_to_test}/${param_test_type}/ssh_key-us-west-1"
 
 
                     if(("${params.node_to_test}" == "ubuntu-resolute") || ("${params.node_to_test}" == "ubuntu-resolute-arm") || ("${params.node_to_test}" == "ubuntu-noble") || ("${params.node_to_test}" == "ubuntu-focal") || ("${params.node_to_test}" == "ubuntu-jammy") || ("${params.node_to_test}" == "ubuntu-noble-arm") || ("${params.node_to_test}" == "ubuntu-jammy-arm") || ("${params.node_to_test}" == "ubuntu-focal-arm") || ("${params.node_to_test}" == "ubuntu-bionic")){

--- a/pxc/jenkins/pxc-package-testing.groovy
+++ b/pxc/jenkins/pxc-package-testing.groovy
@@ -1,6 +1,6 @@
-library changelog: false, identifier: 'lib@copy-ssh-key-to-workspace', retriever: modernSCM([
+library changelog: false, identifier: 'lib@master', retriever: modernSCM([
     $class: 'GitSCMSource',
-    remote: 'https://github.com/kaushikpuneet07/jenkins-pipelines.git'
+    remote: 'https://github.com/Percona-Lab/jenkins-pipelines.git'
 ]) _
 
 import groovy.transform.Field

--- a/pxc/jenkins/pxc-package-testing.groovy
+++ b/pxc/jenkins/pxc-package-testing.groovy
@@ -1,6 +1,6 @@
-library changelog: false, identifier: 'lib@master', retriever: modernSCM([
+library changelog: false, identifier: 'lib@copy-ssh-key-to-workspace', retriever: modernSCM([
     $class: 'GitSCMSource',
-    remote: 'https://github.com/Percona-Lab/jenkins-pipelines.git'
+    remote: 'https://github.com/kaushikpuneet07/jenkins-pipelines.git'
 ]) _
 
 import groovy.transform.Field


### PR DESCRIPTION
The generated inventory used by logsbackup.yml pointed ansible_ssh_private_key_file at Molecule's ephemeral cache directory (/home/admin/.cache/molecule/<product>-bootstrap-<test_type>/<node>/ ssh_key-<region>), which is shared across builds on the same agent and can be recreated or removed by another build before this build's post{} log-backup step runs, causing "Permission denied (publickey)" failures (seen on pxc97 maj_upgrade for debian-12-arm and rhel-10-arm).

Copy each bootstrap/common SSH key into the per-build $WORKSPACE right after "molecule create", and point KEYPATH_BOOTSTRAP/ KEYPATH_COMMON at that copy instead, so the log backup step no longer depends on the external, mutable cache path.