### PR TITLE
PMM-15197 Stop log archiving deciding the verdict

### DIFF
--- a/pmm/v3/pmm3-upgrade-test-runner.groovy
+++ b/pmm/v3/pmm3-upgrade-test-runner.groovy
@@ -626,14 +626,14 @@ pipeline {
                 tar -zcvf srv-logs.tar.gz srv-logs
             '''
             script {
-                archiveArtifacts artifacts: 'pmm-managed-full.log'
-                archiveArtifacts artifacts: 'pmm-update-perform.log'
-                archiveArtifacts artifacts: 'pmm-agent.log'
-                archiveArtifacts artifacts: 'logs.zip'
-                archiveArtifacts artifacts: 'srv-logs.tar.gz'
-                archiveArtifacts artifacts: 'playwright-report.tar.gz'
-                archiveArtifacts artifacts: 'playwright-screenshots.tar.gz'
-                archiveArtifacts artifacts: 'playwright-logs.tar.gz'
+                archiveArtifacts artifacts: 'pmm-managed-full.log', allowEmptyArchive: true
+                archiveArtifacts artifacts: 'pmm-update-perform.log', allowEmptyArchive: true
+                archiveArtifacts artifacts: 'pmm-agent.log', allowEmptyArchive: true
+                archiveArtifacts artifacts: 'logs.zip', allowEmptyArchive: true
+                archiveArtifacts artifacts: 'srv-logs.tar.gz', allowEmptyArchive: true
+                archiveArtifacts artifacts: 'playwright-report.tar.gz', allowEmptyArchive: true
+                archiveArtifacts artifacts: 'playwright-screenshots.tar.gz', allowEmptyArchive: true
+                archiveArtifacts artifacts: 'playwright-logs.tar.gz', allowEmptyArchive: true
 
                 def PATH_TO_REPORT_RESULTS = 'tests/output/*.xml'
                 try {
@@ -654,10 +654,10 @@ pipeline {
         }
         failure {
             dir('/home/ec2-user/workspace/pmm3-upgrade-test-runner') {
-                archiveArtifacts artifacts: 'tests/output/*.png'
+                archiveArtifacts artifacts: 'tests/output/*.png', allowEmptyArchive: true
             }
             dir('/srv/pmm-qa/codeceptjs-e2e') {
-                archiveArtifacts artifacts: 'tests/output/*.png'
+                archiveArtifacts artifacts: 'tests/output/*.png', allowEmptyArchive: true
             }
         }
     }


### PR DESCRIPTION
Three upgrade lanes in `pmm3-nightly-orchestrator` #4 reported FAILURE with **every stage green**. The verdict came from the log archiving in `post { always }`, not from a test.

## The failure

`pmm3-upgrade-test-runner` #23470 — all 22 stages SUCCESS, `Declarative: Post Actions` SUCCESS, `Finished: FAILURE`:

```
'pmm-agent.log' doesn't match anything, but 'srv-logs/pmm-agent.log' does. Perhaps that's what you mean?
Error when executing always post condition:
hudson.AbortException: No artifacts found that match the file pattern "pmm-agent.log". Configuration error?
	at hudson.tasks.ArtifactArchiver.perform(ArtifactArchiver.java:280)
…
ERROR: No artifacts found that match the file pattern "pmm-agent.log". Configuration error?
Finished: FAILURE
```

The producer, in the same `post` block, is **already guarded** — a tarball client has no systemd unit to read from:

```sh
# get logs from systemd pmm-agent.service
if [[ ${CLIENT_VERSION} != http* ]]; then
    journalctl -u pmm-agent.service >  ./pmm-agent.log
fi
```

The archive of that file is not guarded:

```groovy
archiveArtifacts artifacts: 'pmm-agent.log'
```

Whoever added that `if` knew the file would not exist for a tarball client and did not carry the same condition to the consumer. `allowEmptyArchive` defaults to `false`, so the absence aborts the post block and fails an otherwise-green build.

It is not only that one file. Of the eight archives in `always`, **six have producers that can legitimately produce nothing**: four commands end in `|| true` (`logs.zip` and the three `playwright-*.tar.gz`), and `pmm-agent.log` is the conditional above. Any one of them missing fails the build, and the first one to fail also skips the archiving of everything after it — so the failure costs the diagnostics too.

## Why these three lanes and not the others

`pmm-agent.log` is skipped exactly when `CLIENT_VERSION` is an `http*` URL. In #4 the only upgrade source installed from a tarball is 3.7.0, whose client deb has aged out of the apt pool (Percona-Lab/jenkins-pipelines#4430) — so `upgrade / 3.7.0 SSL`, `EXTERNAL SERVICES` and `OTHERS` were the three lanes that took the guarded path, and all three failed this way. The other 15 upgrade lanes install from a deb, produce the file, and were unaffected.

The bug is pre-existing rather than introduced by that PR: `pmm3-upgrade-tests-matrix.groovy` has always passed tarball URLs as `CLIENT_VERSION` for its older sources, so any tarball lane there hits the same wall. Percona-Lab/jenkins-pipelines#4430 is only what made it visible, by routing a source through the tarball path in a run someone was watching.

Worth separating clearly: **this is not the same as `upgrade / 3.8.1 OTHERS`**, which also failed in #4 but ends with `ERROR: script returned exit code 1` — a real failure, and still open.

## The change

`allowEmptyArchive: true` on all ten `archiveArtifacts` calls in `post` — the eight in `always` and the two `tests/output/*.png` in `failure`. A post-mortem diagnostic must never be what fails the build. It is the same defect as a rescue that reports itself instead of the error it was collected to explain, which is what percona/pmm-qa#1370 fixed on the pmm-qa side of this run.

The two in `failure` cannot change a verdict — the build is already FAILURE there — but an empty first glob currently aborts before the second `dir` block, losing the screenshots from the other suite. Same one-line remedy.

## Verification

- **The mechanism is from the console, not inferred**: the `AbortException` and its `ArtifactArchiver.perform` frame are quoted above verbatim from #23470, and Jenkins itself names the file that does exist (`srv-logs/pmm-agent.log`).
- **The correlation is exact**: the three failing lanes are precisely the three whose `CLIENT_VERSION` is an `http*` URL, which is precisely the condition under which the producer skips the file.
- **A neighbouring failure was checked and is different**, so this is not being used to explain away unrelated red: #23481 (`3.8.1 OTHERS`) ends `script returned exit code 1`.
- **`npm-groovy-lint`**: 1 error and 101 warnings, **identical before and after**. The error is pre-existing and unrelated — `The variable [oldVersions] in class None is not used` at line 46, dead since the tarball logic moved out of this file.
- The branch this job actually runs is `*/master` (checked in its SCM config), which is why this PR targets `master` rather than the orchestrator's staging branch.

## Not changed here

The same unguarded pattern exists in ten other pipelines, including two this orchestrator dispatches:

| file | unguarded `archiveArtifacts` |
|---|---|
| `pmm3-migration-tests.groovy` | 8 |
| `pmm3-ui-tests.groovy` | 5 |
| `pmm3-ami-upgrade-tests.groovy` | 5 |
| `pmm3-ui-tests-nightly-gssapi.groovy` | 3 |
| `pmm3-testsuite.groovy` | 2 |
| `pmm3-api-tests.groovy`, `pmm3-package-testing-{amd,arm}64.groovy`, `pmm3-upgrade-ami-test-runner.groovy` | 1 each |

None of them has been observed failing this way, so they are left alone rather than swept into this PR. They are worth a follow-up sweep — `pmm3-ui-tests.groovy` in particular, since it backs the `ui / *` lanes.

The unused `oldVersions` at line 46 is also left alone: it is a real finding but unrelated to this failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAA4rTkQmjq8kkYvn2TWeh

---
_Generated by [Claude Code](https://claude.ai/code/session_01JAA4rTkQmjq8kkYvn2TWeh)_