### PR TITLE
Add AWS and RDS credentials to HA E2E tests

### DIFF
--- a/pmm/v3/pmm3-ha-e2e-tests-gha.groovy
+++ b/pmm/v3/pmm3-ha-e2e-tests-gha.groovy
@@ -67,6 +67,13 @@ pipeline {
     agent {
         label 'agent-amd64'
     }
+    environment {
+        PMM_QA_AWS_ACCESS_KEY_ID=credentials('PMM_QA_AWS_ACCESS_KEY_ID')
+        PMM_QA_AWS_ACCESS_KEY=credentials('PMM_QA_AWS_ACCESS_KEY')
+        PMM_QA_MYSQL_RDS_8_4_HOST=credentials('PMM_QA_MYSQL_RDS_8_4_HOST')
+        PMM_QA_MYSQL_RDS_8_4_USER=credentials('PMM_QA_MYSQL_RDS_8_4_USER')
+        PMM_QA_MYSQL_RDS_8_4_PASSWORD=credentials('PMM_QA_MYSQL_RDS_8_4_PASSWORD')
+    }
     parameters {
         string(
             defaultValue: 'main',


### PR DESCRIPTION
This change adds the required AWS and MySQL RDS credential variables to the HA E2E pipeline environment so tests can authenticate to the QA infrastructure during execution.