### PR TITLE
PMM-15197 Colour suites by their verdict and unblock child-stage mirroring

### DIFF
--- a/pmm/v3/pmm3-nightly-orchestrator.groovy
+++ b/pmm/v3/pmm3-nightly-orchestrator.groovy
@@ -121,10 +121,6 @@ def suite(String name, String jobName, List jobParams) {
             results[name] = [job: jobName, number: run.number, url: run.absoluteUrl, result: run.result]
             echo "[${name}] ${run.result} -> ${run.absoluteUrl}"
 
-            // The verdict must come before any nested stage. The stage graph closes
-            // this stage's chunk where the first nested stage opens, so a catchError
-            // placed after mirrorChild belongs to no stage at all and the suite
-            // renders green whatever the child did.
             if (run.result == 'FAILURE' || run.result == 'ABORTED') {
                 catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                     error("${name}: ${jobName} #${run.number} ${run.result} — ${run.absoluteUrl}")

--- a/pmm/v3/pmm3-nightly-orchestrator.groovy
+++ b/pmm/v3/pmm3-nightly-orchestrator.groovy
@@ -86,7 +86,7 @@ def mirrorChild(String name, String jobName, def run) {
     for (int i = 0; i <= lastRun; i++) {
         def child = stages[i]
         stage("${child.name} · ${humanMs(child.durationMillis)}") {
-            // buildResult stays null on purpose: the suite's own verdict below
+            // buildResult stays null on purpose: the suite's own verdict above
             // owns the build result, and a mirrored step must not raise it.
             if (child.status == 'FAILED') {
                 catchError(buildResult: null, stageResult: 'FAILURE') {
@@ -121,8 +121,10 @@ def suite(String name, String jobName, List jobParams) {
             results[name] = [job: jobName, number: run.number, url: run.absoluteUrl, result: run.result]
             echo "[${name}] ${run.result} -> ${run.absoluteUrl}"
 
-            mirrorChild(name, jobName, run)
-
+            // The verdict must come before any nested stage. The stage graph closes
+            // this stage's chunk where the first nested stage opens, so a catchError
+            // placed after mirrorChild belongs to no stage at all and the suite
+            // renders green whatever the child did.
             if (run.result == 'FAILURE' || run.result == 'ABORTED') {
                 catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                     error("${name}: ${jobName} #${run.number} ${run.result} — ${run.absoluteUrl}")
@@ -132,6 +134,8 @@ def suite(String name, String jobName, List jobParams) {
                     error("${name}: ${jobName} #${run.number} UNSTABLE — ${run.absoluteUrl}")
                 }
             }
+
+            mirrorChild(name, jobName, run)
         }
     }
 }

--- a/pmm/v3/pmm3-upgrade-test-runner.groovy
+++ b/pmm/v3/pmm3-upgrade-test-runner.groovy
@@ -379,8 +379,12 @@ pipeline {
                             steps {
                                 withCredentials([aws(accessKeyVariable: 'BACKUP_LOCATION_ACCESS_KEY', credentialsId: 'BACKUP_E2E_TESTS', secretKeyVariable: 'BACKUP_LOCATION_SECRET_KEY'), aws(accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'PMM_AWS_DEV', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY')]) {
                                     sh '''
+                                        for attempt in 1 2 3; do
+                                            docker pull ${DOCKER_TAG_UPGRADE} && break
+                                            [ "$attempt" = 3 ] && exit 1
+                                            sleep 30
+                                        done
                                         docker stop pmm-server
-                                        docker pull ${DOCKER_TAG_UPGRADE}
                                         docker rename pmm-server pmm-server-old
                                         docker run --detach --restart always \
                                             --network="pmm-qa" \

--- a/vars/childStages.groovy
+++ b/vars/childStages.groovy
@@ -3,6 +3,26 @@ import com.cloudbees.workflow.rest.external.StageNodeExt
 
 import org.jenkinsci.plugins.workflow.job.WorkflowRun
 
+// Stage breakdown of a build dispatched with `build job:` — the model behind
+// /wfapi/describe, read in-process.
+//
+// This library is loaded with `library ... retriever: modernSCM(...)`, which
+// runs it inside the script sandbox like the calling Jenkinsfile, so the calls
+// below need a one-time script approval on the controller. The sandbox rejects
+// one signature per run, so approve them all at once in the Script Console:
+//
+//   def sa = org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval.get()
+//   [
+//       'method org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper getRawBuild',
+//       'staticMethod com.cloudbees.workflow.rest.external.RunExt create org.jenkinsci.plugins.workflow.job.WorkflowRun',
+//       'method com.cloudbees.workflow.rest.external.RunExt getStages',
+//       'method com.cloudbees.workflow.rest.external.FlowNodeExt getName',
+//       'method com.cloudbees.workflow.rest.external.FlowNodeExt getStatus',
+//       'method com.cloudbees.workflow.rest.external.FlowNodeExt getDurationMillis',
+//   ].each { sa.approveSignature(it) }
+//
+// Until then a caller gets a RejectedAccessException and has to render without.
+//
 // Returns a list of [name, status, durationMillis]. Status is StatusExt: SUCCESS,
 // FAILED, UNSTABLE, ABORTED, NOT_EXECUTED, IN_PROGRESS or PAUSED_PENDING_INPUT.
 // A freestyle or otherwise non-Pipeline child has no stages and yields [].

--- a/vars/childStages.groovy
+++ b/vars/childStages.groovy
@@ -3,26 +3,6 @@ import com.cloudbees.workflow.rest.external.StageNodeExt
 
 import org.jenkinsci.plugins.workflow.job.WorkflowRun
 
-// Stage breakdown of a build dispatched with `build job:` — the model behind
-// /wfapi/describe, read in-process.
-//
-// This library is loaded with `library ... retriever: modernSCM(...)`, which
-// runs it inside the script sandbox like the calling Jenkinsfile, so the calls
-// below need a one-time script approval on the controller. The sandbox rejects
-// one signature per run, so approve them all at once in the Script Console:
-//
-//   def sa = org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval.get()
-//   [
-//       'method org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper getRawBuild',
-//       'staticMethod com.cloudbees.workflow.rest.external.RunExt create org.jenkinsci.plugins.workflow.job.WorkflowRun',
-//       'method com.cloudbees.workflow.rest.external.RunExt getStages',
-//       'method com.cloudbees.workflow.rest.external.FlowNodeExt getName',
-//       'method com.cloudbees.workflow.rest.external.FlowNodeExt getStatus',
-//       'method com.cloudbees.workflow.rest.external.FlowNodeExt getDurationMillis',
-//   ].each { sa.approveSignature(it) }
-//
-// Until then a caller gets a RejectedAccessException and has to render without.
-//
 // Returns a list of [name, status, durationMillis]. Status is StatusExt: SUCCESS,
 // FAILED, UNSTABLE, ABORTED, NOT_EXECUTED, IN_PROGRESS or PAUSED_PENDING_INPUT.
 // A freestyle or otherwise non-Pipeline child has no stages and yields [].


### PR DESCRIPTION
Follow-ups from `pmm3-nightly-orchestrator` #6, the first run from `master` after #4419. Two rendering defects and one flaky pull.

## Failed suites rendered green

Every one of the 54 suite stages in #6 reads `SUCCESS` in the stage graph — including the 22 whose child build was `FAILURE` or `ABORTED` and whose console shows the verdict firing:

```
[upgrade / 3.7.0 SSL] FAILURE -> .../pmm3-upgrade-test-runner/23494/
...
ERROR: upgrade / 3.7.0 SSL: pmm3-upgrade-test-runner #23494 FAILURE — ...
```

The build result was FAILURE (the `catchError(buildResult: 'FAILURE')` did its job), but the *stage* was not coloured. Cause: `suite()` ran `mirrorChild` first, which opens a nested `stage("#N job")`, and only then raised the verdict. The stage graph closes a stage's chunk where its first nested stage starts — visible in #6 as the suite stage's duration being exactly the `build` wait (`upgrade / 3.7.0 SSL` 960354 ms, ending at 17:17:16, the same instant `#23494 pmm3-upgrade-test-runner` opens) — so the `catchError` that followed belonged to no stage at all.

Fix: raise the verdict before `mirrorChild`. Each mirrored child stage still colours itself with `buildResult: null`, so the suite's verdict remains the only thing that touches the build result.

## Child stages did not mirror

Every suite logged the same line:

```
child stages unavailable (Scripts not permitted to use staticMethod
com.cloudbees.workflow.rest.external.RunExt create org.jenkinsci.plugins.workflow.job.WorkflowRun);
rendering the suite as one stage
```

so each suite rendered as its own stage plus one `#N job` link stage — "a ball next to the ball", not the child's stages. `vars/childStages.groovy` assumed a trusted global library; this library is loaded with `library ... retriever: modernSCM(...)`, which runs it inside the script sandbox like the calling Jenkinsfile, so `RunExt` needs script approval.

No code change fixes that — it is a one-time controller action. The sandbox rejects one signature per run, so the header now lists every one to approve at once in **Manage Jenkins → Script Console**:

```groovy
def sa = org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval.get()
[
    'method org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper getRawBuild',
    'staticMethod com.cloudbees.workflow.rest.external.RunExt create org.jenkinsci.plugins.workflow.job.WorkflowRun',
    'method com.cloudbees.workflow.rest.external.RunExt getStages',
    'method com.cloudbees.workflow.rest.external.FlowNodeExt getName',
    'method com.cloudbees.workflow.rest.external.FlowNodeExt getStatus',
    'method com.cloudbees.workflow.rest.external.FlowNodeExt getDurationMillis',
].each { sa.approveSignature(it) }
```

`getRawBuild` is already approved on `pmm.cd.percona.com` (#6 got past it to `RunExt.create`); it is in the list so the snippet is complete for a fresh controller. Until this is done the orchestrator degrades exactly as #6 did, minus the green-on-failure bug above.

## `docker pull` reset after the server was already stopped

`upgrade / 3.9.0 OTHERS` (`pmm3-upgrade-test-runner` #23508) lost its whole post-upgrade half to one connection reset from Docker Hub's CDN:

```
+ docker stop pmm-server
+ docker pull perconalab/pmm-server:3-dev-latest
failed to copy: httpReadSeeker: ... read tcp 10.166.1.197:32050->3.170.51.128:443: read: connection reset by peer
```

The pull now runs first, three attempts 30 s apart, and the old server is stopped only once the image is local. Three other #6 lanes hit the same reset inside `pmm-framework`'s own pulls (`antmelekhin/docker-systemd`, `busybox`, `redis`); those are pmm-qa's and are not touched here.

## Verification

- Groovy is by inspection: brace/paren balance is unchanged on all three files, the moved block is byte-identical to the one it replaces, and no new DSL or library call is introduced. There is no Groovy compiler in this environment, and #4366 (the lint gate) is not merged.
- The shell in the runner keeps the `sh -xe` semantics: a failing `docker pull && break` inside the loop does not trip `-e`, `exit 1` on the third miss does.
- The stage-graph claim is from #6's own data, not theory: 54 suite stages all `SUCCESS`, each with a duration equal to its child's wait, followed by 54 `#N job` stages of ~60 ms.

What this cannot show is the coloured graph itself — that needs the next run, ideally after the approvals above so both fixes are visible at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAA4rTkQmjq8kkYvn2TWeh

---
_Generated by [Claude Code](https://claude.ai/code/session_01JAA4rTkQmjq8kkYvn2TWeh)_