### PR TITLE
PMM-15197 Give the AMI upgrade runner 90 minutes and retry client installs

### DIFF
--- a/pmm/v3/pmm3-upgrade-ami-test-runner.groovy
+++ b/pmm/v3/pmm3-upgrade-ami-test-runner.groovy
@@ -144,7 +144,7 @@ pipeline {
     }
     options {
         skipDefaultCheckout()
-        timeout(time: 60, unit: 'MINUTES')
+        timeout(time: 90, unit: 'MINUTES')
     }
     stages {
         stage('Prepare') {
@@ -295,40 +295,52 @@ pipeline {
         stage('Upgrade PMM client') {
             steps {
                 sh '''
+                   # repo.percona.com republishes pool/experimental continuously and a
+                   # reader can see a package mid-write; refresh the index and try again.
+                   install_client() {
+                       for attempt in 1 2 3 4 5; do
+                           docker exec "\$1" \$2 install -y pmm-client && return 0
+                           echo "pmm-client install failed in \$1 (attempt \$attempt of 5), retrying in 60s"
+                           sleep 60
+                           docker exec "\$1" percona-release enable pmm3-client $CLIENT_REPOSITORY
+                       done
+                       return 1
+                   }
+
                    containers=\$(docker ps --format "{{ .Names }}")
 
                    for i in \$containers; do
                        if [[ \$i == *"rs10"* ]]; then
                            docker exec rs101 percona-release enable pmm3-client $CLIENT_REPOSITORY
-                           docker exec rs101 dnf install -y pmm-client
+                           install_client rs101 dnf
                            docker exec rs101 systemctl restart pmm-agent
                        elif [[ \$i == *"mysql_"* ]]; then
                            docker exec \$i percona-release enable pmm3-client $CLIENT_REPOSITORY
-                           docker exec \$i apt install -y pmm-client
+                           install_client \$i apt
                            mysql_process_id=\$(docker exec \$i ps aux | grep pmm-agent | awk -F " " '{print \$2}')
                            docker exec \$i kill \$mysql_process_id
                            docker exec -d \$i pmm-agent --config-file=/usr/local/percona/pmm/config/pmm-agent.yaml
                        elif [[ \$i == *"pdpgsql"* ]]; then
                            docker exec \$i percona-release enable pmm3-client $CLIENT_REPOSITORY
-                           docker exec \$i apt install -y pmm-client
+                           install_client \$i apt
                            pdpgsql_process_id=\$(docker exec \$i ps aux | grep pmm-agent | awk -F " " '{print \$2}')
                            docker exec \$i kill \$pdpgsql_process_id
                            docker exec -d \$i pmm-agent --config-file=/usr/local/percona/pmm/config/pmm-agent.yaml
                        elif [[ \$i == *"pgsql"* ]]; then
                            docker exec \$i percona-release enable pmm3-client $CLIENT_REPOSITORY
-                           docker exec \$i apt install -y pmm-client
+                           install_client \$i apt
                            pgsql_process_id=\$(docker exec \$i ps aux | grep pmm-agent | awk -F " " '{print \$2}')
                            docker exec \$i kill \$pgsql_process_id
                            docker exec -d \$i pmm-agent --config-file=/usr/local/percona/pmm/config/pmm-agent.yaml
                        elif [[ \$i == *"ps_"* ]]; then
                            docker exec \$i percona-release enable pmm3-client $CLIENT_REPOSITORY
-                           docker exec \$i apt install -y pmm-client
+                           install_client \$i apt
                            ps_process_id=\$(docker exec \$i ps aux | grep pmm-agent | awk -F " " '{print \$2}')
                            docker exec \$i kill \$ps_process_id
                            docker exec -d \$i pmm-agent --config-file=/usr/local/percona/pmm/config/pmm-agent.yaml
                        elif [[ \$i == *"external_pmm"* ]]; then
                            docker exec \$i percona-release enable pmm3-client $CLIENT_REPOSITORY
-                           docker exec \$i apt install -y pmm-client
+                           install_client \$i apt
                            ps_process_id=\$(docker exec \$i ps aux | grep pmm-agent | awk -F " " '{print \$2}')
                            docker exec \$i kill \$ps_process_id
                            docker exec -d \$i pmm-agent --config-file=/usr/local/percona/pmm/config/pmm-agent.yaml


### PR DESCRIPTION
Targets `PMM-7-fix-ami-upgrade` because that is the branch the `pmm3-upgrade-ami-test-runner` job's SCM points at — a change on `master` would not run.

Four of the five `upgrade / ami` lanes in `pmm3-nightly-orchestrator` #6 went red, for two causes, neither of them the upgrade under test.

## Three lanes hit the 60-minute timeout

`#1021` (3.7.1), `#1023` (3.8.1) and `#1025` (3.9.1) all ended with `Timeout has been exceeded` → `ABORTED` at ~18:03, about 62 minutes after they started. Where the time went, `#1021` against `#1022` (3.8.0, which passed in 41 minutes on the same dispatch):

| stage | #1021 (aborted) | #1022 (passed) |
|---|---|---|
| Start AMI server Instance | 11m34s | 7m19s |
| Setup Databases for PMM-Server | **31m48s** | 14m04s |
| Install dependencies | 5m35s | 1m00s |
| reached `Upgrade PMM client` at | 60m | 28m |

Same job, same images, same minute — the difference is contention: this dispatch ran the five AMI lanes alongside 18 docker upgrade lanes and 16 package lanes, and the AMI instance's image pulls and package installs slowed by 2–5×. `#1021` was aborted inside `Upgrade PMM client`, after the server upgrade had already passed. `pmm3-upgrade-test-runner` allows 90 minutes for the same work; this brings the AMI runner in line.

The old `pmm3-upgrade-ami-test` wrapper hid this with `retry(2)`, which #4433 deliberately did not carry over: a second 60-minute attempt on a lane that needed 62 is the wrong lever.

## One lane hit a half-written package on the mirror

`#1024` (3.9.0) failed `Upgrade PMM client` with `exit code 100`:

```
E: Failed to fetch http://repo.percona.com/pmm3-client/apt/pool/experimental/p/pmm-client/pmm-client_3.10.0-1.noble_amd64.deb
   File has unexpected size (180401138 != 180401210). Mirror sync in progress?
```

The same failure mode percona/pmm-qa#1373 handled in the package playbooks, in the one place that installs the client outside them: the runner's own `docker exec <container> apt install -y pmm-client` / `dnf install -y pmm-client`, which had no retry. Each install now goes through `install_client`, five attempts a minute apart, re-running `percona-release enable` before each retry so the index is refreshed along with the pool. Under the step's `sh -xe` a final failure still aborts the stage as before.

## Verification

- Brace/paren balance unchanged; the six `docker exec … install -y pmm-client` lines are replaced one-for-one, and the surrounding `percona-release enable` / agent-restart lines are untouched.
- Groovy string escaping follows the existing lines in this `sh '''…'''` block: `\$1`, `\$2`, `\$attempt` for shell variables, `$CLIENT_REPOSITORY` left to the shell environment like the neighbouring `$CLIENT_REPOSITORY` uses.
- Not exercised: this runner only runs from Jenkins, on an AMI instance. The next orchestrator dispatch is the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAA4rTkQmjq8kkYvn2TWeh

---
_Generated by [Claude Code](https://claude.ai/code/session_01JAA4rTkQmjq8kkYvn2TWeh)_