### PR TITLE
PMM-15197 Inline the AMI upgrade wrapper

### DIFF
--- a/pmm/v3/pmm3-nightly-orchestrator.groovy
+++ b/pmm/v3/pmm3-nightly-orchestrator.groovy
@@ -225,6 +225,26 @@ def upgradeBranches(Map branches, List pmmVersions, List clientDebVersions, Stri
     }
 }
 
+def amiUpgradeBranches(Map branches, String serverImage, String latestDevVersion) {
+    // The AMI equivalent of upgradeBranches, and the last matrix wrapper this job
+    // replaces: pmm3-upgrade-ami-test fanned these five out itself, on an executor,
+    // behind a retry(2), and reported them as one box.
+    def amis = pmmVersion('v3-ami')
+    pmmVersion('v3')[-5..-1].each { ver ->
+        def name = "upgrade / ami ${ver}"
+        branches[name] = suite(name, 'pmm3-upgrade-ami-test-runner', [
+            string(name: 'PMM_UI_PRE_UPGRADE_GIT_BRANCH', value: "pmm-${ver}"),
+            string(name: 'PMM_QA_GIT_BRANCH',             value: params.PMM_QA_GIT_BRANCH),
+            string(name: 'AMI_TAG',                       value: amis[ver] ?: ''),
+            string(name: 'DOCKER_TAG_UPGRADE',            value: serverImage),
+            string(name: 'CLIENT_VERSION',                value: ver),
+            string(name: 'CLIENT_REPOSITORY',             value: 'experimental'),
+            string(name: 'PMM_SERVER_LATEST',             value: latestDevVersion),
+            booleanParam(name: 'USE_ONDEMAND', value: params.USE_ONDEMAND),
+        ])
+    }
+}
+
 timestamps {
     def serverImage = params.DOCKER_VERSION.trim()
     def amiId = pmmVersion('v3-ami').values()[-1]
@@ -305,11 +325,7 @@ timestamps {
     packageBranches(branches, 'pkg arm64', 'nightly-package-testing-arm64', 'arm64', serverImage, latestDevVersion, latestVersion)
     upgradeBranches(branches, upgradeVersions, clientDebVersions, serverImage, latestDevVersion)
 
-    branches['upgrade / ami'] = suite('upgrade / ami', 'pmm3-upgrade-ami-test', [
-        string(name: 'PMM_QA_GIT_BRANCH',   value: params.PMM_QA_GIT_BRANCH),
-        booleanParam(name: 'IS_RC_TESTING', value: false),
-        booleanParam(name: 'USE_ONDEMAND',  value: params.USE_ONDEMAND),
-    ])
+    amiUpgradeBranches(branches, serverImage, latestDevVersion)
 
     branches['gssapi'] = suite('gssapi', 'pmm3-ui-tests-nightly-gssapi', [
         string(name: 'PMM_QA_GIT_BRANCH', value: params.PMM_QA_GIT_BRANCH),


### PR DESCRIPTION
`pmm3-upgrade-ami-test` was the last matrix wrapper this job still went through, and it was kept by oversight rather than by decision — including in the header comment that names the three wrappers it replaced. The three inlined ones are all `*-matrix` (`pmm3-package-tests-matrix-*`, `pmm3-ui-tests-matrix`, `pmm3-upgrade-tests-matrix`); this one is `pmm3-upgrade-ami-tests`, dispatched under the job name `pmm3-upgrade-ami-test`, with its child at `pmm3-upgrade-ami-test-runner`. The naming is why it wasn't spotted.

## Why it mattered

It is the same shape as the three that went: a pipeline-level `agent`, one `stage`, and a `parallel` whose branches each `build job:` a child.

| | Cost |
|---|---|
| Executor | `agent { label params.USE_ONDEMAND ? 'cli-ondemand' : 'cli' }` held for the whole `parallel`, `timeout(300, MINUTES)`. Not a deadlock — its children run on `agent-amd64-ondemand`, so it can't starve them — but a `cli` slot idles for hours |
| Visibility | 5 variants reported as one lane. The board was 51 boxes for 55 suites |
| Honesty | `retry(2)` inside each variant, so a first-attempt failure is retried silently and never reaches the report. `upgrade / ami` was SUCCESS in #3 with no way to see whether anything failed first |
| RC fossil | The same one Percona-Lab/jenkins-pipelines#4432 removed, untouched by it because it lives in a different job on a different branch |

The fossil in detail: `generateVariants` sends four of five variants to `perconalab/pmm-server:${latestVersion}-rc` — `3.9.1-rc`, pushed `2026-08-18` — instead of the image under test. The fifth goes to `3-dev-latest` but passes `PMM_SERVER_LATEST=latestVersion` (`3.9.1`) while the tip is `3.10.0`, so its post-upgrade assertion and its upgrade target disagree. Its pre-upgrade client is `3-dev-latest` against the newest **GA** AMI, which is the same mismatch in the other direction.

## What this does

The five variants become branches of the one flat parallel, dispatching `pmm3-upgrade-ami-test-runner` directly with the shape `upgradeBranches` already uses after Percona-Lab/jenkins-pipelines#4432: the GA AMI and its matching client on the pre-upgrade side, `DOCKER_VERSION` on the post-upgrade side, `experimental` throughout since every lane ends at the tip, and `PMM_SERVER_LATEST` following the upgrade target rather than splitting from it.

| lane | `AMI_TAG` | `CLIENT_VERSION` | `DOCKER_TAG_UPGRADE` | repo | `PMM_SERVER_LATEST` |
|---|---|---|---|---|---|
| `upgrade / ami 3.7.1` | `ami-07fe22a2d9e2e5672` | `3.7.1` | `DOCKER_VERSION` | experimental | `3.10.0` |
| `upgrade / ami 3.8.0` | `ami-0948285405115bcbf` | `3.8.0` | `DOCKER_VERSION` | experimental | `3.10.0` |
| `upgrade / ami 3.8.1` | `ami-045ba46ff67584b6b` | `3.8.1` | `DOCKER_VERSION` | experimental | `3.10.0` |
| `upgrade / ami 3.9.0` | `ami-084707c8a853d6168` | `3.9.0` | `DOCKER_VERSION` | experimental | `3.10.0` |
| `upgrade / ami 3.9.1` | `ami-02b001dfc081467a1` | `3.9.1` | `DOCKER_VERSION` | experimental | `3.10.0` |

`retry(2)` is deliberately not carried over. A silent retry is what let this lane read green regardless of what happened inside it, and the point of the flat fan-out is that the report says what ran.

## Verification

- **The variant logic was read from `PMM-7-fix-ami-upgrade`, the branch both Jenkins jobs actually run**, not from `master`. That distinction is load-bearing here: `master` and that branch differ by 128 lines in `pmm3-upgrade-ami-test-runner.groovy` and 9 in the wrapper, so reading `master` would have produced the wrong parameter set.
- **Neither job's config is touched.** `pmm3-upgrade-ami-test-runner` stays on its own branch with its own SCM; this change only stops calling the wrapper that fanned out to it. Nothing in-flight on that branch is disturbed.
- **Every parameter is one the runner declares.** All eight — `PMM_UI_PRE_UPGRADE_GIT_BRANCH`, `PMM_QA_GIT_BRANCH`, `AMI_TAG`, `DOCKER_TAG_UPGRADE`, `CLIENT_VERSION`, `PMM_SERVER_LATEST`, `CLIENT_REPOSITORY`, `USE_ONDEMAND` — match its `parameterDefinitions`, and `experimental` is one of `CLIENT_REPOSITORY`'s three choices. `IS_RC_TESTING` is gone because only the wrapper had it.
- **All five newest releases have an AMI recorded**, checked against `vars/pmmVersion.groovy`: no lane resolves to an empty `AMI_TAG` today, and `?: ''` keeps a future gap to the one lane instead of throwing during branch construction and killing the run.
- **The version list is a `List`, not the AMI map.** Iterating `pmmVersion('v3')[-5..-1]` and looking the AMI up by key is order-independent, which the wrapper's `values().toList()[-5..-1]` is not by construction (it works only because a Groovy map literal is a `LinkedHashMap`).
- **`npm-groovy-lint`**: 0 errors before and after; 20 → 21 warnings. The one new warning is `DuplicateMapLiteral` on `[name: CLIENT_REPOSITORY, value: experimental`], now present in both `upgradeBranches` and here. Left as is on purpose — a shared constant for two literals is worse than the duplication.
- **The lane table above is generated** by replaying the new expressions against `vars/pmmVersion.groovy` at this commit, not written by hand.

## Audit: is there another one?

Every job this orchestrator dispatches was checked for the wrapper signature — a `parallel` whose branches dispatch child jobs. There isn't another.

| Job | `parallel` | `build job:` | Verdict |
|---|---|---|---|
| `pmm3-upgrade-ami-test` | fans out 5 versions | `…-test-runner` | **wrapper — this PR** |
| `pmm3-ui-tests-nightly-gha` | internal test shards | infra only (`staging-start`/`stop`, `pmm3-ha-eks`, `openshift-cluster-*`, `ami-staging-*`) | leaf |
| `pmm3-ui-tests-nightly-gssapi` | internal test shards | infra only | leaf |
| `pmm3-ui-tests` | internal test shards | none | leaf |
| `pmm3-upgrade-test-runner` | — | — | leaf |
| `openshift-helm-tests` | none | 2, `cluster-create`/`destroy` only | leaf |
| `nightly-package-testing-{amd,arm}64` | 8 OS stages | infra only | leaf by design |

A suite that provisions its own infrastructure is not a wrapper — it is the thing being measured, and the `build job:` calls inside it are setup and teardown, not fan-out.

## Not changed here

- `pmm3-upgrade-ami-tests.groovy` and `pmm3-ami-upgrade-tests-matrix.groovy` still exist and still carry the fossil, for whoever runs those jobs outside this orchestrator.
- `pmm3-upgrade-tests-matrix.groovy` on `master` still has the dead `ver in oldVersions` fallback that Percona-Lab/jenkins-pipelines#4430 worked around here. Its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAA4rTkQmjq8kkYvn2TWeh

---
_Generated by [Claude Code](https://claude.ai/code/session_01JAA4rTkQmjq8kkYvn2TWeh)_