### PR TITLE
PMM-15197 Upgrade to the image under test

### DIFF
--- a/pmm/v3/pmm3-nightly-orchestrator.groovy
+++ b/pmm/v3/pmm3-nightly-orchestrator.groovy
@@ -245,18 +245,23 @@ def supportsUiUpgrade(String version) {
     return major < 3 || (major == 3 && minor < 9)
 }
 
-def upgradeBranches(Map branches, List pmmVersions, List clientDebVersions, String latestVersion, String latestDevVersion) {
-    // Mirrors pmm3-upgrade-tests-matrix: every recent version upgraded, with the
-    // newest one going from its RC image up to the dev tip.
+def upgradeBranches(Map branches, List pmmVersions, List clientDebVersions, String serverImage, String latestDevVersion) {
+    // Every recent release upgraded to the image under test. pmm3-upgrade-tests-matrix,
+    // which this fan-out replaces, sends the newest source from its own RC image to the
+    // dev tip and every older source to that same RC — right for the job it is, which
+    // tests a release candidate, and wrong here: it left 15 of these 18 suites
+    // upgrading to a three-week-old RC and never loading the image this run is about.
+    //
+    // So the pre-upgrade side is the GA a user would actually be running, and the
+    // post-upgrade side is DOCKER_VERSION. A nightly then exercises the tip and a run
+    // pointed at an RC exercises the RC, with no branch here needing to know which.
     def variants = ['SSL', 'EXTERNAL SERVICES', 'OTHERS']
     pmmVersions.each { ver ->
-        def isNewest = (ver == pmmVersions.last())
-        def dockerTag = isNewest ? "perconalab/pmm-server:${ver}-rc" : "percona/pmm-server:${ver}"
-        def dockerTagUpgrade = isNewest ? 'perconalab/pmm-server:3-dev-latest' : "perconalab/pmm-server:${pmmVersions.last()}-rc"
-        def clientVersion = isNewest ? 'pmm3-rc'
-            : (ver in clientDebVersions ? ver : "https://downloads.percona.com/downloads/pmm3/${ver}/binary/tarball/pmm-client-${ver}-x86_64.tar.gz")
-        def clientRepo = isNewest ? 'experimental' : 'testing'
-        def serverLatest = isNewest ? latestDevVersion : latestVersion
+        // The apt pool carries only the newest few client debs; an older source
+        // installs from its published tarball instead.
+        def clientVersion = ver in clientDebVersions
+            ? ver
+            : "https://downloads.percona.com/downloads/pmm3/${ver}/binary/tarball/pmm-client-${ver}-x86_64.tar.gz"
 
         def upgradeType = supportsUiUpgrade(ver) ? params.UPGRADE_TYPE : 'DOCKER'
 
@@ -264,11 +269,11 @@ def upgradeBranches(Map branches, List pmmVersions, List clientDebVersions, Stri
             def name = "upgrade / ${ver} ${variant}"
             branches[name] = suite(name, 'pmm3-upgrade-test-runner', [
                 string(name: 'PMM_UI_PRE_UPGRADE_GIT_BRANCH', value: "pmm-${ver}"),
-                string(name: 'DOCKER_TAG',                    value: dockerTag),
-                string(name: 'DOCKER_TAG_UPGRADE',            value: dockerTagUpgrade),
+                string(name: 'DOCKER_TAG',                    value: "percona/pmm-server:${ver}"),
+                string(name: 'DOCKER_TAG_UPGRADE',            value: serverImage),
                 string(name: 'CLIENT_VERSION',                value: clientVersion),
-                string(name: 'CLIENT_REPOSITORY',             value: clientRepo),
-                string(name: 'PMM_SERVER_LATEST',             value: serverLatest),
+                string(name: 'CLIENT_REPOSITORY',             value: 'experimental'),
+                string(name: 'PMM_SERVER_LATEST',             value: latestDevVersion),
                 string(name: 'PMM_QA_GIT_BRANCH',             value: params.PMM_QA_GIT_BRANCH),
                 string(name: 'UPGRADE_FLAG',                  value: variant),
                 string(name: 'UPGRADE_TYPE',                  value: upgradeType),
@@ -356,7 +361,7 @@ timestamps {
 
     packageBranches(branches, 'pkg amd64', 'nightly-package-testing-amd64', 'amd64', serverImage, latestDevVersion, latestVersion)
     packageBranches(branches, 'pkg arm64', 'nightly-package-testing-arm64', 'arm64', serverImage, latestDevVersion, latestVersion)
-    upgradeBranches(branches, upgradeVersions, clientDebVersions, latestVersion, latestDevVersion)
+    upgradeBranches(branches, upgradeVersions, clientDebVersions, serverImage, latestDevVersion)
 
     branches['upgrade / ami'] = suite('upgrade / ami', 'pmm3-upgrade-ami-test', [
         string(name: 'PMM_QA_GIT_BRANCH',   value: params.PMM_QA_GIT_BRANCH),

--- a/pmm/v3/pmm3-nightly-orchestrator.groovy
+++ b/pmm/v3/pmm3-nightly-orchestrator.groovy
@@ -198,19 +198,9 @@ def supportsUiUpgrade(String version) {
 }
 
 def upgradeBranches(Map branches, List pmmVersions, List clientDebVersions, String serverImage, String latestDevVersion) {
-    // Every recent release upgraded to the image under test. pmm3-upgrade-tests-matrix,
-    // which this fan-out replaces, sends the newest source from its own RC image to the
-    // dev tip and every older source to that same RC — right for the job it is, which
-    // tests a release candidate, and wrong here: it left 15 of these 18 suites
-    // upgrading to a three-week-old RC and never loading the image this run is about.
-    //
-    // So the pre-upgrade side is the GA a user would actually be running, and the
-    // post-upgrade side is DOCKER_VERSION. A nightly then exercises the tip and a run
-    // pointed at an RC exercises the RC, with no branch here needing to know which.
     def variants = ['SSL', 'EXTERNAL SERVICES', 'OTHERS']
     pmmVersions.each { ver ->
-        // The apt pool carries only the newest few client debs; an older source
-        // installs from its published tarball instead.
+        // The apt pool carries only the newest few client debs.
         def clientVersion = ver in clientDebVersions
             ? ver
             : "https://downloads.percona.com/downloads/pmm3/${ver}/binary/tarball/pmm-client-${ver}-x86_64.tar.gz"


### PR DESCRIPTION
15 of the 18 upgrade suites in this orchestrator were not testing the image the run is about.

## What was wrong

`upgradeBranches` was copied from `pmm3-upgrade-tests-matrix.groovy`, which splits on `isNewest`:

| | pre-upgrade | upgrade target |
|---|---|---|
| newest source (3.9.1) | `perconalab/pmm-server:3.9.1-rc` | `perconalab/pmm-server:3-dev-latest` |
| every older source | `percona/pmm-server:<ver>` | `perconalab/pmm-server:3.9.1-rc` |

That is correct for the job it came from — that job *is* release-candidate testing, so the RC is the artifact under test. Here it is a fossil. With `upgradeVersions = 3.7.0 … 3.9.1`, five of six sources × three variants = **15 suites upgraded to `perconalab/pmm-server:3.9.1-rc`**, pushed `2026-08-18T12:02:03Z`. The dev tip they exist to validate was pushed `2026-09-08T14:37:52Z`. Only the 3 newest-source suites ever loaded it.

They did not fail, which is the part that matters: `pmm3-upgrade-test-runner` asserts the post-upgrade version with `checkClientAfterUpgrade(PMM_SERVER_LATEST)`, and `PMM_SERVER_LATEST` split the same way — `latestVersion` (3.9.1) for those 15. Target and assertion agreed with each other and disagreed with the point of the run, so the suites went green on three-week-old code.

The newest lane had the mirror-image problem: it started from `3.9.1-rc` rather than GA `3.9.1`, a pre-release build no user ever ran, published one day before the GA it was standing in for.

## What it does now

`DOCKER_TAG_UPGRADE` is `serverImage` — i.e. `DOCKER_VERSION`, the parameter that already means "the image under test" — for every source. So a nightly exercises the tip, and a run pointed at `perconalab/pmm-server:3.10.0-rc` exercises that RC, with no branch here needing to know which. `PMM_SERVER_LATEST` is `latestDevVersion` throughout, which tracks both cases: `pmm-submodules` `v3/VERSION` is `3.10.0`, the version of the tip and of its eventual RC alike.

The pre-upgrade side is `percona/pmm-server:<ver>` for every source — the GA a user upgrading from that release would actually be running. `CLIENT_REPOSITORY` is `experimental` throughout, since every lane now ends at the dev tip and only experimental carries a 3.10.0 client.

The `isNewest` split disappears. The one thing that still varies per source is whether its client comes from the apt pool or a tarball, which is Percona-Lab/jenkins-pipelines#4430's logic, unchanged.

## Resulting matrix, resolved against live data

`3.10.0` dev tip, apt pool `3.7.1 3.8.0 3.8.1 3.9.0 3.9.1`:

| source | pre-upgrade | target | client | repo | asserts | path |
|---|---|---|---|---|---|---|
| 3.7.0 | `percona/pmm-server:3.7.0` | `DOCKER_VERSION` | tarball | experimental | 3.10.0 | UI |
| 3.7.1 | `percona/pmm-server:3.7.1` | `DOCKER_VERSION` | `3.7.1` deb | experimental | 3.10.0 | UI |
| 3.8.0 | `percona/pmm-server:3.8.0` | `DOCKER_VERSION` | `3.8.0` deb | experimental | 3.10.0 | UI |
| 3.8.1 | `percona/pmm-server:3.8.1` | `DOCKER_VERSION` | `3.8.1` deb | experimental | 3.10.0 | UI |
| 3.9.0 | `percona/pmm-server:3.9.0` | `DOCKER_VERSION` | `3.9.0` deb | experimental | 3.10.0 | DOCKER |
| 3.9.1 | `percona/pmm-server:3.9.1` | `DOCKER_VERSION` | `3.9.1` deb | experimental | 3.10.0 | DOCKER |

The Docker-only path on 3.9.0+ is Percona-Lab/jenkins-pipelines#4431's, unchanged — 3.9.0 removed the in-app updater.

## Verification

- **Every artifact the new matrix pulls exists.** All six `percona/pmm-server:<ver>` GA tags return 200 on Docker Hub. `pmm-client-3.7.0-x86_64.tar.gz`, the one source aged out of the apt pool, returns 200.
- **The staleness is measured, not asserted.** `perconalab/pmm-server:3.9.1-rc` → 200, `last_updated 2026-08-18T12:02:03Z`; `percona/pmm-server:3.9.1` → 200, `2026-08-19T14:43:46Z`; `perconalab/pmm-server:3-dev-latest` → 200, `2026-09-08T14:37:52Z`. The old target was real, so nothing was failing — it was 21 days behind.
- **The matrix above is generated**, not hand-written: resolved by replaying the new expressions against the live apt `Packages` index, the live `v3/VERSION`, and `pmmVersion('v3')` at this commit.
- **`npm-groovy-lint`**, each version linted alone: 0 errors before and after, 21 warnings → 20 (the collapsed ternaries drop a >120-char line). No new finding.
- `latestVersion` is still used by both `packageBranches` calls, so dropping it from `upgradeBranches`' signature leaves no unused binding.

## Not changed here

- **`RUN_GH_RC_SUITE`** passes `rc_version: latestDevVersion` into a workflow that composes `<rc_version>-rc`, which for `3.10.0` names an image that does not exist yet. It is `false` by default and its own parameter description says so, so it is honest rather than broken — but it is the same fossil in a lane that is off.
- **`pmmVersion('v3')` is hand-maintained** in `vars/pmmVersion.groovy` and ends at 3.9.1. If a release lands without that list being updated, `latestVersion` silently stays behind — the same class of hardcoded ladder as the one Percona-Lab/jenkins-pipelines#4430 worked around. Worth its own change.
- **`pmm3-upgrade-tests-matrix.groovy` itself is untouched.** Its `-rc` shape is correct for what it does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAA4rTkQmjq8kkYvn2TWeh

---
_Generated by [Claude Code](https://claude.ai/code/session_01JAA4rTkQmjq8kkYvn2TWeh)_