### PR TITLE
Fix build pipeline selection for pxb-new-ps-* jobs

### DIFF
--- a/pxb/jenkins/pxb-new-ps-inc-backup-load.groovy
+++ b/pxb/jenkins/pxb-new-ps-inc-backup-load.groovy
@@ -139,7 +139,7 @@ pipeline {
     string(
       name: 'PXB_BUILD_DOCKER_OS_RHEL',
       defaultValue: 'oraclelinux:9',
-      description: 'DOCKER_OS used to build the PXB binary for the RedHat-family test host (oracle-9). Must be a valid DOCKER_OS choice of the target compile pipeline. Valid 8.0 choices: centos:8, oraclelinux:9, ubuntu:focal, ubuntu:jammy, ubuntu:noble, debian:bullseye, debian:bookworm. Valid 9.x choices: oraclelinux:9, ubuntu:jammy, ubuntu:noble, debian:bookworm, debian:trixie.'
+      description: 'DOCKER_OS used to build the PXB binary for the RedHat-family test host (oracle-9). Must be a valid DOCKER_OS choice of the target compile pipeline. Valid 8.x choices: centos:8, oraclelinux:9, ubuntu:focal, ubuntu:jammy, ubuntu:noble, debian:bullseye, debian:bookworm. Valid 9.x choices: oraclelinux:9, ubuntu:jammy, ubuntu:noble, debian:bookworm, debian:trixie.'
     )
     string(
       name: 'PXB_BUILD_DOCKER_OS_DEB',
@@ -201,8 +201,19 @@ pipeline {
       }
       steps {
         script {
-          def pxbMajor = params.PXB_VERSION.tokenize('.')[0]
-          def compileJob = (pxbMajor == '9') ? 'percona-xtrabackup-9.x-compile-pipeline' : 'percona-xtrabackup-8.0-compile-pipeline'
+          // PXB_VERSION also drives the compile-pipeline choice: 8.0 has its own pipeline,
+          // the 8.1 pipeline owns the whole post-8.0 line (8.1, 8.4, ...), 9.x its own.
+          def pxbVer = params.PXB_VERSION.tokenize('-')[0].tokenize('.')
+          def pxbMajor = pxbVer[0].toInteger()
+          def pxbMinor = (pxbVer.size() > 1 ? pxbVer[1] : '0').toInteger()
+          def compileJob
+          if (pxbMajor >= 9) {
+            compileJob = 'percona-xtrabackup-9.x-compile-pipeline'
+          } else if (pxbMajor == 8 && pxbMinor > 0) {
+            compileJob = 'percona-xtrabackup-8.1-compile-pipeline'
+          } else {
+            compileJob = 'percona-xtrabackup-8.0-compile-pipeline'
+          }
 
           // Build one PXB binary on the given DOCKER_OS via the compile pipeline and
           // resolve the public S3 URL of the resulting tarball.

--- a/pxb/jenkins/pxb-new-ps-innodb-rocksdb.groovy
+++ b/pxb/jenkins/pxb-new-ps-innodb-rocksdb.groovy
@@ -139,7 +139,7 @@ pipeline {
     string(
       name: 'PXB_BUILD_DOCKER_OS_RHEL',
       defaultValue: 'oraclelinux:9',
-      description: 'DOCKER_OS used to build the PXB binary for the RedHat-family test host (oracle-9). Must be a valid DOCKER_OS choice of the target compile pipeline. Valid 8.0 choices: centos:8, oraclelinux:9, ubuntu:focal, ubuntu:jammy, ubuntu:noble, debian:bullseye, debian:bookworm. Valid 9.x choices: oraclelinux:9, ubuntu:jammy, ubuntu:noble, debian:bookworm, debian:trixie.'
+      description: 'DOCKER_OS used to build the PXB binary for the RedHat-family test host (oracle-9). Must be a valid DOCKER_OS choice of the target compile pipeline. Valid 8.x choices: centos:8, oraclelinux:9, ubuntu:focal, ubuntu:jammy, ubuntu:noble, debian:bullseye, debian:bookworm. Valid 9.x choices: oraclelinux:9, ubuntu:jammy, ubuntu:noble, debian:bookworm, debian:trixie.'
     )
     string(
       name: 'PXB_BUILD_DOCKER_OS_DEB',
@@ -203,8 +203,19 @@ pipeline {
       }
       steps {
         script {
-          def pxbMajor = params.PXB_VERSION.tokenize('.')[0]
-          def compileJob = (pxbMajor == '9') ? 'percona-xtrabackup-9.x-compile-pipeline' : 'percona-xtrabackup-8.0-compile-pipeline'
+          // PXB_VERSION also drives the compile-pipeline choice: 8.0 has its own pipeline,
+          // the 8.1 pipeline owns the whole post-8.0 line (8.1, 8.4, ...), 9.x its own.
+          def pxbVer = params.PXB_VERSION.tokenize('-')[0].tokenize('.')
+          def pxbMajor = pxbVer[0].toInteger()
+          def pxbMinor = (pxbVer.size() > 1 ? pxbVer[1] : '0').toInteger()
+          def compileJob
+          if (pxbMajor >= 9) {
+            compileJob = 'percona-xtrabackup-9.x-compile-pipeline'
+          } else if (pxbMajor == 8 && pxbMinor > 0) {
+            compileJob = 'percona-xtrabackup-8.1-compile-pipeline'
+          } else {
+            compileJob = 'percona-xtrabackup-8.0-compile-pipeline'
+          }
 
           // Build one PXB binary on the given DOCKER_OS via the compile pipeline and
           // resolve the public S3 URL of the resulting tarball.

--- a/pxb/jenkins/pxb-new-ps-replication.groovy
+++ b/pxb/jenkins/pxb-new-ps-replication.groovy
@@ -139,7 +139,7 @@ pipeline {
     string(
       name: 'PXB_BUILD_DOCKER_OS_RHEL',
       defaultValue: 'oraclelinux:9',
-      description: 'DOCKER_OS used to build the PXB binary for the RedHat-family test host (oracle-9). Must be a valid DOCKER_OS choice of the target compile pipeline. Valid 8.0 choices: centos:8, oraclelinux:9, ubuntu:focal, ubuntu:jammy, ubuntu:noble, debian:bullseye, debian:bookworm. Valid 9.x choices: oraclelinux:9, ubuntu:jammy, ubuntu:noble, debian:bookworm, debian:trixie.'
+      description: 'DOCKER_OS used to build the PXB binary for the RedHat-family test host (oracle-9). Must be a valid DOCKER_OS choice of the target compile pipeline. Valid 8.x choices: centos:8, oraclelinux:9, ubuntu:focal, ubuntu:jammy, ubuntu:noble, debian:bullseye, debian:bookworm. Valid 9.x choices: oraclelinux:9, ubuntu:jammy, ubuntu:noble, debian:bookworm, debian:trixie.'
     )
     string(
       name: 'PXB_BUILD_DOCKER_OS_DEB',
@@ -201,8 +201,19 @@ pipeline {
       }
       steps {
         script {
-          def pxbMajor = params.PXB_VERSION.tokenize('.')[0]
-          def compileJob = (pxbMajor == '9') ? 'percona-xtrabackup-9.x-compile-pipeline' : 'percona-xtrabackup-8.0-compile-pipeline'
+          // PXB_VERSION also drives the compile-pipeline choice: 8.0 has its own pipeline,
+          // the 8.1 pipeline owns the whole post-8.0 line (8.1, 8.4, ...), 9.x its own.
+          def pxbVer = params.PXB_VERSION.tokenize('-')[0].tokenize('.')
+          def pxbMajor = pxbVer[0].toInteger()
+          def pxbMinor = (pxbVer.size() > 1 ? pxbVer[1] : '0').toInteger()
+          def compileJob
+          if (pxbMajor >= 9) {
+            compileJob = 'percona-xtrabackup-9.x-compile-pipeline'
+          } else if (pxbMajor == 8 && pxbMinor > 0) {
+            compileJob = 'percona-xtrabackup-8.1-compile-pipeline'
+          } else {
+            compileJob = 'percona-xtrabackup-8.0-compile-pipeline'
+          }
 
           // Build one PXB binary on the given DOCKER_OS via the compile pipeline and
           // resolve the public S3 URL of the resulting tarball.

--- a/pxb/jenkins/pxb-new-ps-upgrade.groovy
+++ b/pxb/jenkins/pxb-new-ps-upgrade.groovy
@@ -145,7 +145,7 @@ pipeline {
     string(
       name: 'PXB_BUILD_DOCKER_OS_RHEL',
       defaultValue: 'oraclelinux:9',
-      description: 'DOCKER_OS used to build the NEW PXB binary for the RedHat-family test host (oracle-9). Must be a valid DOCKER_OS choice of the target compile pipeline. Valid 8.0 choices: centos:8, oraclelinux:9, ubuntu:focal, ubuntu:jammy, ubuntu:noble, debian:bullseye, debian:bookworm. Valid 9.x choices: oraclelinux:9, ubuntu:jammy, ubuntu:noble, debian:bookworm, debian:trixie.'
+      description: 'DOCKER_OS used to build the NEW PXB binary for the RedHat-family test host (oracle-9). Must be a valid DOCKER_OS choice of the target compile pipeline. Valid 8.x choices: centos:8, oraclelinux:9, ubuntu:focal, ubuntu:jammy, ubuntu:noble, debian:bullseye, debian:bookworm. Valid 9.x choices: oraclelinux:9, ubuntu:jammy, ubuntu:noble, debian:bookworm, debian:trixie.'
     )
     string(
       name: 'PXB_BUILD_DOCKER_OS_DEB',
@@ -207,8 +207,19 @@ pipeline {
       }
       steps {
         script {
-          def pxbMajor = params.PXB_VERSION.tokenize('.')[0]
-          def compileJob = (pxbMajor == '9') ? 'percona-xtrabackup-9.x-compile-pipeline' : 'percona-xtrabackup-8.0-compile-pipeline'
+          // PXB_VERSION also drives the compile-pipeline choice: 8.0 has its own pipeline,
+          // the 8.1 pipeline owns the whole post-8.0 line (8.1, 8.4, ...), 9.x its own.
+          def pxbVer = params.PXB_VERSION.tokenize('-')[0].tokenize('.')
+          def pxbMajor = pxbVer[0].toInteger()
+          def pxbMinor = (pxbVer.size() > 1 ? pxbVer[1] : '0').toInteger()
+          def compileJob
+          if (pxbMajor >= 9) {
+            compileJob = 'percona-xtrabackup-9.x-compile-pipeline'
+          } else if (pxbMajor == 8 && pxbMinor > 0) {
+            compileJob = 'percona-xtrabackup-8.1-compile-pipeline'
+          } else {
+            compileJob = 'percona-xtrabackup-8.0-compile-pipeline'
+          }
 
           // Build one NEW PXB binary on the given DOCKER_OS via the compile pipeline and
           // resolve the public S3 URL of the resulting tarball. OLD_PXB_VERSION is always


### PR DESCRIPTION
When PXB is built from branch if 8.4 was selected it was using 8.0-compile-pipeline job instead of 8.1-compile-pipeline.