### PR TITLE
PKG-1459: Keep boot entries on Oracle Linux package-test AMIs

### DIFF
--- a/ppg/packer/scripts/provision.sh
+++ b/ppg/packer/scripts/provision.sh
@@ -22,10 +22,15 @@ fi
 rm -f /boot/vmlinuz-0-rescue-* /boot/initramfs-0-rescue-* /boot/.vmlinuz-0-rescue-*.hmac
 rm -f /boot/loader/entries/*-0-rescue*.conf
 
+# An entry's "linux" path is relative to the filesystem that holds /boot: a
+# separate /boot partition gives "/vmlinuz-<ver>", /boot on the root filesystem
+# (the Oracle Linux cloud images) gives "/boot/vmlinuz-<ver>". Check both forms,
+# or every entry on a root-filesystem /boot image is deleted and the image only
+# boots again if this same bake happens to install a new kernel.
 for entry in /boot/loader/entries/*.conf; do
   [[ -e "${entry}" ]] || continue
   image="$(sed -n 's/^linux //p' "${entry}")"
-  if [[ -n "${image}" && ! -e "/boot${image}" ]]; then
+  if [[ -n "${image}" && ! -e "/boot${image}" && ! -e "${image}" ]]; then
     rm -f "${entry}"
   fi
 done


### PR DESCRIPTION
**Bug**
- Since 2026-08-13 the factory's rescue cleanup pruned every boot loader entry whose kernel path was not found under `/boot`. Oracle Linux cloud images keep `/boot` on the root filesystem and write entries as `/boot/vmlinuz-<ver>`, so the check looked in `/boot/boot/` and deleted all of them. The candidate then stops at the GRUB menu with no OS entry and the smoke boot fails.
- A lane only passed when the same bake installed a new kernel, which writes a fresh entry afterwards. On 09-09 OL8, OL10 and Rocky 9 arm64 passed that way, OL9 arm64 got only userland updates and failed, and failed again on 09-11.

**Fix**
- Resolve the entry path for both layouts (`/boot<path>` for a separate partition, `<path>` for a root-filesystem `/boot`) before treating an entry as stale.
- Verified with a fake tree in both layouts and on the live OL9 and OL8 arm64 factory images, where the old check flagged every entry for deletion and the new one keeps them.

**Tickets**
- [PKG-1459](https://perconadev.atlassian.net/browse/PKG-1459) (this), [PKG-1444](https://perconadev.atlassian.net/browse/PKG-1444) (origin of the cleanup), [PS-11259](https://perconadev.atlassian.net/browse/PS-11259) (the arm64 lanes this unblocks).

[PKG-1459]: https://perconadev.atlassian.net/browse/PKG-1459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-1444]: https://perconadev.atlassian.net/browse/PKG-1444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ