### PR TITLE
PKG-1447: Dated weekly AMI pin PRs and a daily pin staleness check

### DIFF
--- a/.github/workflows/ppg-ami-factory.yml
+++ b/.github/workflows/ppg-ami-factory.yml
@@ -3,7 +3,9 @@
 # Manager (no inbound SSH), authenticated via GitHub OIDC (no static keys), and
 # promotes each via a fresh-boot smoke test. Consumer: pg.cd molecule jobs use
 # the static AMI pins in vars/moleculeEnvPPG.groovy, refreshed weekly by the
-# update-molecule-env job through an auto-opened PR.
+# update-molecule-env job through a dated PR (one new PR per refresh, the
+# previous one closed as superseded). ppg-ami-pins-check.yml goes red when
+# master's pins lag the newest promoted AMIs.
 # Rocky lineage roots are seeded once per combo via dispatch (just ci-seed-rocky).
 #
 # Triggers: PR validate-only (pull_request -> check job, no AWS), recipe change
@@ -184,11 +186,18 @@ jobs:
   update-molecule-env:
     name: Update moleculeEnvPPG.groovy (OL/Rocky AMI IDs)
     needs: bake
-    # Weekly runs only, never manual/PR/push, where a partial or test-env combo
-    # list must not drive the pins. !cancelled() rather than success(): a partial
-    # bake still refreshes the pins, because the script resolves from the promote
-    # tags, so a failed combo simply keeps last week's AMI while the rest advance.
-    if: github.event_name == 'schedule' && !cancelled() && needs.bake.result != 'skipped'
+    # Every prod bake from master publishes: the weekly schedule, a recipe push
+    # (its bake promotes 12 new AMIs, and an unpublished promote would start the
+    # daily staleness clock with no PR to merge), and a manual prod dispatch so
+    # a failed Monday can be repaired the same day. The resolver reads the
+    # promote tags of every combo, never this run's matrix, and test bakes
+    # promote to a different role tag, so a partial or test-env combo list
+    # cannot drive the pins. !cancelled() rather than success(): a partial bake
+    # still refreshes the pins, a failed combo keeps last week's AMI.
+    if: >-
+      (github.event_name == 'schedule' || github.event_name == 'push' ||
+       (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master' && (inputs.env || 'prod') == 'prod'))
+      && !cancelled() && needs.bake.result != 'skipped'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -215,39 +224,82 @@ jobs:
 
       - name: Commit and open a PR if changed
         # master rejects direct pushes (protected branch, changes must go through
-        # a pull request), so the refresh is published as a PR on one fixed rolling
-        # branch. Force-push keeps that branch current; an already-open PR is
-        # reused. Needs pull-requests: write plus the repo setting "Allow GitHub
-        # Actions to create and approve pull requests".
+        # a pull request), so the refresh is published as a PR from a branch
+        # named after the run date. A new branch and PR every refresh keeps it
+        # visible: the PR date is the refresh date, CODEOWNERS requests the
+        # reviewers on creation, and every earlier refresh PR is closed as
+        # superseded, also when this run has nothing new to publish (a stale
+        # open refresh PR would otherwise pin an image the prune may remove). A
+        # same-day re-run reuses that day's PR. Needs pull-requests: write plus
+        # the repo setting "Allow GitHub Actions to create and approve pull
+        # requests".
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          same_repo='select(.head.repo.owner.login == "'"${GITHUB_REPOSITORY_OWNER}"'")'
+          refresh_head='select(.head.ref | test("^ppg-ami-refresh(-[0-9]{8})?$"))'
+          # All open same-repo refresh PRs, paginated so none hides behind newer PRs.
+          open_refresh_prs=$(gh api --paginate "repos/${GITHUB_REPOSITORY}/pulls?state=open&base=master&per_page=100" \
+            --jq ".[] | ${same_repo} | ${refresh_head} | .number")
+          pr_number=""
           if git diff --quiet -- vars/moleculeEnvPPG.groovy; then
-            echo "no AMI ID changes; nothing to commit"
-            exit 0
-          fi
-          branch=ppg-ami-refresh
-          git config user.name "ppg-ami-factory-bot"
-          git config user.email "actions@github.com"
-          git checkout -B "$branch"
-          git add vars/moleculeEnvPPG.groovy
-          git commit -m "Auto-update OL/Rocky molecule AMI IDs (weekly ppg-ami-factory refresh)"
-          # The rolling branch is bot-owned and rebuilt from master every week;
-          # manual commits on it do not survive the next refresh.
-          git push --force origin "HEAD:$branch"
-          # Count only same-repo PRs: an unqualified --head also matches a fork
-          # PR whose head branch happens to share the name, which would skip
-          # creation here and silently leave the refresh unpublished.
-          open_prs=$(gh pr list --head "$branch" --base master --state open \
-            --json number,headRepositoryOwner \
-            --jq '[.[] | select(.headRepositoryOwner.login == "'"${GITHUB_REPOSITORY_OWNER}"'")] | length')
-          if [ "$open_prs" = "0" ]; then
-            gh pr create --head "$branch" --base master \
-              --title "Auto-update OL/Rocky molecule AMI IDs (weekly refresh)" \
-              --body "Weekly ppg-ami-factory refresh: OL/Rocky pins in vars/moleculeEnvPPG.groovy updated to the newest promoted AMIs (tag role=ppg-package-test). Opened automatically by the update-molecule-env job."
+            echo "no AMI ID changes; nothing to publish"
           else
-            echo "open PR for $branch already exists; branch force-updated"
+            refresh_date=$(date -u +%Y-%m-%d)
+            branch="ppg-ami-refresh-${refresh_date//-/}"
+            git config user.name "ppg-ami-factory-bot"
+            git config user.email "actions@github.com"
+            git checkout -B "$branch"
+            git add vars/moleculeEnvPPG.groovy
+            git commit -m "Auto-update OL/Rocky molecule AMI IDs (ppg-ami-factory refresh ${refresh_date})"
+            # Force only matters for a same-day re-run: the branch is bot-owned and
+            # rebuilt from master, manual commits on it do not survive.
+            git push --force origin "HEAD:$branch"
+            pr_number=$(gh api --paginate "repos/${GITHUB_REPOSITORY}/pulls?state=open&base=master&head=${GITHUB_REPOSITORY_OWNER}:${branch}&per_page=100" \
+              --jq ".[] | ${same_repo} | .number" | head -n 1)
+            if [ -z "$pr_number" ]; then
+              # A failed create must not leave an orphan branch behind: the next
+              # run publishes from a new dated branch and only closes PRs.
+              if ! pr_url=$(gh pr create --head "$branch" --base master \
+                --title "Auto-update OL/Rocky molecule AMI IDs (${refresh_date})" \
+                --body "ppg-ami-factory refresh of ${refresh_date}: OL/Rocky pins in vars/moleculeEnvPPG.groovy updated to the newest promoted AMIs (tag role=ppg-package-test). Opened automatically by the update-molecule-env job. The branch is bot-owned: do not merge master into it, merge or close only."); then
+                echo "FAIL: could not open the refresh PR, deleting branch $branch"
+                git push origin --delete "$branch"
+                exit 1
+              fi
+              pr_number=${pr_url##*/}
+              echo "opened PR #${pr_number}"
+            else
+              echo "open PR #${pr_number} for $branch already exists; branch force-updated"
+            fi
+            # The published PR must carry the pins file, otherwise the refresh is
+            # lost silently (a merge of master into the branch did exactly that).
+            gh pr diff "$pr_number" --name-only > changed-files.txt
+            grep -Fxq 'vars/moleculeEnvPPG.groovy' changed-files.txt \
+              || { echo "FAIL: PR #${pr_number} does not change vars/moleculeEnvPPG.groovy"; exit 1; }
+          fi
+          # Close every other open refresh PR (older dated branches and the legacy
+          # rolling branch). One failed close is reported and the rest still run,
+          # the step fails at the end so a stale PR never stays open unnoticed.
+          close_failures=0
+          for old_pr in $open_refresh_prs; do
+            [ "$old_pr" = "$pr_number" ] && continue
+            if [ -n "$pr_number" ]; then
+              reason="Superseded by #${pr_number}."
+            else
+              reason="Superseded: master already carries the newest promoted AMIs."
+            fi
+            if gh pr close "$old_pr" --comment "$reason" --delete-branch; then
+              echo "closed superseded PR #${old_pr}"
+            else
+              echo "::warning::could not close superseded PR #${old_pr}"
+              close_failures=$((close_failures + 1))
+            fi
+          done
+          if [ "$close_failures" -gt 0 ]; then
+            echo "FAIL: ${close_failures} superseded refresh PR(s) could not be closed"
+            exit 1
           fi
 
   notify:
@@ -263,9 +315,15 @@ jobs:
     env:
       SLACK_WEBHOOK: ${{ secrets.RELEASES_CI_SLACK_WEBHOOK }}
     steps:
+      - name: Refuse to alert into the void
+        # On the canonical repo a missing webhook secret is itself a failure:
+        # a skipped alert hid three red weeks in a row. Forks stay quiet.
+        if: env.SLACK_WEBHOOK == '' && github.repository == 'Percona-Lab/jenkins-pipelines'
+        run: |
+          echo "::error::RELEASES_CI_SLACK_WEBHOOK is not set in this repository, the failure alert was not delivered"
+          exit 1
+
       - name: Slack on failure
-        # Skip cleanly when the webhook secret is unset (e.g. fork tests), so a real
-        # bake failure is not masked by a second "missing webhook" failure.
         if: env.SLACK_WEBHOOK != ''
         uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
         with:

--- a/.github/workflows/ppg-ami-pins-check.yml
+++ b/.github/workflows/ppg-ami-pins-check.yml
@@ -1,0 +1,85 @@
+# Daily guard for the OL/Rocky package-test AMI pins: goes red when a pin on
+# master lags the newest promoted AMI by more than the review window, so an
+# unmerged (or emptied) weekly refresh PR cannot sit unnoticed. Read-only:
+# resolves with the same script the weekly refresh uses, writes nothing.
+# Actions are pinned to commit SHAs; the trailing "# vX.Y.Z" records the tag.
+
+name: ppg-ami-pins-check
+run-name: ppg AMI pins check (${{ github.event_name }})
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 7 * * 2-6' # daily Tue-Sat 07:00 UTC, Monday is the bake + refresh day
+
+permissions:
+  contents: read
+
+env:
+  AWS_REGION: eu-central-1
+  GRACE_DAYS: '3' # review window for the weekly refresh PR before a lagging pin counts as stale
+
+jobs:
+  check-pins:
+    name: master pins vs newest promoted AMIs
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write # ONLY this job mints the OIDC token
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: master
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          role-to-assume: ${{ secrets.PPG_AMI_FACTORY_ROLE_ARN || 'arn:aws:iam::119175775298:role/percona-ci-platform-gha-ppg-ami-factory' }}
+          role-session-name: ppg-ami-pins-check-${{ github.run_id }}-${{ github.run_attempt }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Compare master pins with the newest promoted AMIs
+        run: |
+          set -euo pipefail
+          python3 -m pip install --quiet 'boto3==1.43.74' 'botocore==1.43.74'
+          python3 ppg/packer/scripts/update_molecule_env.py --check --grace-days "$GRACE_DAYS" 2>&1 | tee check.log
+
+      - name: Step summary
+        # Separate step so the verdict lands in the summary on STALE and on a
+        # check that failed before producing one.
+        if: always()
+        run: |
+          {
+            echo "### OL/Rocky pins on master"
+            echo '```'
+            if [ -s check.log ]; then
+              grep -E '^(STALE|FAIL|pins current)' check.log || echo "check produced no verdict (see the job log)"
+            else
+              echo "check did not run (see the job log)"
+            fi
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  notify:
+    needs: check-pins
+    if: failure()
+    runs-on: ubuntu-latest
+    env:
+      SLACK_WEBHOOK: ${{ secrets.RELEASES_CI_SLACK_WEBHOOK }}
+    steps:
+      - name: Refuse to alert into the void
+        # On the canonical repo a missing webhook secret is itself a failure.
+        if: env.SLACK_WEBHOOK == '' && github.repository == 'Percona-Lab/jenkins-pipelines'
+        run: |
+          echo "::error::RELEASES_CI_SLACK_WEBHOOK is not set in this repository, the stale-pins alert was not delivered"
+          exit 1
+
+      - name: Slack on stale pins
+        if: env.SLACK_WEBHOOK != ''
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        with:
+          webhook: ${{ env.SLACK_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: "PPG OL/Rocky AMI pins check FAILED (stale pins, or the check itself could not run) - ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/ppg/packer/justfile
+++ b/ppg/packer/justfile
@@ -292,38 +292,113 @@ prune-all apply="0":
     @just prune-test "{{apply}}"
     @just prune-stale "{{apply}}"
 
-# deregister SUPERSEDED prod bases: per (os_major, arch) KEEP the newest role={{role_prod}}
-# AMI (the one the consumer selects) and remove older duplicates left by refreshes
-# (deprecate_at only marks, never deletes -> inventory grows). Lists by default; pass `1`
-# to deregister. NEVER deletes the newest-per-combo, and skips any AMI missing maj/arch.
-[doc("deregister superseded prod bases, keeping newest per combo; lists unless apply=1")]
+# deregister SUPERSEDED prod bases. Per (os, os_major, arch) the floor is the pin in
+# vars/moleculeEnvPPG.groovy on origin/master: the pin and every newer AMI survive (a newer
+# image may already be named by an open refresh PR), and so does any image an open refresh
+# PR pins. Only images older than the pin go (deprecate_at only marks, never deletes, so the
+# inventory grows). Lists by default, pass `1` to deregister. Refuses unless each of the 12
+# OL/Rocky pins parses exactly once and, for apply, unless origin/master and the open refresh
+# PRs could be read, so a stale checkout can never turn into a deletion of a live image.
+[doc("deregister prod bases older than the master pin per combo, keeping newest + pinned + open-PR images; lists unless apply=1")]
 prune-superseded apply="0":
     #!/usr/bin/env bash
     set -euo pipefail
     echo "prune-superseded (apply={{apply}}; lists unless apply=1):"
+    pins_remote="${PINS_REMOTE:-origin}"
+    workdir=$(mktemp -d)
+    trap 'rm -rf "${workdir}"' EXIT
+    pins_pattern='^ *export ami_(ol|rocky)[0-9]+_(x86_64|arm64)=ami-[0-9a-f]+'
+    # Pins from the fetched master, never a stale local ref. Listing may fall back to
+    # the working tree, an apply run must not.
+    if git -C ../.. fetch -q "${pins_remote}" master && git -C ../.. show FETCH_HEAD:vars/moleculeEnvPPG.groovy > "${workdir}/pins" 2>/dev/null; then
+      echo "  pins from ${pins_remote}/master:vars/moleculeEnvPPG.groovy (fetched)"
+    elif [[ "{{apply}}" = "1" ]]; then
+      echo "refusing to prune: could not fetch ${pins_remote}/master for the current pins" >&2
+      exit 1
+    else
+      cp ../../vars/moleculeEnvPPG.groovy "${workdir}/pins"
+      echo "  pins from the working tree (${pins_remote}/master unavailable, list only)"
+    fi
+    declare -A pin_of protected
+    for var_prefix in ol rocky; do
+      os_name=oraclelinux
+      [[ "${var_prefix}" = rocky ]] && os_name=rocky
+      for os_major in 8 9 10; do
+        for arch in x86_64 arm64; do
+          mapfile -t values < <(grep -oE "^ *export ami_${var_prefix}${os_major}_${arch}=ami-[0-9a-f]+" "${workdir}/pins" | sed -E 's/.*=//')
+          if [[ "${#values[@]}" -ne 1 ]]; then
+            echo "refusing to prune: ami_${var_prefix}${os_major}_${arch} found ${#values[@]} times in the pins file, expected once" >&2
+            exit 1
+          fi
+          pin_of["${os_name}/${os_major}/${arch}"]="${values[0]}"
+          protected["${values[0]}"]="pinned on master"
+        done
+      done
+    done
+    # Images named by open refresh PRs are protected too: merging such a PR must never
+    # point pg.cd at a deregistered image.
+    repo_url=$(git -C ../.. remote get-url "${pins_remote}")
+    if open_heads=$(gh pr list -R "${repo_url}" --base master --state open --limit 500 --json headRefName,headRepositoryOwner \
+         --jq '.[] | select(.headRepositoryOwner.login == "Percona-Lab") | select(.headRefName | test("^ppg-ami-refresh(-[0-9]{8})?$")) | .headRefName'); then
+      for head in ${open_heads}; do
+        if git -C ../.. fetch -q "${pins_remote}" "${head}" && git -C ../.. show FETCH_HEAD:vars/moleculeEnvPPG.groovy > "${workdir}/pr-pins" 2>/dev/null; then
+          while read -r ami_id; do
+            [[ -z "${ami_id}" ]] && continue
+            protected["${ami_id}"]="${protected[${ami_id}]:-named by open refresh PR ${head}}"
+          done < <(grep -oE "${pins_pattern}" "${workdir}/pr-pins" | sed -E 's/.*=//')
+          echo "  protecting the pins of open refresh PR branch ${head}"
+        elif [[ "{{apply}}" = "1" ]]; then
+          echo "refusing to prune: could not read the pins of open refresh PR branch ${head}" >&2
+          exit 1
+        fi
+      done
+    elif [[ "{{apply}}" = "1" ]]; then
+      echo "refusing to prune: could not list open refresh PRs (gh)" >&2
+      exit 1
+    else
+      echo "  could not list open refresh PRs (gh), list only"
+    fi
     aws ec2 describe-images --profile {{profile}} --region {{region}} --owners self \
       --filters Name=tag:role,Values={{role_prod}} Name=tag:os,Values={{os_csv}} Name=state,Values=available \
-      --query "reverse(sort_by(Images,&CreationDate))[].[ImageId, Tags[?Key=='os']|[0].Value, Tags[?Key=='os_major']|[0].Value, Tags[?Key=='arch']|[0].Value]" --output text \
-      | { declare -A keep
-
-          while read -r ami_id os_name major arch; do
-            [[ -z "${ami_id}" ]] && continue
-            [[ "${os_name}" = None || "${major}" = None || "${arch}" = None ]] && { echo "  SKIP ${ami_id} (untagged os/major/arch)"; continue; }
-            combo_key="${os_name}/${major}/${arch}"
-
-            if [[ -z "${keep[${combo_key}]:-}" ]]; then
-              keep[${combo_key}]=${ami_id}
-              echo "  KEEP ${ami_id} (${os_name}${major} ${arch}, newest)"
-              continue
-            fi
-
-            if [[ "{{apply}}" = "1" ]]; then
-              echo "  deregister ${ami_id} (${os_name}${major} ${arch}, superseded)"
-              just _deregister "${ami_id}"
-            else
-              echo "  would deregister ${ami_id} (${os_name}${major} ${arch}, superseded)"
-            fi
-          done; }
+      --query "Images[].[CreationDate, ImageId, Tags[?Key=='os']|[0].Value, Tags[?Key=='os_major']|[0].Value, Tags[?Key=='arch']|[0].Value]" --output text \
+      | sort -r > "${workdir}/rows"
+    declare -A below_pin seen_pin
+    combo_errors=0
+    while read -r created ami_id os_name major arch; do
+      [[ -z "${ami_id}" ]] && continue
+      [[ "${os_name}" = None || "${major}" = None || "${arch}" = None ]] && { echo "  SKIP ${ami_id} (untagged os/major/arch)"; continue; }
+      combo_key="${os_name}/${major}/${arch}"
+      combo_pin="${pin_of[${combo_key}]:-}"
+      if [[ -z "${combo_pin}" ]]; then
+        echo "  SKIP ${ami_id} (${os_name}${major} ${arch}, no pin for this combo)"
+        continue
+      fi
+      if [[ -n "${protected[${ami_id}]:-}" ]]; then
+        echo "  KEEP ${ami_id} (${os_name}${major} ${arch}, ${protected[${ami_id}]})"
+        [[ "${ami_id}" = "${combo_pin}" ]] && seen_pin[${combo_key}]=1 && below_pin[${combo_key}]=1
+        continue
+      fi
+      if [[ -z "${below_pin[${combo_key}]:-}" ]]; then
+        echo "  KEEP ${ami_id} (${os_name}${major} ${arch}, newer than the pin)"
+        continue
+      fi
+      if [[ "{{apply}}" = "1" ]]; then
+        echo "  deregister ${ami_id} (${os_name}${major} ${arch}, older than the pin)"
+        just _deregister "${ami_id}"
+      else
+        echo "  would deregister ${ami_id} (${os_name}${major} ${arch}, older than the pin)"
+      fi
+    done < "${workdir}/rows"
+    for combo_key in "${!pin_of[@]}"; do
+      if [[ -z "${seen_pin[${combo_key}]:-}" ]]; then
+        echo "  ${combo_key}: pinned ${pin_of[${combo_key}]} is not among the {{role_prod}} candidates (deregistered or retagged?), nothing pruned for it" >&2
+        combo_errors=$((combo_errors + 1))
+      fi
+    done
+    if (( combo_errors > 0 )); then
+      echo "prune-superseded: ${combo_errors} combo(s) had no visible pin" >&2
+      exit 1
+    fi
 
 # create the SSM builder instance profile locally (one-time, for local builds).
 # PRODUCTION is terraform-managed: percona-cd-platform terraform/ppg-ami-factory.tf.

--- a/ppg/packer/scripts/update_molecule_env.py
+++ b/ppg/packer/scripts/update_molecule_env.py
@@ -12,6 +12,11 @@ RHEL/Ubuntu/Debian are already hand-pinned. It runs even after a
 partial bake: each combo resolves to its newest promoted AMI, so a
 failed combo keeps last week's image while the others advance.
 
+`--check` writes nothing and exits 1 when a promoted AMI newer than the
+pin has waited unpinned for more than `--grace-days` (the review window of
+the weekly refresh PR), or when a pin is missing or deregistered. The
+daily ppg-ami-pins-check workflow runs it against master.
+
 Fails closed: if any combo fails to resolve, exits non-zero without
 writing anything, so a wiped-out factory (or a transient API error)
 never corrupts the file: last week's still-valid AMI IDs are left in
@@ -44,10 +49,22 @@ _HELPER_BLOCK_RE = re.compile(
 )
 
 
+def parse_aws_time(ts):
+    """EC2 timestamps as naive UTC. CreationDate usually carries milliseconds
+    (2026-09-07T06:30:00.000Z), DeprecationTime does not, so accept both."""
+    from datetime import datetime
+
+    return datetime.fromisoformat(ts.replace("Z", "+00:00")).replace(tzinfo=None)
+
+
 def resolve_all(client):
-    """Query AWS once per combo; return {var_name: ami_id}. Raises/exits
-    via caller on any missing resolution — see fail-closed note above."""
+    """Query AWS once per combo; return ({var_name: ami_id},
+    {var_name: creation_date}, {var_name: [(creation_date, ami_id), ...]
+    newest first}). Raises/exits via caller on any missing resolution — see
+    fail-closed note above."""
     resolved = {}
+    created = {}
+    promoted = {}
     missing = []
     for os_name, var_prefix, major in COMBOS:
         for arch in ARCHES:
@@ -65,12 +82,17 @@ def resolve_all(client):
             if not images:
                 missing.append(var)
                 continue
-            newest = sorted(images, key=lambda x: x["CreationDate"])[-1]
-            resolved[var] = newest["ImageId"]
-            print(f"resolved {var} = {newest['ImageId']}")
+            ordered = sorted(
+                ((x["CreationDate"], x["ImageId"]) for x in images),
+                key=lambda pair: (parse_aws_time(pair[0]), pair[1]),
+                reverse=True,
+            )
+            promoted[var] = ordered
+            created[var], resolved[var] = ordered[0]
+            print(f"resolved {var} = {resolved[var]} ({created[var]})")
     if missing:
         raise RuntimeError(f"no available AMI found for: {', '.join(missing)}")
-    return resolved
+    return resolved, created, promoted
 
 
 def rewrite_file(content, resolved):
@@ -90,9 +112,86 @@ def rewrite_file(content, resolved):
     return content
 
 
+def current_pins(content):
+    """{var_name: ami_id} for every OL/Rocky export line in the file. A var
+    that appears more than once raises: the consumer shell would use the last
+    value while a reader would trust the first, so the file is ambiguous."""
+    pins = {}
+    for os_name, var_prefix, major in COMBOS:
+        for arch in ARCHES:
+            var = f"ami_{var_prefix}{major}_{arch}"
+            matches = re.findall(r"^ *(?:export )?" + re.escape(var) + r"=(\S+)\s*$", content, re.MULTILINE)
+            if len(matches) > 1:
+                raise ValueError(f"{var} is assigned {len(matches)} times, expected once")
+            pins[var] = matches[0] if matches else None
+    return pins
+
+
+def pinned_creation_dates(client, pins):
+    """{ami_id: CreationDate} for the pinned ids that still exist. A filter
+    query (not ImageIds=) so a deregistered id is simply absent instead of
+    failing the whole call."""
+    ids = sorted({ami for ami in pins.values() if ami})
+    if not ids:
+        return {}
+    images = client.describe_images(Owners=["self"], Filters=[{"Name": "image-id", "Values": ids}])["Images"]
+    return {img["ImageId"]: img["CreationDate"] for img in images}
+
+
+def stale_pins(pins, pinned_dates, resolved, promoted, grace_days, now):
+    """Return [(var, pinned, newest, reason)] for every combo whose pin is
+    missing, deregistered, or has left a newer promoted AMI unpinned for
+    more than grace_days. The clock starts at the OLDEST promoted AMI newer
+    than the pin, so the weekly refresh PR gets grace_days of review after
+    each bake and later bakes can never reset the clock on a rotting pin.
+    Age is measured from the AMI's CreationDate: an image promoted long after
+    it was created counts the time it spent unpromoted."""
+    from datetime import timedelta
+
+    stale = []
+    for var, newest in resolved.items():
+        pinned = pins.get(var)
+        if not pinned:
+            stale.append((var, pinned, newest, "no pin line in file"))
+            continue
+        if pinned not in pinned_dates:
+            stale.append((var, pinned, newest, "pinned AMI no longer exists"))
+            continue
+        if pinned not in {ami for _, ami in promoted[var]}:
+            stale.append((var, pinned, newest, "pinned AMI is not a promoted image of this combo"))
+            continue
+        if pinned == newest:
+            continue
+        pinned_at = parse_aws_time(pinned_dates[pinned])
+        newer = [parse_aws_time(ts) for ts, ami in promoted[var] if parse_aws_time(ts) > pinned_at]
+        if not newer:
+            continue
+        waiting = now - min(newer)
+        if waiting > timedelta(days=grace_days):
+            days = round(waiting.total_seconds() / 86400, 1)
+            stale.append((var, pinned, newest, f"a newer promoted AMI has waited {days} days unpinned"))
+    return stale
+
+
 def main():
+    import argparse
+
     import boto3
     import botocore.config as C
+
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="write nothing; exit 1 when a pin lags the newest promoted AMI by more than --grace-days",
+    )
+    parser.add_argument(
+        "--grace-days",
+        type=int,
+        default=3,
+        help="review window before a lagging pin counts as stale (default 3)",
+    )
+    args = parser.parse_args()
 
     client = boto3.client(
         "ec2",
@@ -100,7 +199,7 @@ def main():
         config=C.Config(retries={"max_attempts": 10, "mode": "adaptive"}),
     )
     try:
-        resolved = resolve_all(client)
+        resolved, created, promoted = resolve_all(client)
     except RuntimeError as e:
         print(f"FAIL: {e}", file=sys.stderr)
         sys.exit(1)
@@ -108,6 +207,27 @@ def main():
     path = "vars/moleculeEnvPPG.groovy"
     with open(path) as f:
         content = f.read()
+
+    if args.check:
+        from datetime import datetime, timezone
+
+        try:
+            pins = current_pins(content)
+        except ValueError as e:
+            print(f"FAIL: {e}", file=sys.stderr)
+            sys.exit(1)
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+        stale = stale_pins(pins, pinned_creation_dates(client, pins), resolved, promoted, args.grace_days, now)
+        for var, pinned, newest, reason in stale:
+            print(f"STALE: {var} pins {pinned}, newest promoted is {newest}: {reason}")
+        if stale:
+            print(
+                f"FAIL: {len(stale)} pin(s) lag the newest promoted AMI by more than {args.grace_days} days",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        print(f"pins current (no drift older than {args.grace_days} days)")
+        return
 
     try:
         new_content = rewrite_file(content, resolved)


### PR DESCRIPTION
**Bug**
- The weekly AMI refresh force-pushed one rolling PR with no comment or new review request, so three refreshes went unnoticed, a merge of master into that branch emptied it, and master kept the Aug 17 OL/Rocky pins for 3.5 weeks.
- `just prune-superseded` kept only the newest AMI per combo and would have deregistered every AMI master pins.

**Fix**
- Every prod bake from master (schedule, recipe push, prod dispatch) publishes a new dated PR, asserted to change `vars/moleculeEnvPPG.groovy`, and every earlier refresh PR is closed as superseded, also when nothing new is published.
- `update_molecule_env.py --check` exits 1 when the oldest promoted AMI newer than a pin has waited unpinned for more than 3 days, or a pin is missing, deregistered, or assigned twice, and the new `ppg-ami-pins-check.yml` runs it daily against master with the verdict always in the step summary.
- `prune-superseded` fetches master's pins and the pins of open refresh PRs, keeps each combo's pin and everything newer plus every image an open PR names, and refuses to apply without those inputs.
- The notify jobs fail with an error annotation when the Slack webhook secret is unset on the canonical repo instead of skipping silently.

**Tickets**
- [PKG-1447](https://perconadev.atlassian.net/browse/PKG-1447) (pin mechanism), [PG-2353](https://perconadev.atlassian.net/browse/PG-2353) (factory), companion [PR 4213](https://github.com/Percona-Lab/jenkins-pipelines/pull/4213) (post-promote prune, replaces this PR's prune recipe at merge time)

[PKG-1447]: https://perconadev.atlassian.net/browse/PKG-1447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ