### PR TITLE
PMM-7 Route 3.9.0+ upgrade suites down the Docker path

### DIFF
--- a/pmm/v3/pmm3-nightly-orchestrator.groovy
+++ b/pmm/v3/pmm3-nightly-orchestrator.groovy
@@ -236,6 +236,18 @@ def packageBranches(Map branches, String prefix, String jobName, String serverAr
     }
 }
 
+// PMM 3.9.0 removed the in-app ("UI") updater: the Updates page renders a
+// "deprecated ... managed via the CLI" notice instead of an "Update now" button,
+// and POST /v1/server/updates:start answers 404. A UI upgrade cannot start from
+// 3.9.0 or later however UPGRADE_TYPE is set, so those sources take the Docker
+// path -- the one PMM itself now documents -- regardless.
+def supportsUiUpgrade(String version) {
+    def parts = version.tokenize('.')
+    def major = parts[0].toInteger()
+    def minor = parts.size() > 1 ? parts[1].toInteger() : 0
+    return major < 3 || (major == 3 && minor < 9)
+}
+
 def upgradeBranches(Map branches, List pmmVersions, List oldVersions, String latestVersion, String latestDevVersion) {
     // Mirrors pmm3-upgrade-tests-matrix: every recent version upgraded, with the
     // newest one going from its RC image up to the dev tip.
@@ -249,6 +261,8 @@ def upgradeBranches(Map branches, List pmmVersions, List oldVersions, String lat
         def clientRepo = isNewest ? 'experimental' : 'testing'
         def serverLatest = isNewest ? latestDevVersion : latestVersion
 
+        def upgradeType = supportsUiUpgrade(ver) ? params.UPGRADE_TYPE : 'DOCKER'
+
         variants.each { variant ->
             def name = "upgrade / ${ver} ${variant}"
             branches[name] = suite(name, 'pmm3-upgrade-test-runner', [
@@ -260,7 +274,7 @@ def upgradeBranches(Map branches, List pmmVersions, List oldVersions, String lat
                 string(name: 'PMM_SERVER_LATEST',             value: serverLatest),
                 string(name: 'PMM_QA_GIT_BRANCH',             value: params.PMM_QA_GIT_BRANCH),
                 string(name: 'UPGRADE_FLAG',                  value: variant),
-                string(name: 'UPGRADE_TYPE',                  value: params.UPGRADE_TYPE),
+                string(name: 'UPGRADE_TYPE',                  value: upgradeType),
                 booleanParam(name: 'USE_ONDEMAND', value: params.USE_ONDEMAND),
             ])
         }
@@ -288,6 +302,8 @@ timestamps {
                 deleteDir()
             }
         }
+        def uiCapable = upgradeVersions.findAll { supportsUiUpgrade(it) }
+        def dockerOnly = upgradeVersions.findAll { !supportsUiUpgrade(it) }
         currentBuild.description = "server=${serverImage} client=${params.CLIENT_VERSION}"
         echo """Nightly release readiness
   server image    : ${serverImage}
@@ -295,6 +311,7 @@ timestamps {
   AMI             : ${amiId}
   compat clients  : ${compatVersions.join(', ')}
   upgrade from    : ${upgradeVersions.join(', ')}
+  upgrade path    : UI-capable ${uiCapable.join(', ')} | Docker-only ${dockerOnly.join(', ')}
   dev version     : ${latestDevVersion}
   on-demand       : ${params.USE_ONDEMAND}"""
     }

--- a/pmm/v3/pmm3-nightly-orchestrator.groovy
+++ b/pmm/v3/pmm3-nightly-orchestrator.groovy
@@ -236,11 +236,6 @@ def packageBranches(Map branches, String prefix, String jobName, String serverAr
     }
 }
 
-// PMM 3.9.0 removed the in-app ("UI") updater: the Updates page renders a
-// "deprecated ... managed via the CLI" notice instead of an "Update now" button,
-// and POST /v1/server/updates:start answers 404. A UI upgrade cannot start from
-// 3.9.0 or later however UPGRADE_TYPE is set, so those sources take the Docker
-// path -- the one PMM itself now documents -- regardless.
 def supportsUiUpgrade(String version) {
     def parts = version.tokenize('.')
     def major = parts[0].toInteger()


### PR DESCRIPTION
## Failures fixed (investigator)

- source: https://pmm.cd.percona.com/job/pmm3-nightly-orchestrator/3/ (validation run, group "upgrade from 3.7.1 / 3.8.0 / 3.8.1 / 3.9.0 / 3.9.1")
- tests:
  - `codeceptjs-e2e/tests/upgrade/upgradePMM_test.js` / `PMM-T3 - Verify user is able to Upgrade PMM version [blocker] @pmm-upgrade`
  - `codeceptjs-e2e/tests/upgrade/upgradePMM_test.js` / `Verify pmm server is upgraded to correct version @pmm-upgrade` (cascade)
  - builds [23464](https://pmm.cd.percona.com/job/pmm3-upgrade-test-runner/23464/) (3.9.0 SSL), [23465](https://pmm.cd.percona.com/job/pmm3-upgrade-test-runner/23465/) (3.9.0 EXTERNAL SERVICES), [23466](https://pmm.cd.percona.com/job/pmm3-upgrade-test-runner/23466/) (3.9.0 OTHERS), [23467](https://pmm.cd.percona.com/job/pmm3-upgrade-test-runner/23467/) (3.9.1 SSL), [23468](https://pmm.cd.percona.com/job/pmm3-upgrade-test-runner/23468/) (3.9.1 EXTERNAL SERVICES), [23469](https://pmm.cd.percona.com/job/pmm3-upgrade-test-runner/23469/) (3.9.1 OTHERS)

**This PR fixes only the 3.9.0/3.9.1 rows.** The 3.7.1/3.8.0/3.8.1 EXTERNAL SERVICES and OTHERS failures in the same run are an unrelated second cause and are *not* addressed here — see "The other six failures" at the bottom.

## What actually failed

The run's failure table has two distinct shapes, and the split is the whole diagnosis:

| from | SSL | EXTERNAL SERVICES | OTHERS |
|---|---|---|---|
| 3.7.1 | PASS (45m) | FAIL (60m) | FAIL (69m) |
| 3.8.0 | PASS (49m) | FAIL (66m) | FAIL (81m) |
| 3.8.1 | PASS (50m) | FAIL (71m) | FAIL (45m) |
| 3.9.0 | **FAIL (17m)** | **FAIL (21m)** | **FAIL (26m)** |
| 3.9.1 | **FAIL (18m)** | **FAIL (21m)** | **FAIL (24m)** |

The six fast 3.9.x failures all die in the **same stage**, `Run UI upgrade`, with the same two cases:

```
PMM-T3 - Verify user is able to Upgrade PMM version [blocker] @pmm-upgrade
  element ({xpath: //button[contains(., 'Update now')]}) still not present on page after 60 sec
Verify pmm server is upgraded to correct version @pmm-upgrade
  After upgrade version of PMM Server is not correct.: expected '3.9.0' to include '3.9.1'
```

Every later stage is then `NOT_EXECUTED`/skipped, which is why they finish in 17–26 min instead of 45–81. The second case is a cascade of the first: no upgrade ran, so the version never changed.

The CodeceptJS step log shows the test got **further** than "no update offered" — it found and clicked the widget's trigger and only then timed out:

```
- I.waitForElement("//button//span[contains(text(), \"Upgrade to\")]", 180)   <- found
- I.seeElement("//button//span[contains(text(), \"Upgrade to\")]")            <- ok
- I.click("//button//span[contains(text(), \"Upgrade to\")]")                 <- ok
- I.waitForElement({xpath: //button[contains(., 'Update now')]})              <- 60s timeout
```

## Root cause: PMM 3.9.0 removed the in-app updater

Not a product bug, not infra, not the test code. `homePage.js` and `upgradePMM_test.js` are **byte-identical** on `pmm-3.8.1`, `pmm-3.9.0`, `pmm-3.9.0-upgrade`, `pmm-3.9.1` and `pmm-3.9.1-upgrade`, so the test is not what changed. The pre-upgrade UI is served by the **old** server image, and that is what differs.

`percona/pmm` says so in its own source. `ui/apps/pmm/src/pages/updates/update-card/UpdateCard.messages.ts`:

```
deprecationWarning:
  'Note: The in-app update button has been deprecated. All updates are now securely managed via the CLI.',
deprecation: {
  paragraph1BeforeUpdateNow: ': This ',
  paragraph1AfterUpdateNow: ' button will be removed in PMM 3.9.0.',
```

and in `UpdateCard.tsx` the only action rendered when an update is available is now a docs link (`howToUpdateDocs`), alongside `UpdateInfo` — *"Step 1 of 2: Update PMM Server … via Docker (recommended), Podman, or Helm"*. There is no "Update now" control and no handler that performs an update.

### Reproduced on a throwaway Linode VM

Started `percona/pmm-server:3.9.0` with the same watchtower + `PMM_ENABLE_UPDATES=1` + `PMM_DEV_UPDATE_DOCKER_IMAGE=perconalab/pmm-server:3.9.1-rc` shape the pipeline uses.

**Update detection works** — which is why the "Upgrade to" trigger appears:

```
GET /v1/server/updates?force=true
  "installed": {"version": "3.9.0"}
  "latest":    {"version": "3.9.1-rc", "tag": "perconalab/pmm-server:3.9.1-rc"}
  "update_available": true
```

**The Updates page has no "Update now" button.** `/pmm-ui/updates` on 3.9.0, verbatim:

```
Updates
New update available: PMM 3.9.1-rc
Running version: 3.9.0, July 24, 2026
New version: 3.9.1-rc, January 1, 1
Note: The in-app update button has been deprecated. All updates are now securely managed via the CLI.
How to
Step 1 of 2: Update PMM Server
...
How to update docs
```

`//button[contains(., "Update now")]` → **0 matches**. (The one "Update now" string anywhere in the UI is prose inside the "Update to PMM 3.9.1-rc" modal that PMM-T3 dismisses first, not a button.)

**And the backend endpoint is gone.** The A/B, same VM, same env:

| source image | `POST /v1/server/updates:start` | `Update now` button |
|---|---|---|
| `percona/pmm-server:3.8.1` | **200** — `{"auth_token": "...", "log_offset": 0}`, and the server immediately restarted itself into 3.9.1-rc | present (these rows pass the stage in CI) |
| `percona/pmm-server:3.9.0` | **404** — endpoint removed | **absent** |

So `UPGRADE_TYPE=UI` cannot work from 3.9.0 or later, by design. Those six cells could never have gone green. It also explains the three SSL passes the previous theory could not: 3.7.1/3.8.0/3.8.1 still ship the button.

## Two hypotheses this refutes

**"The parameters were wrong / `UPGRADE_TYPE=UI` is not how these normally run."** No. Build [23439](https://pmm.cd.percona.com/job/pmm3-upgrade-test-runner/23439/), a pre-orchestrator run, carries an identical parameter set — `UPGRADE_TYPE=UI`, `PMM_QA_GIT_BRANCH=main`, `PMM_SERVER_LATEST=3.9.1`, `DOCKER_TAG_UPGRADE=perconalab/pmm-server:3.9.1-rc`, `CLIENT_REPOSITORY=testing`, `USE_ONDEMAND=true`. The orchestrator changed nothing here; this failure predates it and is why `pmm3-upgrade-tests-matrix` had been red on 8 consecutive runs back to #387.

**"The 50-suite fan-out starved the runners, so the UI timed out."** No. The failure is version-correlated, not load-correlated: 6/6 3.9.x cells failed at this stage while 6/6 3.7.1–3.8.1 cells *passed the very same stage* concurrently, on the same executors, in the same run. `PMM-T3` is `.retry(0)` and the reproduction above is on an idle VM. Self-inflicted concurrency is a real concern for this run — it is just not what broke these six.

**Peter's unmerged branches do not fix this.** Checked `PMM-7-debug-upgrade`, `PMM-7-migration-of-upgrade-tests`, `claude/pmm-ui-upgrade-test-0q0238`, `claude/agents-running-upgrade-test-rg3jop`, `3.8.1-peter`, `claude/pmm-3-7-0-upgrade-alerts-folder-fix`, plus the `pmm-3.9.0-upgrade` / `pmm-3.9.1-upgrade` release branches. None touches the `Update now` locator or the UI-upgrade flow — and no locator change could, since the control no longer exists.

## The change

`UPGRADE_TYPE` is a single job-level choice applied uniformly to all 18 upgrade cells. Pick it per source version instead: `UI` only where the source server still has an in-app updater, `DOCKER` from 3.9.0 on.

The runner already implements the Docker path in full (`Run Docker upgrade` → `Docker upgrade` → `Sanity check after upgrade`, `docker rename` + `--volumes-from pmm-server-old`); it was simply never selected. No pmm-qa change is needed — in `DOCKER` mode the `Run UI upgrade` stage is skipped, so `PMM-T3` never runs.

Also echoes the split in the Plan stage, so a future reader sees which cells took which path without diffing parameters:

```
upgrade from    : 3.7.0, 3.7.1, 3.8.0, 3.8.1, 3.9.0, 3.9.1
upgrade path    : UI-capable 3.7.0, 3.7.1, 3.8.0, 3.8.1 | Docker-only 3.9.0, 3.9.1
```

## Verification

**The Docker path works from the exact failing source**, same VM, the pipeline's own command sequence (`docker stop` / `pull` / `rename` / `run --volumes-from pmm-server-old` / poll `readyz`):

```
BEFORE: "3.9.0"
--- DOCKER upgrade, exactly as pmm3-upgrade-test-runner does it ---
readyz 200 after docker upgrade
AFTER:  "3.9.1"
```

So the cell that failed as `expected '3.9.0' to include '3.9.1'` reaches 3.9.1 on this path.

**Version selection**, `supportsUiUpgrade` evaluated over the boundary cases:

| version | UI |
|---|---|
| 3.7.0, 3.7.1, 3.8.0, 3.8.1 | true |
| 3.9.0, 3.9.1, 3.10.0 | false |
| 2.44.1 | true |
| 4.0.0 | false |

`3.10.0` is the one worth noting — a `minor`-integer comparison, not a string compare, so 3.10 sorts after 3.9 correctly.

### Reproduction gaps, stated plainly

- **No Jenkins run of this pipeline.** The groovy change is unexercised in Jenkins; there is no Groovy compiler in this environment (`java` only, no `groovy`/`groovyc`) and the repo carries no pipeline linter, so the edit is reviewed-by-eye plus the version-logic table above. The mechanism it selects is proven on a VM, but **only a real `pmm3-nightly-orchestrator` run can confirm the six cells go green end to end** — they exercise far more than the upgrade step itself.
- The helper is called from inside `.each`/`.findAll` closures. That matches what this file already does (`suite(...)` inside `variants.each`), and the two `findAll` results are hoisted into locals rather than interpolated inside the `echo` GString, to keep CPS out of it.

## Deliberately not in this PR

- **Coverage lost by skipping `Run UI upgrade`.** That stage is the only one running `--grep '@pmm-upgrade'`, so in `DOCKER` mode four cases besides `PMM-T3` stop running: `PMM-T288` (update widget present), `PMM-T289` (What's New link), `PMM-T1647` (no `pmm-server` package), and the post-upgrade version assertion. `PMM-T288`/`PMM-T289`/`PMM-T1647` are still meaningful under a Docker upgrade, and the version assertion especially so. Restoring a Docker-appropriate `@pmm-upgrade` subset needs its own change in both repos plus its own verification — flagging it rather than smuggling it in. `Check Packages after Upgrade` (`check_upgrade.py -p post`) and `Sanity check after upgrade` still run, so the path is not unchecked.
- **A version guard inside `PMM-T3` itself.** Belt-and-braces once the matrix is right, and awkward to land: the test is read from the frozen `pmm-<version>` release branches, so it would need editing on each.
- **Retiring `UPGRADE_TYPE=UI` entirely.** Still the correct path for 3.7.x/3.8.x, and those rows pass today. It becomes dead once 3.8.1 ages out of the six-version window.

## The other six failures (not this PR)

3.7.1/3.8.0/3.8.1 EXTERNAL SERVICES + OTHERS fail **much later and for an unrelated reason**: `Run UI upgrade` *succeeds*, all 35 CodeceptJS cases pass, and the run dies in `Run post upgrade Playwright E2E tests` on

```
PMM-T2252 Verify RTA overview CSV export @rta
  Error: expect(received).toEqual(expected)   e2e_tests/tests/qan/rta/overview.test.ts:274
  expect(headers).toEqual(expect.arrayContaining([...]))
```

failing all 3 retries. SSL passes these rows because the pipeline sets `PLAYWRIGHT_FLAG="noTestsRunning"` for the SSL variant (`pmm3-upgrade-test-runner.groovy:174`) — SSL never runs `@rta` at all, which is the entire reason that column is green. Notably the same test, from the same `main` checkout, **passed 21/21 against `perconalab/pmm-server:3-dev-latest`** in `gssapi-psmdb-tests-matrix` run 376 the same morning, so it is not simply broken. Under investigation separately; it needs no orchestrator change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAA4rTkQmjq8kkYvn2TWeh

---
_Generated by [Claude Code](https://claude.ai/code/session_01JAA4rTkQmjq8kkYvn2TWeh)_