### PR TITLE
PMM-15197 Fill mirrored stages and drop the run header node

### DIFF
--- a/pmm/v3/pmm3-nightly-orchestrator.groovy
+++ b/pmm/v3/pmm3-nightly-orchestrator.groovy
@@ -64,6 +64,36 @@ def humanMs(def millis) {
     return "${s}s"
 }
 
+def nodeName(String name) {
+    // The parallel branch label wraps and crops, so the node leads with what tells
+    // the lanes of a family apart and keeps the family as a suffix or qualifier.
+    int cut = name.lastIndexOf(' / ')
+    if (cut < 0) {
+        return "${name} standalone"
+    }
+    def family = name.substring(0, cut)
+    def leaf = name.substring(cut + 3)
+    if (family == 'nightly') {
+        return "${leaf} nightly"
+    }
+    if (family == 'compat') {
+        return "compat nightly ${leaf.replace('client ', '')}"
+    }
+    if (family == 'ui') {
+        return "ui-tests ${leaf}"
+    }
+    if (family == 'pkg amd64') {
+        return "package (amd) ${leaf}"
+    }
+    if (family == 'pkg arm64') {
+        return "package (arm) ${leaf}"
+    }
+    if (family == 'upgrade') {
+        return leaf.startsWith('ami ') ? "upgrade (ami) ${leaf.replace('ami ', '')}" : "upgrade ${leaf}"
+    }
+    return "${leaf} ${family}"
+}
+
 def mirrorChild(String name, String jobName, def run) {
     def stages = []
     try {
@@ -119,11 +149,9 @@ def mirrorChild(String name, String jobName, def run) {
 
 def suite(String name, String jobName, List jobParams) {
     return {
-        // The row label wraps and crops, so the first node leads with the part
-        // that tells the lanes of a family apart. The stage name is fixed before
-        // the child starts, so the run number can only go in the node's log.
-        def cut = name.lastIndexOf(' / ')
-        stage(cut > 0 ? name.substring(cut + 3) : name) {
+        // The stage name is fixed before the child starts, so the run number
+        // can only go in the node's log.
+        stage(nodeName(name)) {
             def run = build job: jobName, parameters: jobParams, wait: true, propagate: false
             results[name] = [job: jobName, number: run.number, url: run.absoluteUrl, result: run.result]
             echo "[${name}] ${jobName} #${run.number} ${run.result} -> ${run.absoluteUrl}"
@@ -334,7 +362,7 @@ timestamps {
 
     amiUpgradeBranches(branches, serverImage, latestDevVersion)
 
-    branches['gssapi'] = suite('gssapi', 'pmm3-ui-tests-nightly-gssapi', [
+    branches['nightly / gssapi'] = suite('nightly / gssapi', 'pmm3-ui-tests-nightly-gssapi', [
         string(name: 'PMM_QA_GIT_BRANCH', value: params.PMM_QA_GIT_BRANCH),
         string(name: 'SERVER_TYPE',       value: 'docker'),
         string(name: 'DOCKER_VERSION',    value: serverImage),

--- a/pmm/v3/pmm3-nightly-orchestrator.groovy
+++ b/pmm/v3/pmm3-nightly-orchestrator.groovy
@@ -72,20 +72,31 @@ def mirrorChild(String name, String jobName, def run) {
         echo "[${name}] child stages unavailable (${err.message}); rendering the suite as one stage"
     }
 
-    stage("#${run.number} ${jobName}") {
-        echo "${run.absoluteUrl}"
-    }
+    def blue = "${env.JENKINS_URL}blue/organizations/jenkins/${jobName}/detail/${jobName}/${run.number}/pipeline"
 
-    int lastRun = -1
-    for (int i = 0; i < stages.size(); i++) {
-        if (stages[i].status != 'NOT_EXECUTED') {
-            lastRun = i
-        }
-    }
-
-    for (int i = 0; i <= lastRun; i++) {
+    int i = 0
+    while (i < stages.size()) {
         def child = stages[i]
+        if (child.status == 'NOT_EXECUTED') {
+            // A declarative child still runs its post actions after a failure, so
+            // never-run stages can sit in the middle; each run of them is one node.
+            int j = i
+            while (j < stages.size() && stages[j].status == 'NOT_EXECUTED') {
+                j++
+            }
+            def names = stages[i..<j].collect { it.name }
+            stage(names.size() == 1 ? names[0] : "${names.size()} stages skipped") {
+                catchError(buildResult: null, stageResult: 'NOT_BUILT') {
+                    error("never ran in ${jobName} #${run.number}: ${names.join(', ')}")
+                }
+            }
+            i = j
+            continue
+        }
         stage("${child.name} · ${humanMs(child.durationMillis)}") {
+            // Blue Ocean draws a stage with no steps as never run (hollow), whatever
+            // its status, so every mirrored stage carries at least this echo.
+            echo "${child.name}: ${child.status} in ${humanMs(child.durationMillis)} — ${blue}/${child.id}"
             // buildResult stays null on purpose: the suite's own verdict above
             // owns the build result, and a mirrored step must not raise it.
             if (child.status == 'FAILED') {
@@ -102,24 +113,18 @@ def mirrorChild(String name, String jobName, def run) {
                 }
             }
         }
-    }
-
-    int skipped = stages.size() - 1 - lastRun
-    if (skipped > 0) {
-        stage("${skipped} stages skipped") {
-            catchError(buildResult: null, stageResult: 'NOT_BUILT') {
-                error("${skipped} stages never ran: ${jobName} #${run.number} stopped at '${stages[lastRun].name}'")
-            }
-        }
+        i++
     }
 }
 
 def suite(String name, String jobName, List jobParams) {
     return {
-        stage(name) {
+        // The branch name is already the row label in Blue Ocean, so the first
+        // node names the job instead of repeating it.
+        stage(jobName) {
             def run = build job: jobName, parameters: jobParams, wait: true, propagate: false
             results[name] = [job: jobName, number: run.number, url: run.absoluteUrl, result: run.result]
-            echo "[${name}] ${run.result} -> ${run.absoluteUrl}"
+            echo "[${name}] ${jobName} #${run.number} ${run.result} -> ${run.absoluteUrl}"
 
             if (run.result == 'FAILURE' || run.result == 'ABORTED') {
                 catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {

--- a/pmm/v3/pmm3-nightly-orchestrator.groovy
+++ b/pmm/v3/pmm3-nightly-orchestrator.groovy
@@ -119,9 +119,11 @@ def mirrorChild(String name, String jobName, def run) {
 
 def suite(String name, String jobName, List jobParams) {
     return {
-        // The branch name is already the row label in Blue Ocean, so the first
-        // node names the job instead of repeating it.
-        stage(jobName) {
+        // The row label wraps and crops, so the first node leads with the part
+        // that tells the lanes of a family apart. The stage name is fixed before
+        // the child starts, so the run number can only go in the node's log.
+        def cut = name.lastIndexOf(' / ')
+        stage(cut > 0 ? name.substring(cut + 3) : name) {
             def run = build job: jobName, parameters: jobParams, wait: true, propagate: false
             results[name] = [job: jobName, number: run.number, url: run.absoluteUrl, result: run.result]
             echo "[${name}] ${jobName} #${run.number} ${run.result} -> ${run.absoluteUrl}"

--- a/vars/childStages.groovy
+++ b/vars/childStages.groovy
@@ -3,7 +3,8 @@ import com.cloudbees.workflow.rest.external.StageNodeExt
 
 import org.jenkinsci.plugins.workflow.job.WorkflowRun
 
-// Returns a list of [name, status, durationMillis]. Status is StatusExt: SUCCESS,
+// Returns a list of [id, name, status, durationMillis]. id is the stage's flow node
+// id, which Blue Ocean uses in .../pipeline/<id>. Status is StatusExt: SUCCESS,
 // FAILED, UNSTABLE, ABORTED, NOT_EXECUTED, IN_PROGRESS or PAUSED_PENDING_INPUT.
 // A freestyle or otherwise non-Pipeline child has no stages and yields [].
 @NonCPS
@@ -14,6 +15,7 @@ def call(run) {
     }
     return RunExt.create(build).stages.collect { StageNodeExt stage ->
         [
+            id            : stage.id,
             name          : stage.name,
             status        : stage.status.toString(),
             durationMillis: stage.durationMillis,


### PR DESCRIPTION
## What

Follow-up to #4437, from the first orchestrator run with the `childStages` signatures approved (run #8).

**Hollow nodes.** Blue Ocean draws a stage with no steps as never run (`PipelineNodeGraphVisitor`: `firstExecuted == null` → `NOT_EXECUTED`), regardless of the status the stage view reports. Every mirrored child stage that *succeeded* had an empty body and rendered hollow, while failed ones carry a `catchError` step and rendered red. Each mirrored stage now echoes `name: STATUS in duration — <Blue Ocean deep link into the child run>`, so it is solid, and clicking it tells you what happened and where.

**The extra `#N job` node** between the suite node and its mirrored stages is gone. Its only job was to hold the child run's URL, which now lives in the first node's log.

**Every node name is self-contained.** The parallel branch label wraps and crops, so `upgrade / ami 3.9.0` lost the version that tells the lane apart, and the job name is identical on every lane of a family. Each node now leads with the distinguishing part and keeps the family as a suffix or qualifier:

| Branch | Node |
|---|---|
| `nightly / docker arm64` | `docker arm64 nightly` |
| `nightly / gssapi` | `gssapi nightly` |
| `compat / client 3.9.1` | `compat nightly 3.9.1` |
| `upgrade / 3.9.1 EXTERNAL SERVICES` | `upgrade 3.9.1 EXTERNAL SERVICES` |
| `upgrade / ami 3.9.0` | `upgrade (ami) 3.9.0` |
| `pkg amd64 / upgrade custom path` | `package (amd) upgrade custom path` |
| `pkg arm64 / custom path (GA 3.9.1)` | `package (arm) custom path (GA 3.9.1)` |
| `ui / @instances` | `ui-tests @instances` |
| `openshift` | `openshift standalone` |

gssapi moves from a bare branch name into the nightly family, which is what it is; it now groups under nightly in the report too. The run number can't go in a stage name — it is fixed before the child starts — so it stays in that node's now-readable log.

**Never-run stages in the middle.** A declarative child still runs `Declarative: Post Actions` after a failure, so the tail-only "N stages skipped" node never appeared and the skipped stages were mirrored as (hollow, now green) nodes. Every run of `NOT_EXECUTED` stages is collapsed into one `NOT_BUILT` node wherever it sits.

`childStages` now also returns the stage's flow node id for the deep link.

## ⚠️ One more Script Console approval before merge

The deep link needs `FlowNodeExt.getId`, which the sandbox rejects until approved. Without it the library throws and every lane falls back to a single node, as before #4437.

```groovy
org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval.get()
    .approveSignature('method com.cloudbees.workflow.rest.external.FlowNodeExt getId')
```

## Verification

Local Groovy harness stubbing `stage`/`echo`/`catchError`/`build`/`childStages`, run over the `suite()` closure and `nodeName()` from this file:

- child SUCCESS, all stages ran → lane node + one solid node per stage, each with the echo and `.../pipeline/<id>` link;
- child FAILURE at `Setup Databases` with never-run stages before `Declarative: Post Actions` → red lane node, green `Prepare`, red `Setup Databases`, one `NOT_BUILT` node, green post actions;
- child ABORTED → aborted stage node, single skipped stage rendered under its own name;
- library unavailable → lane node only, as before;
- `nodeName` over all 21 branch names the job builds → the table above, no collisions.

Not exercised on Jenkins: the branch is not the one the job's SCM config points at (`*/master`), so the next scheduled run after merge is the live check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAA4rTkQmjq8kkYvn2TWeh