### PR TITLE
PMM-15197 Give the GSSAPI lane the dynamic client

### DIFF
--- a/pmm/v3/pmm3-nightly-orchestrator.groovy
+++ b/pmm/v3/pmm3-nightly-orchestrator.groovy
@@ -34,10 +34,6 @@ import groovy.json.JsonBuilder
 // (see mirrorChild). So a lane is "suite name" followed by the job, the build
 // number and one box per stage the child ran.
 
-// The GSSAPI suite needs the dynamic client tarball, not a package client;
-// see the gssapi lane below for why.
-GSSAPI_CLIENT_TARBALL = 'https://s3.us-east-2.amazonaws.com/pmm-build-cache/PR-BUILDS/pmm-client/pmm-client-dynamic-ol9-latest.tar.gz'
-
 properties([
     buildDiscarder(logRotator(numToKeepStr: '30')),
     disableConcurrentBuilds(),
@@ -49,13 +45,8 @@ properties([
             trim: true),
         string(
             defaultValue: '3-dev-latest',
-            description: 'PMM Client for the main lanes. 3-dev-latest installs the package from the experimental repo; latest-tarball pulls the S3 tarball. Compatibility lanes always use GA releases, and the GSSAPI lane takes GSSAPI_CLIENT_VERSION instead.',
+            description: 'PMM Client for the main lanes. 3-dev-latest installs the package from the experimental repo; latest-tarball pulls the S3 tarball. Compatibility lanes always use GA releases.',
             name: 'CLIENT_VERSION',
-            trim: true),
-        string(
-            defaultValue: GSSAPI_CLIENT_TARBALL,
-            description: 'PMM Client for the GSSAPI lane. Must stay a "dynamic" build tarball — GSSAPI is compiled in only by the dynamic flavour, so a package client cannot run that suite. Point this at the RC tarball when testing an RC.',
-            name: 'GSSAPI_CLIENT_VERSION',
             trim: true),
         string(
             defaultValue: 'main',
@@ -289,7 +280,6 @@ def upgradeBranches(Map branches, List pmmVersions, List oldVersions, String lat
 
 timestamps {
     def serverImage = params.DOCKER_VERSION.trim()
-    def gssapiClient = params.GSSAPI_CLIENT_VERSION ?: GSSAPI_CLIENT_TARBALL
     def amiId = pmmVersion('v3-ami').values()[-1]
     def compatVersions = pmmVersion('v3')[-5..-1]
     def upgradeVersions = pmmVersion('v3')[-6..-1]
@@ -315,7 +305,6 @@ timestamps {
         echo """Nightly release readiness
   server image    : ${serverImage}
   client          : ${params.CLIENT_VERSION}
-  gssapi client   : ${gssapiClient}
   AMI             : ${amiId}
   compat clients  : ${compatVersions.join(', ')}
   upgrade from    : ${upgradeVersions.join(', ')}
@@ -370,22 +359,12 @@ timestamps {
         booleanParam(name: 'USE_ONDEMAND',  value: params.USE_ONDEMAND),
     ])
 
-    // Not CLIENT_VERSION: GSSAPI lives only in the dynamic client build
-    // (build-client-binary runs `make release-gssapi`, -tags gssapi, for
-    // BUILD_TYPE=dynamic). The package client the other lanes use is the static
-    // build, whose pmm-agent carries the stub that answers a GSSAPI connection
-    // check with "GSSAPI support not enabled during build (-tags gssapi)" — so
-    // forwarding CLIENT_VERSION here fails the suite in setup, before any test
-    // runs (#2 and #3, pmm3-ui-tests-nightly-gssapi #462 and #464).
-    //
-    // gssapiClient falls back to the constant because a parameter is absent
-    // from `params` on the very run that first declares it, and that run must
-    // not hand the suite a null client.
+    // Not CLIENT_VERSION: GSSAPI is compiled into the dynamic client build only.
     branches['gssapi'] = suite('gssapi', 'pmm3-ui-tests-nightly-gssapi', [
         string(name: 'PMM_QA_GIT_BRANCH', value: params.PMM_QA_GIT_BRANCH),
         string(name: 'SERVER_TYPE',       value: 'docker'),
         string(name: 'DOCKER_VERSION',    value: serverImage),
-        string(name: 'CLIENT_VERSION',    value: gssapiClient),
+        string(name: 'CLIENT_VERSION',    value: 'https://s3.us-east-2.amazonaws.com/pmm-build-cache/PR-BUILDS/pmm-client/pmm-client-dynamic-ol9-latest.tar.gz'),
         string(name: 'ENABLE_PULL_MODE',  value: 'no'),
         string(name: 'ADMIN_PASSWORD',    value: 'pmm3admin!'),
         string(name: 'PSMDB_VERSION',     value: '8.0'),

--- a/pmm/v3/pmm3-nightly-orchestrator.groovy
+++ b/pmm/v3/pmm3-nightly-orchestrator.groovy
@@ -34,6 +34,10 @@ import groovy.json.JsonBuilder
 // (see mirrorChild). So a lane is "suite name" followed by the job, the build
 // number and one box per stage the child ran.
 
+// The GSSAPI suite needs the dynamic client tarball, not a package client;
+// see the gssapi lane below for why.
+GSSAPI_CLIENT_TARBALL = 'https://s3.us-east-2.amazonaws.com/pmm-build-cache/PR-BUILDS/pmm-client/pmm-client-dynamic-ol9-latest.tar.gz'
+
 properties([
     buildDiscarder(logRotator(numToKeepStr: '30')),
     disableConcurrentBuilds(),
@@ -45,8 +49,13 @@ properties([
             trim: true),
         string(
             defaultValue: '3-dev-latest',
-            description: 'PMM Client for the main lanes. 3-dev-latest installs the package from the experimental repo; latest-tarball pulls the S3 tarball. Compatibility lanes always use GA releases.',
+            description: 'PMM Client for the main lanes. 3-dev-latest installs the package from the experimental repo; latest-tarball pulls the S3 tarball. Compatibility lanes always use GA releases, and the GSSAPI lane takes GSSAPI_CLIENT_VERSION instead.',
             name: 'CLIENT_VERSION',
+            trim: true),
+        string(
+            defaultValue: GSSAPI_CLIENT_TARBALL,
+            description: 'PMM Client for the GSSAPI lane. Must stay a "dynamic" build tarball — GSSAPI is compiled in only by the dynamic flavour, so a package client cannot run that suite. Point this at the RC tarball when testing an RC.',
+            name: 'GSSAPI_CLIENT_VERSION',
             trim: true),
         string(
             defaultValue: 'main',
@@ -269,6 +278,7 @@ def upgradeBranches(Map branches, List pmmVersions, List oldVersions, String lat
 
 timestamps {
     def serverImage = params.DOCKER_VERSION.trim()
+    def gssapiClient = params.GSSAPI_CLIENT_VERSION ?: GSSAPI_CLIENT_TARBALL
     def amiId = pmmVersion('v3-ami').values()[-1]
     def compatVersions = pmmVersion('v3')[-5..-1]
     def upgradeVersions = pmmVersion('v3')[-6..-1]
@@ -292,6 +302,7 @@ timestamps {
         echo """Nightly release readiness
   server image    : ${serverImage}
   client          : ${params.CLIENT_VERSION}
+  gssapi client   : ${gssapiClient}
   AMI             : ${amiId}
   compat clients  : ${compatVersions.join(', ')}
   upgrade from    : ${upgradeVersions.join(', ')}
@@ -345,11 +356,22 @@ timestamps {
         booleanParam(name: 'USE_ONDEMAND',  value: params.USE_ONDEMAND),
     ])
 
+    // Not CLIENT_VERSION: GSSAPI lives only in the dynamic client build
+    // (build-client-binary runs `make release-gssapi`, -tags gssapi, for
+    // BUILD_TYPE=dynamic). The package client the other lanes use is the static
+    // build, whose pmm-agent carries the stub that answers a GSSAPI connection
+    // check with "GSSAPI support not enabled during build (-tags gssapi)" — so
+    // forwarding CLIENT_VERSION here fails the suite in setup, before any test
+    // runs (#2 and #3, pmm3-ui-tests-nightly-gssapi #462 and #464).
+    //
+    // gssapiClient falls back to the constant because a parameter is absent
+    // from `params` on the very run that first declares it, and that run must
+    // not hand the suite a null client.
     branches['gssapi'] = suite('gssapi', 'pmm3-ui-tests-nightly-gssapi', [
         string(name: 'PMM_QA_GIT_BRANCH', value: params.PMM_QA_GIT_BRANCH),
         string(name: 'SERVER_TYPE',       value: 'docker'),
         string(name: 'DOCKER_VERSION',    value: serverImage),
-        string(name: 'CLIENT_VERSION',    value: params.CLIENT_VERSION),
+        string(name: 'CLIENT_VERSION',    value: gssapiClient),
         string(name: 'ENABLE_PULL_MODE',  value: 'no'),
         string(name: 'ADMIN_PASSWORD',    value: 'pmm3admin!'),
         string(name: 'PSMDB_VERSION',     value: '8.0'),


### PR DESCRIPTION
The `gssapi` lane forwarded `params.CLIENT_VERSION`, so orchestrator #3 handed it `3-dev-latest` and the suite could not pass. It is a parameter defect in the orchestrator, not a flake, not the shared-infra overload, and not a product bug.

## What happened

[pmm3-ui-tests-nightly-gssapi #464](https://pmm.cd.percona.com/job/pmm3-ui-tests-nightly-gssapi/464/) failed in `Mongo pss client` after 19 min. The stage dispatches `pmm3-aws-staging-start` [#25494](https://pmm.cd.percona.com/job/pmm3-aws-staging-start/25494/), whose last lines are:

```
+ docker compose -f docker-compose-rs.yaml exec -T rs101 pmm-admin add mongodb \
    --enable-all-collectors ... --username=pmm@PERCONATEST.COM --password=password1 \
    --authentication-mechanism=GSSAPI --authentication-database=$external \
    --host=rs101 --port=27017 rs101_gssapi_30965
Connection check failed: error creating authenticator: GSSAPI support not enabled during build (-tags gssapi).
ERROR: Setup script 'start-rs-only.sh' failed.
```

Kerberos came up, the replica set came up, the PMM agent registered — the client simply has no GSSAPI support. Nothing after `Mongo pss client` ran, so zero tests executed.

## Why the client had no GSSAPI

GSSAPI is compiled into the **dynamic** client build only. `build/scripts/build-client-binary` in percona/pmm runs `make release-gssapi` (`-tags 'osusergo netgo gssapi'`, `CGO_ENABLED=1`) when `BUILD_TYPE=dynamic`, and that is the build shipped as `pmm-client-<ver>-dynamic-<os>.tar.gz`.

Read straight off the two published artifacts, both from commit `d9256b664` / `3.10.0-v3-6d6b3961b`:

| artifact | `go version -m` on `bin/pmm-agent` | has the `GSSAPI support not enabled during build` stub |
|---|---|---|
| `pmm-client-latest.tar.gz` (static) | `-tags=osusergo,netgo,static_build` | yes |
| `pmm-client-dynamic-ol9-latest.tar.gz` | `-tags=osusergo,netgo,gssapi` | no |

Same commit, different build flavour — no code regression anywhere. (`pmm-admin` is `CGO_ENABLED=0` in both and carries no such string; the message in the log comes from `pmm-agent` on the mongo node, which is exactly the binary that differs.)

`CLIENT_VERSION` decides which of the two the psmdb node gets. In `qa-integration/pmm_psmdb-pbm_setup/Dockerfile`:

```dockerfile
RUN if [[ "$PMM_CLIENT_VERSION" == http* ]]; then \
        curl ... "$PMM_CLIENT_VERSION" && ... ./install_tarball        # dynamic → GSSAPI
    elif [[ "$PMM_CLIENT_VERSION" =~ 3-dev-latest|latest ]]; then \
        dnf -y install pmm-client ;                                    # static package → no GSSAPI
```

So `3-dev-latest` installs the static package from the experimental repo, and the suite fails by construction.

## Control

| build | when | `CLIENT_VERSION` | result |
|---|---|---|---|
| #461 (00:00 cron) | 2026-09-08 | dynamic ol9 tarball (job default) | **SUCCESS** |
| #462 (orchestrator #2) | 2026-09-08 | `3-dev-latest` | FAILURE, same stage |
| #464 (orchestrator #3) | 2026-09-08 | `3-dev-latest` | FAILURE, same stage |

Same server image and same pmm-qa `main` day, green 13 hours earlier with the tarball. The suite's own default has always been the dynamic ol9 tarball; the orchestrator was the only caller overriding it. pmm-qa agrees repo-wide — every job in `.github/workflows/gssapi-psmdb-tests-matrix.yml` pins `pmm-client-dynamic-ol{8,9}-latest.tar.gz`.

## The change

A `GSSAPI_CLIENT_VERSION` parameter (default: the dynamic ol9 tarball, the same URL the suite defaults to) feeds the lane instead of `CLIENT_VERSION`, so `CLIENT_VERSION` keeps meaning "what the main lanes install" and an RC run can point the lane at the RC tarball. The value is resolved with `?: GSSAPI_CLIENT_TARBALL` because a parameter is absent from `params` on the very run that first declares it — without the fallback, the first build after this merge would hand the suite a null client.

## Verification

- The build-tag mechanism is read directly off the two published tarballs (table above), not inferred.
- A confirming run of `pmm3-ui-tests-nightly-gssapi` with exactly the parameters this change now sends (dynamic ol9 tarball, `USE_ONDEMAND=true`) was triggered from queue item 117257; it takes ~40 min, so its result is not in this description. The orchestrator itself has not been re-run.

## Two findings for a human, not fixed here

1. **`pmm3-ui-tests-nightly-gssapi` reads its pipeline from `*/PMM-7-fix-nightly-gssapi-3_8_0`, and that branch is stale.** It diverged from `master` on 2026-05-23 and never picked up `8cd60bb5` (readyz sanity check) or `af741630` (PMM-15001, OVF removal) — it still offers `ovf` as a `SERVER_TYPE`. It is also 2 commits *ahead*: `217939b5` + `76ce6bca` are what add the `USE_ONDEMAND` parameter this orchestrator passes, and `master`'s copy of the file has no such parameter. So the job cannot simply be repointed at `master` today. Those two commits want rebasing onto `master` and merging, after which the job's SCM branch can go back to `master`.
2. **A separate failure in the same suite:** #457 (cron, correct tarball client) got through setup and died 2 s into `Run UI Tests` — `mocha-multi` threw during reporter init, so `npx codeceptjs run --grep @gssapi-nightly` produced no XML and `junit` aborted with "No test report files were found". #461 was green later, so this may already be fixed on pmm-qa `main`; flagging it because it is invisible from #464, which never reached that stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAA4rTkQmjq8kkYvn2TWeh

---
_Generated by [Claude Code](https://claude.ai/code/session_01JAA4rTkQmjq8kkYvn2TWeh)_