### PR TITLE
PMM-15197 Split PMM_VERSION for the arm64 tarball suites

### DIFF
--- a/pmm/v3/pmm3-nightly-orchestrator.groovy
+++ b/pmm/v3/pmm3-nightly-orchestrator.groovy
@@ -203,31 +203,9 @@ def nightlyGha(String name, String serverImage, String amiId, Map cfg = [:]) {
     return suite(name, 'pmm3-ui-tests-nightly-gha', jobParams)
 }
 
-// PMM_VERSION has to name the client the suite actually installs, because the
-// playbooks assert it against `pmm-admin --version`. Most suites install from
-// INSTALL_REPO=experimental, which carries the dev build on both arches, so
-// they take devVersion.
-//
-// Three suites — custom path, custom port, upgrade custom path — install from a
-// tarball URL instead (package_tests/scripts/pmm3_client_install_tarball.sh),
-// and that URL is arch-specific:
-//
-//   amd64  downloads/TESTING/pmm/pmm-client-<v>.tar.gz          — carries dev builds
-//   arm64  downloads/pmm3/<v>/binary/tarball/…-aarch64.tar.gz   — GA releases only
-//
-// No dev arm64 client tarball is published anywhere: TESTING/pmm-arm was never
-// populated by any pipeline, so on arm64 those three can only ever exercise a
-// GA client. Handing them devVersion is a guaranteed 404, which is what
-// reddened all eight OS branches of `pkg arm64 / custom path`, `/ custom port`
-// and `/ upgrade custom path` in pmm3-nightly-orchestrator #3.
-//
-// So the split is per suite, not per arch: the arm64 tarball lanes take
-// gaVersion and say so in their stage name, so a green lane there is not
-// misread as dev-tarball coverage.
 def packageBranches(Map branches, String prefix, String jobName, String serverArch, String serverImage, String devVersion, String gaVersion) {
     // TESTS is the playbook; the trailing spaces in CLIENTS are load-bearing —
     // they keep otherwise identical parameter sets from collapsing in the queue.
-    // The fourth column marks the suites that install from a tarball.
     def variants = [
         ['integration',          'pmm3-client_integration',                     '--help  ',    false],
         ['auth config',          'pmm3-client_integration_auth_config',         '--help   ',   false],

--- a/pmm/v3/pmm3-nightly-orchestrator.groovy
+++ b/pmm/v3/pmm3-nightly-orchestrator.groovy
@@ -203,24 +203,48 @@ def nightlyGha(String name, String serverImage, String amiId, Map cfg = [:]) {
     return suite(name, 'pmm3-ui-tests-nightly-gha', jobParams)
 }
 
-def packageBranches(Map branches, String prefix, String jobName, String serverArch, String serverImage, String pmmVersionLabel) {
+// PMM_VERSION has to name the client the suite actually installs, because the
+// playbooks assert it against `pmm-admin --version`. Most suites install from
+// INSTALL_REPO=experimental, which carries the dev build on both arches, so
+// they take devVersion.
+//
+// Three suites — custom path, custom port, upgrade custom path — install from a
+// tarball URL instead (package_tests/scripts/pmm3_client_install_tarball.sh),
+// and that URL is arch-specific:
+//
+//   amd64  downloads/TESTING/pmm/pmm-client-<v>.tar.gz          — carries dev builds
+//   arm64  downloads/pmm3/<v>/binary/tarball/…-aarch64.tar.gz   — GA releases only
+//
+// No dev arm64 client tarball is published anywhere: TESTING/pmm-arm was never
+// populated by any pipeline, so on arm64 those three can only ever exercise a
+// GA client. Handing them devVersion is a guaranteed 404, which is what
+// reddened all eight OS branches of `pkg arm64 / custom path`, `/ custom port`
+// and `/ upgrade custom path` in pmm3-nightly-orchestrator #3.
+//
+// So the split is per suite, not per arch: the arm64 tarball lanes take
+// gaVersion and say so in their stage name, so a green lane there is not
+// misread as dev-tarball coverage.
+def packageBranches(Map branches, String prefix, String jobName, String serverArch, String serverImage, String devVersion, String gaVersion) {
     // TESTS is the playbook; the trailing spaces in CLIENTS are load-bearing —
     // they keep otherwise identical parameter sets from collapsing in the queue.
+    // The fourth column marks the suites that install from a tarball.
     def variants = [
-        ['integration',          'pmm3-client_integration',                     '--help  '],
-        ['auth config',          'pmm3-client_integration_auth_config',         '--help   '],
-        ['auth register',        'pmm3-client_integration_auth_register',       ' --help'],
-        ['custom path',          'pmm3-client_integration_custom_path',         '  --help'],
-        ['custom port',          'pmm3-client_integration_custom_port',         '   --help'],
-        ['upgrade',              'pmm3-client_integration_upgrade',             '    --help'],
-        ['upgrade custom path',  'pmm3-client_integration_upgrade_custom_path', '    --help '],
-        ['upgrade custom port',  'pmm3-client_integration_upgrade_custom_port', '    --help  '],
+        ['integration',          'pmm3-client_integration',                     '--help  ',    false],
+        ['auth config',          'pmm3-client_integration_auth_config',         '--help   ',   false],
+        ['auth register',        'pmm3-client_integration_auth_register',       ' --help',     false],
+        ['custom path',          'pmm3-client_integration_custom_path',         '  --help',    true],
+        ['custom port',          'pmm3-client_integration_custom_port',         '   --help',   true],
+        ['upgrade',              'pmm3-client_integration_upgrade',             '    --help',  false],
+        ['upgrade custom path',  'pmm3-client_integration_upgrade_custom_path', '    --help ', true],
+        ['upgrade custom port',  'pmm3-client_integration_upgrade_custom_port', '    --help  ', false],
     ]
     variants.each { v ->
         def label = v[0]
         def tests = v[1]
         def clients = v[2]
-        def name = "${prefix} / ${label}"
+        def gaOnly = v[3] && serverArch == 'arm64'
+        def pmmVersionLabel = gaOnly ? gaVersion : devVersion
+        def name = gaOnly ? "${prefix} / ${label} (GA ${gaVersion})" : "${prefix} / ${label}"
         branches[name] = suite(name, jobName, [
             string(name: 'GIT_BRANCH',      value: params.PMM_QA_GIT_BRANCH),
             string(name: 'DOCKER_VERSION',  value: serverImage),
@@ -335,8 +359,8 @@ timestamps {
         ])
     }
 
-    packageBranches(branches, 'pkg amd64', 'nightly-package-testing-amd64', 'amd64', serverImage, latestDevVersion)
-    packageBranches(branches, 'pkg arm64', 'nightly-package-testing-arm64', 'arm64', serverImage, latestDevVersion)
+    packageBranches(branches, 'pkg amd64', 'nightly-package-testing-amd64', 'amd64', serverImage, latestDevVersion, latestVersion)
+    packageBranches(branches, 'pkg arm64', 'nightly-package-testing-arm64', 'arm64', serverImage, latestDevVersion, latestVersion)
     upgradeBranches(branches, upgradeVersions, oldVersions, latestVersion, latestDevVersion)
 
     branches['upgrade / ami'] = suite('upgrade / ami', 'pmm3-upgrade-ami-test', [


### PR DESCRIPTION
## Failures fixed (investigator)

- source: https://pmm.cd.percona.com/job/pmm3-nightly-orchestrator/3/ (`pmm3-nightly-orchestrator` #3, package-tests group)
- tests:
  - `nightly-package-testing-arm64` #21 — `pmm3-client_integration_custom_path` — **all 8 OS branches**
  - `nightly-package-testing-arm64` #22 — `pmm3-client_integration_custom_port` — **all 8 OS branches**
  - `nightly-package-testing-arm64` #24 — `pmm3-client_integration_upgrade_custom_path` — **all 8 OS branches**

Companion pmm-qa PR: https://github.com/percona/pmm-qa/pull/1370 — it fixes the other two causes in this group, and carries the `old_version` change this PR depends on.

## What actually failed

`1ff1a8bf` changed `PMM_VERSION` from the newest GA to `latestDevVersion` (3.10.0). That is **right for five of the eight suites and wrong for three**.

The five repo-based suites install from `INSTALL_REPO=experimental`, which does carry the dev build — 3.10.0 was correct there, and #3 confirms it: those lanes are green except where an unrelated repo-publish race hit them.

The other three install from a download URL instead, via `package_tests/scripts/pmm3_client_install_tarball.sh:92-97`, and that URL is arch-specific:

| arch | tarball URL | carries |
|---|---|---|
| amd64 | `downloads/TESTING/pmm/pmm-client-<v>.tar.gz` | dev builds |
| arm64 | `downloads/pmm3/<v>/binary/tarball/pmm-client-<v>-aarch64.tar.gz` | **GA releases only** |

So on arm64 they asked for a dev tarball that does not exist:

```
aarch64
Downloading https://downloads.percona.com/downloads/pmm3/3.10.0/binary/tarball/pmm-client-3.10.0-aarch64.tar.gz
HTTP request sent, awaiting response... 404 Not Found
2026-09-08 13:41:30 ERROR 404: Not Found.
```

8 of 8 branches on arm64 #21 and #22, all dying at the tarball step (`custom_port.yml:45`) within 20 s of starting — those builds finished in ~40 min against a normal 55. arm64 #24 ran the full suite and then died at the *upgrade* tarball step (`upgrade_custom_path.yml:212`): its `old_version` 3.9.1 downloaded fine, `pmm_version` 3.10.0 did not.

Probed live during triage:

| URL | status |
|---|---|
| `pmm3/3.10.0/…/pmm-client-3.10.0-aarch64.tar.gz` | **404** |
| `pmm3/3.9.1/…/pmm-client-3.9.1-aarch64.tar.gz` | 200 |
| `pmm3/3.9.0/…/pmm-client-3.9.0-aarch64.tar.gz` | 200 |
| `TESTING/pmm/pmm-client-3.10.0.tar.gz` | 200 |
| `TESTING/pmm-arm/pmm-client-3.10.0.tar.gz` | **404** |

**There is no dev arm64 client tarball published anywhere.** `TESTING/pmm-arm` still 404s, matching the script's own comment that it "was never populated by any pipeline". On arm64 the tarball suites can only ever exercise a GA client — that is a property of what gets published, not something a parameter can fix.

## The split, and why it is per suite rather than per arch

A single `PMM_VERSION` per arch cannot satisfy arm64: its repo-based suites need 3.10.0 and its tarball suites need the newest GA. Three ways to resolve it, and why this one:

- **Per-suite `PMM_VERSION` in the orchestrator (chosen).** `packageBranches` already builds each of the eight variants individually, so it only needs a fourth column marking the tarball suites. The decision lives in the file that chooses the parameter, and nothing in pmm-qa has to guess.
- **Fall back inside the script** — probe the arm64 URL, drop to the newest GA on 404. Rejected: a suite would then silently exercise a version other than the one it was asked for, and the playbooks' own `pmm_version` assertions (`verify_pmm_client_version.yml`) would fail against the version that was actually installed.
- **A `-r release|testing` flag on the script** (the shape on the unmerged `PMM-7-package-tests-fix-tarball-installation` — see below). Right idea for *URL* selection, but it does not address the *version*: on arm64 there is no testing bucket for it to point at, and the playbook still needs to be told which version to assert.

The arm64 tarball lanes are therefore renamed `… (GA 3.9.1)`. Without that, a green `pkg arm64 / custom path` reads as dev-tarball coverage that does not exist. The Report stage groups on the first ` / `, so the family stays `pkg arm64` and only the leaf changes.

## Peter's unmerged branch — checked, not reusable as-is

`PMM-7-package-tests-fix-tarball-installation` has two relevant commits, neither merged:

- `85326ab0` moved the arm64 URL from `TESTING/pmm-arm` to the GA `pmm3/<v>/` path. **This is already on pmm-qa `main`**, comment and all, so it is not missing work.
- `4e5c7580` adds the `-r release|testing` flag. It **does not run**: `[[ "$repo" == "testing"]]` is missing the space before `]]` (bash: `syntax error in conditional expression`), it calls `print` instead of `echo`, and it leaves a stray bare `${client_tar}` line in the amd64 branch. Its arm64 `testing` branch also points at `TESTING/pmm-arm/`, which still 404s today.

`3.8.1-peter` merges that same branch and adds nothing further to the tarball script. So there is no ready fix to adopt; this PR does not duplicate one.

## Verification, and the gap

- **Groovy compiles.** `groovy 4.0.22` `FileSystemCompiler` on the patched `pmm3-nightly-orchestrator.groovy`: clean, same as the pre-change file (control run).
- **The selection is exercised**, not just eyeballed — the same `variants` table and the same two expressions run standalone over both arches:

```
== pkg arm64
  pmm3-client_integration                      PMM_VERSION=3.10.0  leaf=integration
  pmm3-client_integration_custom_path          PMM_VERSION=3.9.1   leaf=custom path (GA 3.9.1)
  pmm3-client_integration_custom_port          PMM_VERSION=3.9.1   leaf=custom port (GA 3.9.1)
  pmm3-client_integration_upgrade_custom_path  PMM_VERSION=3.9.1   leaf=upgrade custom path (GA 3.9.1)
  pmm3-client_integration_upgrade_custom_port  PMM_VERSION=3.10.0  leaf=upgrade custom port
```

  amd64 keeps 3.10.0 on all eight. All 16 parameter sets stay unique, so the queue-collapse guard the trailing `CLIENTS` spaces exist for still holds.
- **The URL facts are measured**, table above.

### Reproduction gap, stated plainly

**No Jenkins run was made against this branch, and no VM was provisioned.** The package suites run on nine Jenkins-managed per-OS EC2 agents against an EC2 staging PMM Server; a single throwaway Docker VM cannot stand that matrix up, and the staging servers from #3 are torn down. What is proven here is the parameter arithmetic and that the URLs it selects exist; **only a real `pmm3-nightly-orchestrator` run can confirm the three arm64 lanes go green.** The three amd64 tarball lanes are unchanged by this PR, so their behaviour is not at risk from it.

## Not fixed here

- **Five of the nine failures in this group are not this bug** — they are a `repo.percona.com` publish race (the experimental repo is regenerated on the hour at ~:52; all five failures land in 13:50–14:06), external to both repos. Detailed in the companion pmm-qa PR, along with the one retry gap that belongs in pmm-qa.
- **`pmm3-client_integration_tarball_gssapi` / `upgrade_tarball_gssapi`** are tarball suites too, and are not in this orchestrator's variants list (they come from the gssapi matrix). If an arm64 gssapi lane is ever handed a dev `PMM_VERSION` it will 404 identically. Flagging rather than changing a job this run did not exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAA4rTkQmjq8kkYvn2TWeh

---
_Generated by [Claude Code](https://claude.ai/code/session_01JAA4rTkQmjq8kkYvn2TWeh)_