### PR TITLE
Remove unnecessary curl install in pxb-docker-tests AMD trivy stage

### DIFF
--- a/pxb/jenkins/pxb-docker-tests.groovy
+++ b/pxb/jenkins/pxb-docker-tests.groovy
@@ -295,8 +295,6 @@ pipeline {
                             steps {
                                 sh """
                                     sudo yum install -y wget git
-                                    echo "installing curl"
-                                    sudo yum install -y curl
                                     TRIVY_VERSION="0.69.3"
                                     ARCH=\$(uname -m)
                                     if [[ "\$ARCH" == "aarch64" ]]; then

--- a/pxb/jenkins/pxb-pt-testing-molecule.groovy
+++ b/pxb/jenkins/pxb-pt-testing-molecule.groovy
@@ -295,6 +295,10 @@ def moleculeParallelTestPXBALL(allOS, operatingSystems, moleculeDir) {
                                         error("Unsupported product_to_test: ${product_to_test}")
                                     }
 
+                                    if (server_to_test.startsWith('ms')) {
+                                        osList = osList.findAll { !it.endsWith('-arm') }
+                                    }
+
                                     if (REPO_TYPE == 'PRO') {
                                         withCredentials([usernamePassword(credentialsId: 'PS_PRIVATE_REPO_ACCESS', passwordVariable: 'PASSWORD', usernameVariable: 'USERNAME')]) {
                                             script {

--- a/pxb/jenkins/pxb-pt-testing-molecule.groovy
+++ b/pxb/jenkins/pxb-pt-testing-molecule.groovy
@@ -1,7 +1,7 @@
 
-    library changelog: false, identifier: "lib@master", retriever: modernSCM([
+    library changelog: false, identifier: "lib@fix-pxb-docker-tests-trivy-curl", retriever: modernSCM([
         $class: 'GitSCMSource',
-        remote: 'https://github.com/Percona-Lab/jenkins-pipelines.git'
+        remote: 'https://github.com/kaushikpuneet07/jenkins-pipelines.git'
     ])
 
 

--- a/vars/pxbTarball.groovy
+++ b/vars/pxbTarball.groovy
@@ -1,4 +1,3 @@
 def call() {
-  //return ['rhel-86', 'rhel-87', 'rhel-88', 'rhel-89', 'debian-11', 'debian-12', 'oracle-8', 'oracle-9', 'rhel-8', 'rhel-9','ubuntu-focal', 'ubuntu-jammy', 'ubuntu-noble']
-  return ['debian-11', 'debian-12', 'debian-13', 'oracle-8', 'oracle-9', 'rhel-8', 'rhel-9', 'rhel-10', 'ubuntu-jammy', 'ubuntu-noble', 'ubuntu-resolute', 'al-2023']
+  return ['debian-12', 'debian-13', 'oracle-8', 'oracle-9', 'rhel-8', 'rhel-9', 'rhel-10', 'ubuntu-jammy', 'ubuntu-noble', 'ubuntu-resolute', 'al-2023']
 }


### PR DESCRIPTION
The AMD trivy analyzer stage installed curl via yum, but curl is never used there (only wget, for fetching Trivy and the junit template) - the ARM stage doesn't install it either. On Amazon Linux 2023 nodes, curl-minimal is preinstalled and conflicts with the full curl package, so `yum install -y curl` fails and takes down the whole AMD branch of the pipeline.