### PR TITLE
PMM-15197 Drop the per-lane stage mirroring

### DIFF
--- a/pmm/v3/pmm3-nightly-orchestrator.groovy
+++ b/pmm/v3/pmm3-nightly-orchestrator.groovy
@@ -42,86 +42,12 @@ properties([
 // Script-level binding so the dispatch helpers can record into it.
 results = [:]
 
-def humanMs(def millis) {
-    // A stage still running or paused for input reports no duration.
-    if (millis == null) {
-        return '?'
-    }
-    long ms = millis as long
-    if (ms < 1000) {
-        return "${ms}ms"
-    }
-    long total = (ms / 1000) as long
-    long h = (total / 3600) as long
-    long m = ((total % 3600) / 60) as long
-    long s = total % 60
-    if (h > 0) {
-        return "${h}h${m.toString().padLeft(2, '0')}m"
-    }
-    if (m > 0) {
-        return "${m}m${s.toString().padLeft(2, '0')}s"
-    }
-    return "${s}s"
-}
-
-def mirrorChild(String name, String jobName, def run) {
-    def stages = []
-    try {
-        stages = childStages(run)
-    } catch (err) {
-        echo "[${name}] child stages unavailable (${err.message}); rendering the suite as one stage"
-    }
-
-    stage("#${run.number} ${jobName}") {
-        echo "${run.absoluteUrl}"
-    }
-
-    int lastRun = -1
-    for (int i = 0; i < stages.size(); i++) {
-        if (stages[i].status != 'NOT_EXECUTED') {
-            lastRun = i
-        }
-    }
-
-    for (int i = 0; i <= lastRun; i++) {
-        def child = stages[i]
-        stage("${child.name} · ${humanMs(child.durationMillis)}") {
-            // buildResult stays null on purpose: the suite's own verdict below
-            // owns the build result, and a mirrored step must not raise it.
-            if (child.status == 'FAILED') {
-                catchError(buildResult: null, stageResult: 'FAILURE') {
-                    error("${child.name} failed in ${jobName} #${run.number}")
-                }
-            } else if (child.status == 'UNSTABLE') {
-                catchError(buildResult: null, stageResult: 'UNSTABLE') {
-                    error("${child.name} unstable in ${jobName} #${run.number}")
-                }
-            } else if (child.status == 'ABORTED') {
-                catchError(buildResult: null, stageResult: 'ABORTED') {
-                    error("${child.name} aborted in ${jobName} #${run.number}")
-                }
-            }
-        }
-    }
-
-    int skipped = stages.size() - 1 - lastRun
-    if (skipped > 0) {
-        stage("${skipped} stages skipped") {
-            catchError(buildResult: null, stageResult: 'NOT_BUILT') {
-                error("${skipped} stages never ran: ${jobName} #${run.number} stopped at '${stages[lastRun].name}'")
-            }
-        }
-    }
-}
-
 def suite(String name, String jobName, List jobParams) {
     return {
         stage(name) {
             def run = build job: jobName, parameters: jobParams, wait: true, propagate: false
             results[name] = [job: jobName, number: run.number, url: run.absoluteUrl, result: run.result]
             echo "[${name}] ${run.result} -> ${run.absoluteUrl}"
-
-            mirrorChild(name, jobName, run)
 
             if (run.result == 'FAILURE' || run.result == 'ABORTED') {
                 catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {


### PR DESCRIPTION
Run #4 is the first one that actually executed `mirrorChild` — #3 checked out the branch before `b90f3307` landed — and it threw on every single lane. This removes it.

## What #4 shows

Every branch that finished logged `Failed in branch <name>` immediately after the suite's own verdict echo, including the ones whose child had passed:

```
[2026-09-08T18:41:59.366Z] Build pmm3-ui-tests #11045 completed: SUCCESS
[2026-09-08T18:41:59.381Z] [ui / @ia] SUCCESS -> …/job/pmm3-ui-tests/11045/
[2026-09-08T18:41:59.432Z] [Pipeline] }
[2026-09-08T18:41:59.464Z] [Pipeline] // stage
[2026-09-08T18:41:59.485Z] Failed in branch ui / @ia
```

Counted over the console at 19:45, 38 lanes finished:

| | count |
|---|---|
| `Failed in branch` | **38** |
| Lanes whose child reported SUCCESS | 26 |
| Lanes whose child reported FAILURE | 12 |
| Mirrored child stages ever opened (`[Pipeline] { (#N <job>)`) | **0** |
| `child stages unavailable` echoes from the method's own catch | **0** |

So the throw is *not* the guarded `childStages(run)` call — that catch would have echoed — and it is not an `Exception`, since `catch (err)` is `catch (Exception err)`. The method produced no observable output at all, which is consistent with never being entered. I can't identify the mechanism from the console while the build is still running, and the stack trace only prints when `parallel` unwinds.

## Why remove rather than patch

The damage isn't cosmetic. Two consequences:

1. **Every lane reads FAILED in the stage graph regardless of its child.** The graph, which is the thing the mirroring was meant to improve, became actively misleading — worse than the single opaque box it replaced. It is the same class of error as the unfinished-branch trap this file's header warned about, arriving from the opposite direction: last time the API called unfinished branches SUCCESS, this time it calls passing lanes FAILED.
2. **The Report stage never runs.** Each branch throws, so `parallel` unwinds and the script aborts before `stage('Report')`. #4 will end FAILURE with no grouped summary, and the only truthful record of the run is the per-lane echoes in the log.

Against that: the feature has never rendered a single stage. `childStages` is not in `lib@master` yet — Percona-Lab/jenkins-pipelines#4419 is still open — so even working correctly it would have degraded to one box per lane in #4. It has no proven upside to weigh against a run's report.

Patching it blind would mean wrapping the call in `catch (Throwable)`, which also swallows `FlowInterruptedException` and would make an aborted lane look like a clean one. That trade isn't worth making for an unvalidated feature.

`vars/childStages.groovy` stays in place, unused. A second attempt should be exercised on a scratch job with a real `parallel` and a real `build job:` child before it goes anywhere near this pipeline.

## Verification

- `npm-groovy-lint`: 0 errors, 21 warnings — unchanged from the base.
- No reference to `mirrorChild`, `humanMs` or `childStages` remains in the pipeline; `grep` is clean.
- `suite()` keeps exactly its pre-`b90f3307` body: dispatch, record into `results`, echo, then `catchError` to colour the stage and the build on a non-SUCCESS child.
- The 74 deleted lines are the two helpers and the one call site, nothing else.

## Note for Percona-Lab/jenkins-pipelines#4419

That PR currently carries this defect to `master`. Merging this first removes it from #4419's diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAA4rTkQmjq8kkYvn2TWeh

---
_Generated by [Claude Code](https://claude.ai/code/session_01JAA4rTkQmjq8kkYvn2TWeh)_